### PR TITLE
ci: retry the two Docker Hub pulls the integration jobs depend on

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -103,6 +103,37 @@ jobs:
       - name: Set integration-test mode
         run: ln -s docker-compose.override.integration_tests.yml docker-compose.override.yml
 
+      # mailhog and webhook.endpoint are the only two images this job fetches from
+      # Docker Hub; django, nginx and integration-tests all arrive as artifacts
+      # from the build job. Pulling those two is the single most common cause of a
+      # red check here -- four runs on one branch failed as
+      #
+      #   mailhog Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
+      #
+      # with no test failure anywhere in the log. `docker compose up` gives a pull
+      # exactly one attempt, so a transient timeout takes the whole job with it,
+      # and this matrix plays that lottery 113 times per pull request.
+      #
+      # Retrying here rather than adding a step to fetch them as artifacts: this is
+      # three lines and fixes the observed failure, where plumbing two more images
+      # through the build-and-upload path touches four workflows. If Docker Hub
+      # rate limits become the problem rather than timeouts, the artifact route is
+      # the better answer.
+      - name: Pull external images
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose pull --quiet mailhog webhook.endpoint; then
+              exit 0
+            fi
+            echo "::warning::pull attempt ${attempt} failed; retrying in 15s"
+            sleep 15
+          done
+          echo "::error::could not pull mailhog / webhook.endpoint after 3 attempts"
+          exit 1
+        env:
+          DJANGO_VERSION: ${{ matrix.os }}
+          NGINX_VERSION: alpine
+
       - name: Start Dojo
         run: docker compose up --no-deps -d postgres nginx celerybeat celeryworker mailhog uwsgi valkey webhook.endpoint
         env:


### PR DESCRIPTION
## The failure

Four runs on one branch went red on the same thing, each time on a **different test file**, with no test failure anywhere in the log:

```
mailhog Error Get "https://registry-1.docker.io/v2/": net/http: request canceled
webhook.endpoint Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
```

Files hit: `engagement_test.py`, `test_type_test.py`, `metrics_extended_test.py`, `notification_webhook_test.py`. Nothing in common except the registry.

## Why it happens 113 times per pull request

`mailhog` and `webhook.endpoint` are the **only** two images these jobs fetch from Docker Hub — `django`, `nginx` and `integration-tests` all arrive as artifacts from the build job. `docker compose up` gives a pull exactly one attempt, so a transient registry timeout takes the whole job with it.

At a per-pull failure rate low enough to look like bad luck, 113 draws per pull request makes a red check close to routine. Each one costs a re-run of a 4-minute job plus somebody deciding whether it was real.

## The fix

Pre-pull both images with three attempts and a 15 second backoff, before `Start Dojo`. It sits after the override symlink is created, since `docker compose pull` needs it.

**Why retry rather than fetch them as artifacts.** The artifact route is arguably more correct — it removes Docker Hub from these jobs entirely — but it means plumbing two more images through the build-and-upload path across four workflows. This is a few lines and fixes the failure actually observed. If Docker Hub *rate limits* ever become the problem rather than timeouts, artifacts are the better answer, and the comment in the diff says so.

## Why this is worth more than the annoyance

Two reasons beyond the wasted re-runs:

**A merge queue makes flakiness expensive.** A queue ejects a pull request when a required check fails and re-tests everything queued behind it. A background flake that costs one re-run click today would cost queue thrash instead. If a merge queue is on the roadmap here, this wants fixing first.

**A routine background failure rate trains people to re-run rather than read.** That is the habit that lets a real regression through — the failure looks like the noise everyone has learned to click past.

## Verification

The failure mode is a network timeout, so it cannot be reproduced deterministically. What is verifiable: the workflow parses, the new step lands in the right place in the sequence (`Set integration-test mode` → `Pull external images` → `Start Dojo`), and the two service names match the ones `Start Dojo` brings up. The retry logic fails loudly after three attempts rather than falling through to a confusing error later.