### PR TITLE
ci: report required checks on merge_group, and add one stable gate context

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,6 +6,16 @@ on:
   workflow_call:
   push:
   pull_request:
+  # A merge queue tests each speculative merge commit and waits for the required
+  # status checks to report against it. `ruff-linting` is a required check, so it
+  # has to be produced on merge_group events too -- otherwise the queue waits for
+  # a context that is never going to appear, with no error to say why.
+  #
+  # This trigger must live here rather than relying on the nested call from
+  # unit-tests.yml: a called workflow's context is prefixed with the caller's job
+  # name, so that path reports something other than `ruff-linting` and would not
+  # satisfy the requirement.
+  merge_group:
 jobs:
   ruff-linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,14 @@ on:
       - bugfix
       - release/**
       - hotfix/**
+  # Run the suite against the speculative merge commit a merge queue builds, which
+  # is the only thing that tests what will actually land: two pull requests can
+  # each be green on their own and broken in combination, and nothing before this
+  # point ever evaluates their union.
+  #
+  # Inert until a merge queue is configured -- nothing emits merge_group events
+  # otherwise -- so this can land well ahead of the ruleset that enables one.
+  merge_group:
 
 jobs:
   # hard gate: linting must pass before we spend any time building images or running tests
@@ -56,4 +64,48 @@ jobs:
     needs: build-docker-containers
     uses: ./.github/workflows/k8s-tests.yml
     secrets: inherit
+
+  # One stable context for a branch ruleset or merge queue to require.
+  #
+  # The jobs above report contexts like
+  #   "test-rest-framework (linux/amd64, true) / Rest Framework Unit Tests (debian)"
+  # which change whenever a matrix entry is added, removed or renamed. Requiring
+  # those individually means the ruleset silently stops covering a job the moment
+  # the matrix moves; requiring this one job cannot drift, because its `needs`
+  # list is checked by the workflow itself.
+  #
+  # Why this matters more under a merge queue than it does today: right now a
+  # human reads the checks and decides to merge, so a failing-but-not-required
+  # job still gets seen. A queue merges as soon as the *required* checks pass, so
+  # anything not required stops being a gate at all. Requiring this context is
+  # what keeps the suite meaningful once merging is automatic.
+  unit-tests-complete:
+    name: Unit Tests Complete
+    # always() so this still reports when something upstream fails -- without it
+    # the job would be skipped, and a skipped required check blocks the queue
+    # instead of failing it.
+    if: always()
+    needs:
+      - ruff
+      - build-docker-containers
+      - test-performance
+      - test-rest-framework
+      - test-user-interface
+      - test-k8s
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every job succeeded
+        # A skipped or cancelled dependency is not a pass. Checking explicitly
+        # rather than relying on this job's own conclusion, because a job whose
+        # needs were skipped can otherwise report success by omission.
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "dependency results: ${results}"
+          for result in ${results}; do
+            if [ "${result}" != "success" ]; then
+              echo "::error::At least one job did not succeed (${results})"
+              exit 1
+            fi
+          done
+          echo "All jobs succeeded."
 


### PR DESCRIPTION
## Description

Groundwork for enabling a merge queue. Both changes are inert until one is configured — nothing emits `merge_group` events otherwise — so this can land well ahead of the ruleset.

## 1. Nothing here reports on `merge_group`

A queue builds a speculative merge commit and waits for the required status checks to report against **it**. No workflow in this repository triggers on `merge_group`, so a queue would sit waiting for contexts that will never appear: no error, no annotation, just a stuck queue and a 120-minute timeout.

`ruff.yml` needs the trigger directly rather than inheriting it through the nested call from `unit-tests.yml`. A called workflow's context is prefixed with the calling job's name, so that path reports something other than `ruff-linting` and would not satisfy a requirement on it.

## 2. The bigger issue: today's required checks are not a gate a queue can rely on

The only required check on `master`, `dev` and `bugfix` is **`ruff-linting`**. The unit tests run but are not required — which works today, because a human reads the checks before clicking merge.

**A queue merges as soon as the required checks pass.** Everything not required stops being a gate at all. Enabling a queue against today's requirements would automate merging on a lint pass, which is strictly weaker than the status quo rather than stronger.

Requiring the suite's own contexts is not a good answer either. They look like:

```
test-rest-framework (linux/amd64, true) / Rest Framework Unit Tests (debian)
```

and change whenever a matrix entry is added, removed or renamed. A ruleset pinned to those quietly stops covering a job the moment the matrix moves, and nothing tells you.

So this adds **`unit-tests-complete`** — one context that cannot drift, because its `needs` list is enforced by the workflow itself rather than by a ruleset someone has to remember to update.

Two details in it are load-bearing:

- **`if: always()`** — without it the job is skipped when something upstream fails, and a *skipped* required check blocks a queue rather than failing it.
- **Explicit result checking** rather than trusting the job's own conclusion — a job whose `needs` were skipped otherwise reports success by omission.

## Suggested rollout

1. This lands.
2. A ruleset adds a merge queue and requires `unit-tests-complete` (and `ruff-linting`).
3. A canary pull request validates the queue end to end.

Worth doing (2) **after** the two-tier check work rather than before: until the `pull_request` tier is lightened, every landing runs the full suite twice — once on the pull request and once in the queue. At ~565 runner-minutes per run that is not a doubling worth absorbing for long.

## One decision to make deliberately

`release-3-master-into-dev.yml` opens the release merge-back into `dev`, and **a queue applies a single merge method to everything reaching its base branch**. If that method is squash, merge-backs lose their merge topology.

The good news is that nothing in this repository's automation calls `gh pr merge` — I checked every workflow — so merge-backs are merged by hand and a bypass actor covers them. That is a materially safer position than a repo whose release script automates it: `gh pr merge --merge` on a not-yet-green pull request in a queue-enabled repo **exits 0 without merging**, arming auto-merge instead, and the queue then lands it with the queue's method. Any script reading exit 0 as success would be wrong. Not a problem here, but worth recording before someone automates that step.

## Verification

`unit-tests-complete`'s `needs` list was checked against the workflow's job list programmatically — no job missing, none stale. This pull request's own run exercises the new job on the `pull_request` path; the `merge_group` path cannot be exercised until a queue exists, which is the point of landing it first.