### PR TITLE
docs(connectors): document the Wiz service account scope and project-visibility requirements

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -1453,6 +1453,12 @@ Vulnerability detection must be enabled in Wazuh so that the vulnerability\-stat
 
 Using the Wiz connector requires you to create a service account: see the [Wiz documentation](https://docs.wiz.io/wiz-docs/docs/service-accounts-settings#add-a-service-account) for more info.  You will need a Wiz account to access the documentation.
 
+The service account must meet all of the following requirements. A service account that misses one of them can still authenticate successfully but will import nothing:
+
+* **Type**: Custom Integration (GraphQL API).
+* **API scopes**: at minimum `read:projects`, `read:issues`, and `read:vulnerabilities`.
+* **Project visibility**: the service account must be scoped to every Wiz Project you want imported (or to all Projects). The connector discovers your Wiz Projects first and then pulls each Project's findings — an account that can read issues but has no Project visibility discovers zero Projects, so there is nothing to import and no error is reported by either side.
+
 #### **Connector Mappings**
 
 1. Enter your Wiz Client ID in the Client ID field.


### PR DESCRIPTION
The Wiz section of the connector tool reference only said to create a service account and paste its credentials. A service account without project visibility (or without the read:projects scope) authenticates successfully and imports nothing, with no error reported on either side: the connector discovers Wiz Projects first, and Wiz returns an empty project list rather than a permission error when the account lacks visibility.

This documents the three requirements a working service account must meet: the Custom Integration (GraphQL API) type, the minimum API scopes (read:projects, read:issues, read:vulnerabilities), and project visibility covering every Project meant to be imported - plus the symptom (silent zero-finding imports) when one is missing.

Docs-only change.