### PR TITLE
fix(importers): detect a deleted import target from the write-back itself

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import TemporaryUploadedFile
-from django.db import IntegrityError
+from django.db import DEFAULT_DB_ALIAS, DatabaseError, IntegrityError, connections, transaction
 from django.urls import reverse
 from django.utils.timezone import make_aware
 
@@ -98,6 +98,10 @@ class BaseImporter(ImporterOptions):
         # batches completed within the timeout; False for 'async' (dispatched,
         # not awaited) or when an 'async_wait' join timed out/errored.
         self.deduplication_complete = False
+        # Set by update_timestamps() when it moves the engagement's target end, which is
+        # the only field of the engagement the importer ever changes. The closing
+        # write-back skips the engagement unless this is True -- see process_scan().
+        self.engagement_target_end_updated = False
 
     def post_processing_dispatch_kwargs(self, **kwargs):
         """
@@ -407,9 +411,16 @@ class BaseImporter(ImporterOptions):
         # If the supplied scan date is greater than the current configured
         # target end date on the engagement
         if self.test.engagement.engagement_type == "CI/CD":
-            self.test.engagement.target_end = max_safe(
+            engagement_target_end = max_safe(
                 [self.scan_date.date(), self.test.engagement.target_end],
             )
+            # target_end is the only engagement field the importer touches, so recording
+            # whether it actually moved is enough to tell the closing write-back whether
+            # the engagement needs saving at all. Anything else that starts mutating the
+            # engagement mid-import has to flag itself here too, or it will not be saved.
+            if engagement_target_end != self.test.engagement.target_end:
+                self.test.engagement.target_end = engagement_target_end
+                self.engagement_target_end_updated = True
         # Set the target end date on the test in a similar fashion
         max_test_start_date = max_safe([self.scan_date, self.test.target_end])
         # Quick check to make sure we have a datetime that is timezone aware
@@ -648,6 +659,20 @@ class BaseImporter(ImporterOptions):
 
         return message
 
+    @staticmethod
+    def _is_vanished_row_error(exception: DatabaseError) -> bool:
+        """
+        Return True when `exception` is Django reporting that a forced UPDATE matched no rows.
+
+        Model.save_base raises a bare DatabaseError for this; every genuine database
+        failure arrives as a subclass (IntegrityError, OperationalError, DataError, ...),
+        so the exact class is the discriminator and the message only a second opinion.
+        Classifying on the exception rather than with a follow-up query matters: a real
+        failure can leave the connection in an aborted transaction, where the query would
+        raise in turn and bury the error that actually needs reporting.
+        """
+        return type(exception) is DatabaseError and "did not affect any rows" in str(exception)
+
     def save_without_resurrecting(self, instance: Engagement | Test) -> None:
         """
         Persist an import target, refusing to re-create it if it was deleted mid-import.
@@ -669,22 +694,40 @@ class BaseImporter(ImporterOptions):
         Neither is a save the importer should be making: the target of the import is gone,
         so the import cannot complete. Fail with a message that says exactly that.
 
-        The row is checked before the write rather than relying on save(force_update=True).
-        A forced update raises from inside the atomic block that Model.save_base opens
-        without a savepoint, which marks the whole surrounding transaction for rollback --
-        the caller's failure handling would then hit TransactionManagementError instead of
-        being able to record why the import failed. Costing one indexed primary-key lookup
-        keeps the transaction usable.
+        force_update=True is what detects it. Django then raises instead of falling back to
+        an INSERT, and it does so from the same statement that would have done the damage,
+        so a delete committing mid-check cannot slip past -- which a separate "does the row
+        still exist" SELECT could not promise, and which costs no query at all rather than
+        one per save.
         """
-        if instance.pk is not None and not type(instance)._base_manager.filter(pk=instance.pk).exists():
+        if instance.pk is None:
+            # An insert, so there is nothing to resurrect, and Django cannot force an
+            # update without a primary key.
+            instance.save()
+            return
+
+        try:
+            instance.save(force_update=True)
+        except DatabaseError as exception:
+            if not self._is_vanished_row_error(exception):
+                raise
+            # The UPDATE itself succeeded -- it simply matched no rows -- so nothing needs
+            # rolling back. Django marks the transaction for rollback regardless, because
+            # Model.save_base wraps the write in mark_for_rollback_on_error, and that flag
+            # would make the caller's failure handling raise TransactionManagementError
+            # instead of recording why the import failed. Clear it so the caller can still
+            # use its connection. No-op outside a transaction, which is where the importer
+            # runs today (no ATOMIC_REQUESTS, no atomic block around process_scan).
+            using = instance._state.db or DEFAULT_DB_ALIAS
+            if connections[using].in_atomic_block:
+                transaction.set_rollback(False, using=using)
             msg = (
                 f"The {instance._meta.verbose_name} this scan was being imported into "
                 f"(id {instance.pk}) was deleted while the scan was being processed, so "
                 f"the import could not be completed. Nothing was imported. Re-run the "
                 f"import against a {instance._meta.verbose_name} that still exists."
             )
-            raise ValidationError(msg)
-        instance.save()
+            raise ValidationError(msg) from exception
 
     def update_test_progress(
         self,

--- a/dojo/importers/default_importer.py
+++ b/dojo/importers/default_importer.py
@@ -125,9 +125,15 @@ class DefaultImporter(BaseImporter, DefaultImporterOptions):
         self.update_timestamps()
         # Update the test meta
         self.update_test_meta()
-        # Save the test and engagement for changes to take affect
+        # Save the test for changes to take affect. The engagement is only written back
+        # when update_timestamps() actually moved its target end (CI/CD engagements whose
+        # target end the scan date pushes out); for every other import there is nothing to
+        # write, and saving it anyway costs a full UPDATE plus the SELECT its pre_save
+        # receiver issues. A deleted engagement is still caught, by the test save above:
+        # deleting an engagement cascades to its tests.
         self.save_without_resurrecting(self.test)
-        self.save_without_resurrecting(self.test.engagement)
+        if self.engagement_target_end_updated:
+            self.save_without_resurrecting(self.test.engagement)
         # Create a test import history object to record the flags sent to the importer
         # This operation will return None if the user does not have the import history
         # feature enabled

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -130,9 +130,15 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         self.update_test_meta()
         # Update the test tags
         self.update_test_tags()
-        # Save the test and engagement for changes to take affect
+        # Save the test for changes to take affect. The engagement is only written back
+        # when update_timestamps() actually moved its target end (CI/CD engagements whose
+        # target end the scan date pushes out); for every other reimport there is nothing to
+        # write, and saving it anyway costs a full UPDATE plus the SELECT its pre_save
+        # receiver issues. A deleted engagement is still caught, by the test save above:
+        # deleting an engagement cascades to its tests.
         self.save_without_resurrecting(self.test)
-        self.save_without_resurrecting(self.test.engagement)
+        if self.engagement_target_end_updated:
+            self.save_without_resurrecting(self.test.engagement)
         logger.debug("REIMPORT_SCAN: Updating test tags")
         # Create a test import history object to record the flags sent to the importer
         # This operation will return None if the user does not have the import history

--- a/unittests/test_importers_deleted_target.py
+++ b/unittests/test_importers_deleted_target.py
@@ -1,7 +1,9 @@
 import logging
+from datetime import timedelta
 from unittest import mock
 
 from django.core.exceptions import ValidationError
+from django.db import DEFAULT_DB_ALIAS, IntegrityError, connections
 from django.utils import timezone
 
 from dojo.importers.default_importer import DefaultImporter
@@ -74,8 +76,8 @@ class TestImportersDeletedTarget(DojoTestCase):
     def _importer(self):
         return DefaultImporter(close_old_findings=False, **self._options(engagement=self.engagement))
 
-    def _reimporter(self):
-        return DefaultReImporter(close_old_findings=False, **self._options(test=self.test))
+    def _reimporter(self, **overrides):
+        return DefaultReImporter(close_old_findings=False, **self._options(test=self.test, **overrides))
 
     def _process_with_delete_mid_run(self, importer, delete, hook):
         """
@@ -198,3 +200,125 @@ class TestImportersDeletedTarget(DojoTestCase):
             msg=f"expected percent_complete=100, persisted={persisted.percent_complete}",
         )
         self.assertTrue(Engagement.objects.filter(pk=self.engagement.pk).exists())
+
+    def test_write_back_still_persists_every_field_it_sets(self):
+        """
+        The forced update writes the whole row, exactly as the plain save() it replaced did.
+
+        Narrowing it to save(update_fields=...) would detect the vanished row the same way
+        and write fewer columns, but would silently drop any field a later change starts
+        setting before the write-back. This pins what the importer sets today to what
+        actually lands in the database.
+        """
+        updated_before_reimport = Test.objects.values_list("updated", flat=True).get(pk=self.test.pk)
+        reimporter = self._reimporter(
+            version="1.2.3",
+            build_id="build-42",
+            branch_tag="release/1.2",
+            commit_hash="deadbeef",
+        )
+
+        with (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan:
+            reimporter.process_scan(scan)
+
+        persisted = Test.objects.get(pk=self.test.pk)
+        self.assertEqual("1.2.3", persisted.version)
+        self.assertEqual("build-42", persisted.build_id)
+        self.assertEqual("release/1.2", persisted.branch_tag)
+        self.assertEqual("deadbeef", persisted.commit_hash)
+        self.assertEqual(100, persisted.percent_complete)
+        self.assertEqual(reimporter.scan_date, persisted.target_end)
+        self.assertGreater(
+            persisted.updated, updated_before_reimport,
+            msg="the auto_now `updated` column must still be bumped by the write-back",
+        )
+
+    def test_unchanged_engagement_is_not_written_back(self):
+        """
+        The engagement is only worth saving when the run actually moved its target end.
+
+        `update_timestamps()` touches the engagement for CI/CD engagements only, so for
+        every other import the write-back was spending a full UPDATE, plus the SELECT its
+        pre_save receiver issues, to store nothing.
+        """
+        reimporter = self._reimporter()
+
+        with (
+            (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan,
+            mock.patch.object(
+                reimporter,
+                "save_without_resurrecting",
+                wraps=reimporter.save_without_resurrecting,
+            ) as write_back,
+        ):
+            reimporter.process_scan(scan)
+
+        written_back = [call.args[0] for call in write_back.call_args_list]
+        self.assertFalse(
+            any(isinstance(instance, Engagement) for instance in written_back),
+            msg=f"an unchanged engagement must not be written back, got: {written_back}",
+        )
+        self.assertFalse(reimporter.engagement_target_end_updated)
+
+    def test_ci_cd_engagement_target_end_is_still_written_back(self):
+        """The engagement save the importer does need: a CI/CD target end the scan pushes out."""
+        Engagement.objects.filter(pk=self.engagement.pk).update(
+            engagement_type="CI/CD",
+            target_end=timezone.now().date() - timedelta(days=7),
+        )
+        # Re-fetch rather than refresh: the test caches its engagement, and the write-back
+        # reads engagement_type off that cached copy.
+        self.test = Test.objects.get(pk=self.test.pk)
+        reimporter = self._reimporter()
+
+        with (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan:
+            reimporter.process_scan(scan)
+
+        self.assertTrue(reimporter.engagement_target_end_updated)
+        self.assertEqual(
+            reimporter.scan_date.date(),
+            Engagement.objects.values_list("target_end", flat=True).get(pk=self.engagement.pk),
+        )
+
+    def test_a_real_database_error_is_not_reported_as_a_deleted_target(self):
+        """
+        Only Django's "forced update did not affect any rows" means the target vanished.
+
+        Every other DatabaseError is a genuine failure, and relabelling it as a delete that
+        never happened would send whoever debugs it after the wrong thing.
+        """
+        importer = self._reimporter()
+
+        with (
+            mock.patch.object(Test, "save", side_effect=IntegrityError("null value in column violates not-null constraint")),
+            self.assertRaises(IntegrityError),
+        ):
+            importer.save_without_resurrecting(self.test)
+
+    def test_the_transaction_is_still_usable_after_a_vanished_target(self):
+        """
+        The caller has to be able to record why the import failed.
+
+        Model.save_base wraps the write in mark_for_rollback_on_error, so a forced update
+        that matches no rows leaves the transaction marked for rollback and turns the next
+        query into a TransactionManagementError. The UPDATE itself succeeded -- it matched
+        no rows -- so nothing needs rolling back and the mark is cleared.
+        """
+        test_pk = self.test.pk
+        importer = self._reimporter()
+        Test.objects.filter(pk=test_pk).delete()
+
+        with self.assertRaises(ValidationError):
+            importer.save_without_resurrecting(self.test)
+
+        self.assertFalse(
+            connections[DEFAULT_DB_ALIAS].needs_rollback,
+            msg="the connection must not be left marked for rollback",
+        )
+        # The reads and writes a failure handler makes must both still go through.
+        self.assertFalse(Test.objects.filter(pk=test_pk).exists())
+        Engagement.objects.filter(pk=self.engagement.pk).update(description="recorded after the failure")
+        self.assertEqual(
+            "recorded after the failure",
+            Engagement.objects.values_list("description", flat=True).get(pk=self.engagement.pk),
+        )

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -343,13 +343,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=166,
+            expected_num_queries1=160,
             expected_num_async_tasks1=2,
-            expected_num_queries2=133,
+            expected_num_queries2=127,
             expected_num_async_tasks2=1,
-            expected_num_queries3=33,
+            expected_num_queries3=27,
             expected_num_async_tasks3=1,
-            expected_num_queries4=109,
+            expected_num_queries4=103,
             expected_num_async_tasks4=0,
         )
 
@@ -367,13 +367,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=185,
+            expected_num_queries1=179,
             expected_num_async_tasks1=2,
-            expected_num_queries2=143,
+            expected_num_queries2=137,
             expected_num_async_tasks2=1,
-            expected_num_queries3=43,
+            expected_num_queries3=37,
             expected_num_async_tasks3=1,
-            expected_num_queries4=109,
+            expected_num_queries4=103,
             expected_num_async_tasks4=0,
         )
 
@@ -392,13 +392,13 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=195,
+            expected_num_queries1=189,
             expected_num_async_tasks1=5,
-            expected_num_queries2=153,
+            expected_num_queries2=147,
             expected_num_async_tasks2=4,
-            expected_num_queries3=52,
+            expected_num_queries3=46,
             expected_num_async_tasks3=3,
-            expected_num_queries4=118,
+            expected_num_queries4=112,
             expected_num_async_tasks4=3,
         )
 
@@ -526,9 +526,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=102,
+            expected_num_queries1=96,
             expected_num_async_tasks1=2,
-            expected_num_queries2=80,
+            expected_num_queries2=74,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -547,9 +547,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=121,
+            expected_num_queries1=115,
             expected_num_async_tasks1=2,
-            expected_num_queries2=100,
+            expected_num_queries2=94,
             expected_num_async_tasks2=2,
         )
 
@@ -580,9 +580,9 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         # returns instantly without executing dedup on the request's DB connection.
         with patch("celery.result.AsyncResult.get", return_value=None):
             self._deduplication_performance(
-                expected_num_queries1=103,
+                expected_num_queries1=97,
                 expected_num_async_tasks1=2,
-                expected_num_queries2=81,
+                expected_num_queries2=75,
                 expected_num_async_tasks2=2,
                 dedup_mode="async_wait",
                 check_duplicates=False,
@@ -670,13 +670,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         configure_pghistory_triggers()
 
         self._import_reimport_performance(
-            expected_num_queries1=173,
+            expected_num_queries1=166,
             expected_num_async_tasks1=2,
-            expected_num_queries2=142,
+            expected_num_queries2=135,
             expected_num_async_tasks2=1,
-            expected_num_queries3=41,
+            expected_num_queries3=34,
             expected_num_async_tasks3=1,
-            expected_num_queries4=110,
+            expected_num_queries4=103,
             expected_num_async_tasks4=0,
         )
 
@@ -694,13 +694,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=194,
+            expected_num_queries1=187,
             expected_num_async_tasks1=2,
-            expected_num_queries2=154,
+            expected_num_queries2=147,
             expected_num_async_tasks2=1,
-            expected_num_queries3=53,
+            expected_num_queries3=46,
             expected_num_async_tasks3=1,
-            expected_num_queries4=110,
+            expected_num_queries4=103,
             expected_num_async_tasks4=0,
         )
 
@@ -719,13 +719,13 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=207,
+            expected_num_queries1=200,
             expected_num_async_tasks1=5,
-            expected_num_queries2=167,
+            expected_num_queries2=160,
             expected_num_async_tasks2=4,
-            expected_num_queries3=62,
+            expected_num_queries3=55,
             expected_num_async_tasks3=3,
-            expected_num_queries4=122,
+            expected_num_queries4=115,
             expected_num_async_tasks4=3,
         )
 
@@ -826,9 +826,9 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_deduplication=True)
 
         self._deduplication_performance(
-            expected_num_queries1=109,
+            expected_num_queries1=102,
             expected_num_async_tasks1=2,
-            expected_num_queries2=83,
+            expected_num_queries2=76,
             expected_num_async_tasks2=2,
             check_duplicates=False,  # Async mode - deduplication happens later
         )
@@ -846,8 +846,8 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=130,
+            expected_num_queries1=123,
             expected_num_async_tasks1=2,
-            expected_num_queries2=211,
+            expected_num_queries2=204,
             expected_num_async_tasks2=2,
         )

--- a/unittests/test_tag_inheritance_perf.py
+++ b/unittests/test_tag_inheritance_perf.py
@@ -601,12 +601,15 @@ class TagInheritanceImportPerfBaselines(DojoAPITestCase):
     # FindingVulnerabilityReference bulk writes remain (batched, not per-finding). Removing the
     # legacy Vulnerability_Id dual-write drops the reimport counts by its delete+bulk_insert:
     # -12 reimport-no-change, -6 reimport-with-new. Import counts are unchanged.
-    # +3 on every path from save_without_resurrecting(): the importer confirms its
-    # test and engagement rows still exist before writing them back, instead of
-    # letting Model.save() fall back to an INSERT that re-creates a row deleted
-    # mid-import. One primary-key lookup per guarded save (test, engagement, and
-    # the closing update_test_progress), so the cost is constant rather than
-    # per-finding — which is why the delta is +3 on import and reimport alike.
+    # save_without_resurrecting() no longer costs a query. It used to confirm the row
+    # still existed with its own SELECT before writing it back (+3, one per guarded
+    # save); it now passes force_update=True and lets Django refuse the INSERT
+    # fallback, which detects the same vanished row from the UPDATE itself. On top of
+    # that the engagement is only written back when update_timestamps() actually moved
+    # its target end, which happens for CI/CD engagements only — these baselines use
+    # an Interactive engagement, so its save disappears along with the SELECT its
+    # pre_save receiver issued and the indexing its post_save triggered. Net -8 (v2)
+    # and -9 (v3) on every path, constant rather than per-finding.
     # +2 on the paths that buffer child rows: the batch flush confirms the buffered
     # findings still exist before inserting their vulnerability id references, CWE rows
     # and request/response rows, instead of letting a finding deleted mid-batch turn the
@@ -616,9 +619,9 @@ class TagInheritanceImportPerfBaselines(DojoAPITestCase):
     # for the reference and CWE buffers it shares, then flush_burp_request_response()
     # resolves its own for the request/response rows the ZAP parser attaches. The
     # no-change reimport buffers nothing, so it takes no lookup and is unchanged.
-    EXPECTED_ZAP_IMPORT_V2 = 301
-    EXPECTED_ZAP_IMPORT_V3 = 325
-    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V2 = 82
-    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V3 = 94
-    EXPECTED_ZAP_REIMPORT_WITH_NEW_V2 = 166
-    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 195
+    EXPECTED_ZAP_IMPORT_V2 = 293
+    EXPECTED_ZAP_IMPORT_V3 = 316
+    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V2 = 74
+    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V3 = 85
+    EXPECTED_ZAP_REIMPORT_WITH_NEW_V2 = 158
+    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 186


### PR DESCRIPTION
**Summary**

Follow-up to [PR #15427](https://github.com/DefectDojo/django-DefectDojo/pull/15427), which stopped the importer's closing write-back re-creating a test or engagement that was deleted while its scan was being processed. This keeps that protection, removes its cost, and closes the race it still had.

- **`force_update=True` does the detecting, instead of a preceding existence check.** Django refuses the `UPDATE`-to-`INSERT` fallback and raises when a forced update matches no rows, so the same vanished row is caught — from the statement that would otherwise have re-created it, rather than from a separate `SELECT` a concurrent delete could commit behind. Costs no query rather than one per guarded save.
- **The reason the pre-check was chosen does not apply on this path.** A forced update marks the surrounding transaction for rollback, which would leave the caller hitting `TransactionManagementError` instead of recording why the import failed — but `mark_for_rollback_on_error` only sets that flag inside an atomic block, and the importer runs in autocommit (no `ATOMIC_REQUESTS`, no atomic block around `process_scan`). It is cleared explicitly regardless: the `UPDATE` itself succeeded, it simply matched no rows, so nothing needs rolling back.
- **Only Django's "did not affect any rows" `DatabaseError` becomes the `ValidationError`.** Genuine database failures arrive as subclasses (`IntegrityError`, `OperationalError`, …) and keep their own type and traceback. Classified from the exception rather than with a follow-up query, which would itself fail on a connection left in an aborted transaction and bury the error that needs reporting.
- **The engagement is written back only when the run actually changed it.** `update_timestamps()` moves `engagement.target_end` for CI/CD engagements only, and that is the single engagement field the importer touches, so every other import was spending a full-row `UPDATE`, the `SELECT` its `pre_save` receiver issues, and a search-index refresh to store nothing. A deleted engagement is still caught by the test write-back above it, since deleting an engagement cascades to its tests. Anything that starts mutating the engagement mid-run has to set `engagement_target_end_updated`, as the comment at that assignment says.
- **Query counts move down, uniformly.** `test_importers_performance` −6 (v2) / −7 (v3) and `test_tag_inheritance_perf` −8 (v2) / −9 (v3) on every path — import, no-change reimport and reimport-with-new alike — which is what shows the saving is constant rather than per-finding. The pinned baselines now sit below where they were before #15427 rather than back at it.
- **Coverage added** to `unittests/test_importers_deleted_target.py`: the forced update still persists every field the importer sets, including the `auto_now` `updated` column; an unchanged engagement is not written back; a CI/CD engagement's target end still is (that write-back had no test before); a real `DatabaseError` is not relabelled as a deleted target; and reads and writes both still go through after a vanished target, which is the behaviour the cleared rollback flag exists for.

No model changes, so no migrations. No behaviour change for an import whose target is still present.
