### PR TITLE
docs(reports): drop the BETA label from the Report Builder sidebar reference

### DIFF
--- a/docs/content/metrics_reports/reports/PRO__report_builder.md
+++ b/docs/content/metrics_reports/reports/PRO__report_builder.md
@@ -11,7 +11,7 @@ aliases:
 ---
 <span style="background-color:rgba(242, 86, 29, 0.3)">Note: The reusable Report Builder (Themes, Blocks, Templates, and saved Generated Reports) is a DefectDojo Pro feature, currently in beta.</span>
 
-The DefectDojo Pro Report Builder lets you compose polished reports out of reusable parts, so you can build the pieces once and reuse them everywhere instead of rebuilding a report from scratch each time. You reach it from the **📄 Reporting** area in the sidebar (the live UI labels it "Reporting BETA").
+The DefectDojo Pro Report Builder lets you compose polished reports out of reusable parts, so you can build the pieces once and reuse them everywhere instead of rebuilding a report from scratch each time. You reach it from the **📄 Reporting** area in the sidebar.
 
 ## How it compares to open source
 


### PR DESCRIPTION
The Report Builder page told readers the sidebar entry is labeled "Reporting BETA". Reporting went GA and the menu entry no longer carries a BETA tag, so the docs should not send readers looking for one.

Docs-only change: one sentence in metrics_reports/reports/PRO__report_builder.md.