### PR TITLE
fix(dedupe): stop prefetching the deprecated endpoint relation under V3

### DIFF
--- a/dojo/finding/deduplication.py
+++ b/dojo/finding/deduplication.py
@@ -8,6 +8,7 @@ from django.db.models import Prefetch
 from django.db.models.query_utils import Q
 
 from dojo.celery import app
+from dojo.location.queries import location_prefetch_lookups
 from dojo.models import Endpoint_Status, Finding, System_Settings
 from dojo.vulnerability.queries import vulnerability_id_prefetch
 
@@ -18,7 +19,7 @@ deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 def get_finding_models_for_deduplication(finding_ids):
     """
     Load findings with optimal prefetching for deduplication operations.
-    This avoids N+1 queries when accessing test, engagement, product, endpoints, and original_finding.
+    This avoids N+1 queries when accessing test, engagement, product, locations, and original_finding.
 
     Args:
         finding_ids: A list of Finding IDs
@@ -36,7 +37,7 @@ def get_finding_models_for_deduplication(finding_ids):
         .only(*Finding.DEDUPLICATION_FIELDS)
         .select_related("test", "test__engagement", "test__engagement__product", "test__test_type")
         .prefetch_related(
-            "endpoints",
+            *location_prefetch_lookups(),
             # Prefetch duplicates of each finding to avoid N+1 when set_duplicate iterates
             Prefetch(
                 "original_finding",
@@ -340,13 +341,10 @@ def build_candidate_scope_queryset(test, mode="deduplication", service=None):
             )
         queryset = Finding.objects.filter(scope_q)
 
-    if settings.V3_FEATURE_LOCATIONS:
-        prefetch_list = ["locations__location__url", vulnerability_id_prefetch(), "finding_cwe_set", "found_by"]
-    else:
-        # TODO: Delete this after the move to Locations
-        # Base prefetches for both modes
-        prefetch_list = ["endpoints", vulnerability_id_prefetch(), "finding_cwe_set", "found_by"]
+    prefetch_list = [*location_prefetch_lookups(), vulnerability_id_prefetch(), "finding_cwe_set", "found_by"]
 
+    if not settings.V3_FEATURE_LOCATIONS:
+        # TODO: Delete this after the move to Locations
         # Prefetch all endpoint statuses with their endpoint for reimport mode.
         # The non-special filtering (excluding false_positive, out_of_scope, risk_accepted)
         # is done in Python by EndpointManager.get_non_special_endpoint_statuses().

--- a/dojo/location/queries.py
+++ b/dojo/location/queries.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from django.db.models import (
     Case,
     CharField,
@@ -28,6 +29,28 @@ from dojo.models import (
 from dojo.query_utils import build_count_subquery
 
 logger = logging.getLogger(__name__)
+
+
+def location_prefetch_lookups(prefix: str = "") -> list[str]:
+    """
+    Prefetch lookups for the location relation that the hash and deduplication paths read
+    through ``Finding.get_locations()``, for the location model actually in use.
+
+    Endpoint rows are not deleted by the move to Locations, and ``Endpoint.__init__`` raises
+    ``NotImplementedError`` once ``V3_FEATURE_LOCATIONS`` is on (see
+    ``Endpoint.allow_endpoint_init``). So prefetching the endpoint relation under V3 hydrates
+    the deprecated model for every surviving row and kills the caller -- on a migrated
+    instance, not on a fresh one, which is why it is easy to miss. Under V3 ``get_locations()``
+    reads URL locations and never touches endpoints, so the endpoint prefetch is dead weight
+    there in any case.
+
+    :param prefix: relation path to the Finding, e.g. ``"finding__"`` when paging a model that
+        reaches the finding through a relation.
+    """
+    if settings.V3_FEATURE_LOCATIONS:
+        return [f"{prefix}locations__location__url"]
+    # TODO: Delete this after the move to Locations
+    return [f"{prefix}endpoints"]
 
 
 def get_authorized_locations(permission, queryset=None, user=None):

--- a/dojo/management/commands/dedupe.py
+++ b/dojo/management/commands/dedupe.py
@@ -14,6 +14,7 @@ from dojo.finding.deduplication import (
     get_finding_models_for_deduplication,
     hashcode_values_writer,
 )
+from dojo.location.queries import location_prefetch_lookups
 from dojo.models import Finding, Product
 from dojo.utils import (
     calculate_grade,
@@ -92,37 +93,22 @@ class Command(BaseCommand):
             findings = Finding.objects.all().filter(id__gt=0).exclude(duplicate=True)
             logger.info("######## Will process the full database with %d findings ########", findings.count())
 
-        if settings.V3_FEATURE_LOCATIONS:
-            # Prefetch related objects for synchronous deduplication
-            findings = findings.select_related(
-                "test", "test__engagement", "test__engagement__product", "test__test_type",
-            ).prefetch_related(
-                "locations",
-                # vulnerability id store feeds hash_code computation for parsers whose
-                # HASHCODE_FIELDS_PER_SCANNER includes vulnerability_ids; prefetch to avoid
-                # a per-finding query in get_vulnerability_ids().
-                vulnerability_id_prefetch(),
-                Prefetch(
-                    "original_finding",
-                    queryset=Finding.objects.only("id", "duplicate_finding_id").order_by("-id"),
-                ),
-            )
-        else:
-            # TODO: Delete this after the move to Locations
-            # Prefetch related objects for synchronous deduplication
-            findings = findings.select_related(
-                "test", "test__engagement", "test__engagement__product", "test__test_type",
-            ).prefetch_related(
-                "endpoints",
-                # vulnerability id store feeds hash_code computation for parsers whose
-                # HASHCODE_FIELDS_PER_SCANNER includes vulnerability_ids; prefetch to avoid
-                # a per-finding query in get_vulnerability_ids().
-                vulnerability_id_prefetch(),
-                Prefetch(
-                    "original_finding",
-                    queryset=Finding.objects.only("id", "duplicate_finding_id").order_by("-id"),
-                ),
-            )
+        # Prefetch related objects for synchronous deduplication
+        findings = findings.select_related(
+            "test", "test__engagement", "test__engagement__product", "test__test_type",
+        ).prefetch_related(
+            # location relation for the parsers that hash it; the lookup differs per location
+            # model, and prefetching the deprecated endpoint relation under V3 raises.
+            *location_prefetch_lookups(),
+            # vulnerability id store feeds hash_code computation for parsers whose
+            # HASHCODE_FIELDS_PER_SCANNER includes vulnerability_ids; prefetch to avoid
+            # a per-finding query in get_vulnerability_ids().
+            vulnerability_id_prefetch(),
+            Prefetch(
+                "original_finding",
+                queryset=Finding.objects.only("id", "duplicate_finding_id").order_by("-id"),
+            ),
+        )
 
         # Phase 1: update hash_codes without deduplicating
         if not dedupe_only:

--- a/unittests/test_dedupe_with_endpoints_v3.py
+++ b/unittests/test_dedupe_with_endpoints_v3.py
@@ -1,0 +1,188 @@
+"""
+Regression tests for the V3_FEATURE_LOCATIONS deduplication-prefetch crash.
+
+When ``V3_FEATURE_LOCATIONS`` is enabled the legacy ``Endpoint`` model is deprecated and
+``Endpoint.__init__`` raises ``NotImplementedError``. The move to Locations does not delete
+endpoint rows, so a migrated instance still has them -- and any queryset that prefetches the
+``endpoints`` relation hydrates the deprecated model for every surviving row and blows up.
+
+``get_finding_models_for_deduplication`` prefetched ``endpoints`` unconditionally, which put
+that crash on the batch-deduplication path taken by every import and reimport
+(``post_process_findings_batch``) as well as by ``manage.py dedupe`` in batch mode. A fresh V3
+instance has no endpoint rows to hydrate, so nothing surfaces it until an instance that
+migrated from endpoints runs an import.
+
+The fix routes every dedupe/rehash queryset through ``location_prefetch_lookups()``, which
+returns the lookup for the location model actually in use.
+"""
+import logging
+from types import SimpleNamespace
+
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.utils import timezone
+
+from dojo.finding.deduplication import (
+    build_candidate_scope_queryset,
+    get_finding_models_for_deduplication,
+)
+from dojo.location.queries import location_prefetch_lookups
+from dojo.models import (
+    Endpoint,
+    Endpoint_Status,
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+    UserContactInfo,
+)
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+class TestLocationPrefetchLookups(DojoTestCase):
+
+    """The lookup has to follow the location model in use -- no database needed."""
+
+    @override_settings(V3_FEATURE_LOCATIONS=True)
+    def test_v3_prefetches_url_locations_and_not_endpoints(self):
+        lookups = location_prefetch_lookups()
+        self.assertEqual(lookups, ["locations__location__url"])
+        self.assertNotIn("endpoints", lookups)
+
+    @override_settings(V3_FEATURE_LOCATIONS=False)
+    def test_pre_v3_prefetches_endpoints(self):
+        # TODO: Delete this after the move to Locations
+        self.assertEqual(location_prefetch_lookups(), ["endpoints"])
+
+    @override_settings(V3_FEATURE_LOCATIONS=True)
+    def test_prefix_reaches_the_finding_through_a_relation(self):
+        self.assertEqual(
+            location_prefetch_lookups("finding__"),
+            ["finding__locations__location__url"],
+        )
+
+
+@override_settings(V3_FEATURE_LOCATIONS=True)
+class TestDedupeQuerysetsWithLegacyEndpoints(DojoTestCase):
+
+    """
+    The deduplication querysets must not hydrate the deprecated ``Endpoint`` model, even when
+    a migrated instance still has endpoint rows attached to the findings being deduplicated.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        self.user = User.objects.create(
+            username="test_dedupe_endpoints_v3_user",
+            is_staff=True,
+            is_superuser=True,
+        )
+        UserContactInfo.objects.create(user=self.user, block_execution=True)
+
+        self.system_settings(enable_product_grade=False)
+        self.system_settings(enable_jira=False)
+
+        self.test_type = Test_Type.objects.get_or_create(name="Manual Test")[0]
+
+    def _build_tree(self, suffix, *, with_legacy_endpoint=True):
+        """
+        Create Product_Type -> Product -> Engagement -> Test -> Finding, plus (by default) a
+        legacy Endpoint on the product and an Endpoint_Status linking it to the finding --
+        the rows a migrated instance keeps.
+        """
+        product_type = Product_Type.objects.create(name=f"Org dedupe endpoints {suffix}")
+        product = Product.objects.create(
+            name=f"Product dedupe endpoints {suffix}",
+            description="regression fixture",
+            prod_type=product_type,
+        )
+        engagement = Engagement.objects.create(
+            name=f"Engagement {suffix}",
+            product=product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        test = Test.objects.create(
+            engagement=engagement,
+            test_type=self.test_type,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        finding = Finding.objects.create(
+            test=test,
+            title=f"Finding {suffix}",
+            severity="High",
+            description="regression fixture",
+            mitigation="n/a",
+            impact="n/a",
+            reporter=self.user,
+        )
+        if with_legacy_endpoint:
+            # The Endpoint model is deprecated under V3; creating the rows a migration left
+            # behind requires the escape hatch. Reading them back must not need it.
+            with Endpoint.allow_endpoint_init():
+                endpoint = Endpoint(
+                    product=product,
+                    protocol="https",
+                    host=f"host-{suffix}.example.com",
+                )
+                endpoint.save()
+                Endpoint_Status(endpoint=endpoint, finding=finding).save()
+
+        return SimpleNamespace(
+            product_type=product_type,
+            product=product,
+            engagement=engagement,
+            test=test,
+            finding=finding,
+        )
+
+    def test_batch_dedupe_loader_survives_legacy_endpoint_rows(self):
+        """
+        The loader behind post_process_findings_batch (import/reimport) and the dedupe
+        command's batch mode. Prefetching ``endpoints`` here raised NotImplementedError.
+        """
+        tree = self._build_tree("loader")
+
+        findings = get_finding_models_for_deduplication([tree.finding.id])
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].id, tree.finding.id)
+
+    def test_batch_dedupe_loader_does_not_prefetch_the_deprecated_relation(self):
+        """
+        Shape assertion, so a re-introduced ``endpoints`` prefetch fails here rather than
+        only on an instance that happens to still have endpoint rows.
+        """
+        self._build_tree("shape", with_legacy_endpoint=False)
+
+        queryset = Finding.objects.filter(id__in=[]).prefetch_related(
+            *location_prefetch_lookups(),
+        )
+
+        self.assertNotIn("endpoints", [str(lookup) for lookup in queryset._prefetch_related_lookups])
+
+    def test_candidate_queryset_survives_legacy_endpoint_rows(self):
+        """build_candidate_scope_queryset builds the other prefetch list that branched on V3."""
+        tree = self._build_tree("candidates")
+
+        for mode in ("deduplication", "reimport"):
+            with self.subTest(mode=mode):
+                candidates = build_candidate_scope_queryset(tree.test, mode=mode)
+                # Evaluating the queryset is what triggers the prefetch (and the crash).
+                self.assertIn(tree.finding.id, [candidate.id for candidate in candidates])
+
+    def test_hash_code_recompute_survives_legacy_endpoint_rows(self):
+        """
+        The rehash path the dedupe command runs: compute_hash_code() reads locations through
+        get_locations(), which must not fall back to the deprecated relation.
+        """
+        tree = self._build_tree("rehash")
+
+        self.assertTrue(tree.finding.compute_hash_code())


### PR DESCRIPTION
## Summary

- The move to Locations does not delete `Endpoint` rows, and `Endpoint.__init__` raises `NotImplementedError` once `V3_FEATURE_LOCATIONS` is on (see `Endpoint.allow_endpoint_init`). Any queryset that prefetches the `endpoints` relation therefore hydrates the deprecated model for every surviving row and raises.
- `get_finding_models_for_deduplication` prefetched `endpoints` unconditionally. That put the crash on the batch-deduplication path every import and reimport takes (`post_process_findings_batch`) and on `manage.py dedupe` in batch mode. A fresh V3 instance has no endpoint rows to hydrate, so nothing surfaces it — it only fires on an instance that migrated from endpoints, which is why it went unnoticed.
- Adds `location_prefetch_lookups(prefix="")` to `dojo/location/queries.py`, returning the prefetch lookup for the location model actually in use, and routes the dedupe and rehash querysets through it. This replaces three separate spellings of the same decision: the unconditional prefetch above, the inline `V3_FEATURE_LOCATIONS` branch in `build_candidate_scope_queryset`, and the two duplicated `select_related`/`prefetch_related` blocks in the dedupe command.
- The command's V3 branch previously prefetched `locations` (one hop); it now prefetches `locations__location__url` like the other call sites, since `get_locations()` reads `location.url`.
- `unittests/test_dedupe_with_endpoints_v3.py` covers it, joining the existing `*_endpoints_v3.py` regression family. Verified it catches the original defect: restoring the `endpoints` prefetch fails `test_batch_dedupe_loader_survives_legacy_endpoint_rows` with `NotImplementedError: Endpoint model is deprecated when V3_FEATURE_LOCATIONS is enabled`.
- The `prefix` argument exists because the Pro Tuner's rehash tasks page `EnhancedFinding` and reach the finding through a relation; a follow-up on the Pro side replaces its local copy of this helper with this one.
