### PR TITLE
Name the POST permission on the risk acceptance API

### DIFF
--- a/dojo/authorization/api_permissions.py
+++ b/dojo/authorization/api_permissions.py
@@ -432,9 +432,16 @@ class UserHasRiskAcceptancePermission(permissions.BasePermission):
         return True
 
     def has_object_permission(self, request, view, obj):
+        # The fourth argument is the POST permission, and it has to be given: without it
+        # check_object_permission passes None down to user_has_permission for every POST. This
+        # codebase happens to answer False to an unmapped permission, so it degrades to a 403 --
+        # but an authorization layer that treats "no permission named" as unimplemented raises
+        # instead, turning that into a 500. It went unnoticed because this viewset had no POST
+        # actions until expire and reinstate were added.
         return check_object_permission(
             request,
             obj,
+            "edit",
             "edit",
             "edit",
             "edit",

--- a/unittests/test_risk_acceptance_api.py
+++ b/unittests/test_risk_acceptance_api.py
@@ -1,9 +1,12 @@
 import datetime
+from unittest.mock import patch
 
 from rest_framework.authtoken.models import Token
+from rest_framework.request import Request
 from rest_framework.reverse import reverse
-from rest_framework.test import APIClient, APITestCase
+from rest_framework.test import APIClient, APIRequestFactory, APITestCase
 
+from dojo.authorization.api_permissions import UserHasRiskAcceptancePermission
 from dojo.authorization.models import (
     Product_Type_Member,
     Role,
@@ -555,6 +558,31 @@ class TestRiskAcceptanceApi(APITestCase):
 
         risk_acceptance.refresh_from_db()
         self.assertIsNone(risk_acceptance.expiration_date_handled, "an outsider must not be able to expire it")
+
+    def test_post_object_permission_names_a_permission(self):
+        """
+        A POST to this viewset must be checked against a real permission, not None.
+
+        ``check_object_permission`` takes the POST permission as its fourth argument. Omitting it
+        passes None down to ``user_has_permission``, which this codebase happens to answer False --
+        but a stricter authorization layer treats an unmapped permission as unimplemented and
+        raises, turning a 403 into a 500. DefectDojo Pro does exactly that, and its own tests
+        caught it on the expire and reinstate actions: the first POST actions this viewset gained.
+
+        Asserted on the call rather than through a request because neither outcome is visible
+        end-to-end here: a superuser is allowed before the permission is read, and a user without
+        access is filtered out of the queryset and gets a 404 first.
+        """
+        risk_acceptance = self.make_risk_acceptance()
+        request = Request(APIRequestFactory().post(f"{self.url}{risk_acceptance.id}/expire/", {}, format="json"))
+        request.user = User.objects.create(username="ra_post_permission_user")
+
+        with patch("dojo.authorization.api_permissions.check_object_permission") as check:
+            UserHasRiskAcceptancePermission().has_object_permission(request, None, risk_acceptance)
+
+        # (request, obj, get, put, delete, post)
+        self.assertEqual(len(check.call_args.args), 6, "the POST permission is missing")
+        self.assertEqual(check.call_args.args[5], "edit")
 
     def test_risk_acceptance_created_filter(self):
         # 1. Create a baseline Risk Acceptance using the existing test setup


### PR DESCRIPTION
**Description**

`UserHasRiskAcceptancePermission.has_object_permission` passes three permissions to `check_object_permission`, which leaves its fourth argument — `post_permission` — as `None`. Every `POST` to `/api/v2/risk_acceptance/` was therefore checked against a permission that does not exist.

On its own this codebase answers `False` to an unmapped permission, so it degrades to a 403. An authorization layer that treats "no permission named" as unimplemented raises instead, which turns the same request into a **500**. DefectDojo Pro does that, and its tests hit it on the `expire` and `reinstate` actions — the first `POST` actions this viewset gained, which is why the missing argument went unnoticed until now.

`POST` maps to `"edit"`, matching what those two actions already document: expiring or reinstating needs the same permission as editing the risk acceptance.

Two conditions have to coincide to see it at all, which is worth knowing for anyone reviewing the test choice below:

- a superuser is allowed before the permission is ever looked at, so superuser-authenticated tests pass either way;
- a user with no access is filtered out of `get_authorized_risk_acceptances` and gets a 404 before object permissions are consulted.

So only a non-superuser who *can* see the risk acceptance reaches the check.

**Test results**

`unittests/test_risk_acceptance_api.py` gains `test_post_object_permission_names_a_permission`. It asserts the call into `check_object_permission` rather than driving a request, because — per the two conditions above — neither outcome is observable end-to-end in this suite.

Verified both ways:

- on the unpatched permission class it fails with `AssertionError: 5 != 6 : the POST permission is missing`
- with the fix it passes

All 18 tests in `unittests/test_risk_acceptance_api.py` pass (`manage.py test unittests.test_risk_acceptance_api`). Ruff clean against `ruff.toml`.

**Documentation**

No documentation change. The behaviour now matches what the expire/reinstate docs already state — that both require the same permission as editing the risk acceptance — so there is nothing to correct there.

**Checklist**

- [x] Submitted against `bugfix` (this is a bug fix).
- [x] Ruff compliant.
- [x] Test extended in `unittests/`.
