### PR TITLE
ci: two-tier checks — light pull-request runs, the full suite in the queue

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,9 +45,15 @@ jobs:
           "tests/base_test_class.py",
         ]
         os: [debian]
-        v3_feature_locations: [true, false]
+        # Two tiers: pull requests run the UI suite once, with the flag in its
+        # default (false) position; the merge queue and manual dispatch run both
+        # values against the exact commit that will land. github.event_name is
+        # the CALLING workflow's event -- workflow_call inherits the caller's
+        # context -- so this follows unit-tests.yml's tiering automatically.
+        v3_feature_locations: ${{ github.event_name == 'pull_request' && fromJSON('[false]') || fromJSON('[true, false]') }}
         exclude:
-          # standalone create endpoint page is gone in v3
+          # standalone create endpoint page is gone in v3. On the light tier
+          # v3=true is absent and this exclude simply matches nothing.
           - v3_feature_locations: true
             test-case: "tests/endpoint_test.py"
       fail-fast: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,17 @@ jobs:
     needs: ruff
     strategy:
         matrix:
-          platform: ['linux/amd64', 'linux/arm64']
+          # Two tiers, one workflow. Pull requests build amd64 only; the merge
+          # queue (and manual dispatch) builds both platforms and tests the
+          # speculative merge commit with everything. The queue is the gate, the
+          # pull-request run is feedback -- an arm64-only breakage surfaces when
+          # the queue tests the exact commit that would land, where it costs one
+          # queue ejection instead of a bad merge.
+          #
+          # Tiering must shrink MATRICES, never skip whole jobs: the
+          # unit-tests-complete gate requires every job in its `needs` to report
+          # success, and a skipped job reports skipped. Same jobs, fewer cells.
+          platform: ${{ github.event_name == 'pull_request' && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64", "linux/arm64"]') }}
         fail-fast: false
     uses: ./.github/workflows/build-docker-images-for-testing.yml
     secrets: inherit
@@ -43,7 +53,12 @@ jobs:
   test-rest-framework:
     strategy:
       matrix:
-        platform: ['linux/amd64', 'linux/arm64']
+        # Light tier drops the arm64 cells, matching the build tiering above (a
+        # pull-request run has no arm64 image artifact to test anyway). Both
+        # v3_feature_locations values stay in BOTH tiers: the flag changes the
+        # API schema and endpoint behaviour, so the two runs are genuinely
+        # different suites, not a platform duplicate.
+        platform: ${{ github.event_name == 'pull_request' && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64", "linux/arm64"]') }}
         v3_feature_locations: [ false, true ]
       fail-fast: false
     needs: build-docker-containers


### PR DESCRIPTION
## Design

Pull requests get fast, cheap feedback; the merge queue runs **everything** against the speculative merge commit — the exact tree that lands. Queue = gate, light tier = feedback. A light-tier false green costs one queue ejection, never a bad merge.

This is inert-by-half until the queue ruleset is applied: `merge_group` never fires today, so only the light tier is observable until then. Landing it first means the ruleset flips on against workflows that already know what to do.

| | light (`pull_request`) | full (`merge_group`, `workflow_dispatch`) |
|---|---|---|
| builds | amd64 (4 jobs) | amd64 + arm64 (7) |
| unit tests | amd64 × **both** v3 values (2) | both platforms × both values (4) |
| UI suite | grouped, v3=false (12) | grouped, both values (23) |
| k8s / performance | unchanged (3) | unchanged (3) |
| **total** | **23 jobs / ~130 runner-min** | **~39 jobs / ~230 runner-min** |

## What the light tier drops, and why each is safe

**arm64.** Python-level failures are almost never architecture-specific; when one is, the queue catches it on the commit that would land. (The light tier builds no arm64 artifacts, so the unit cells couldn't run anyway — the two tiers are internally consistent.)

**The v3=true pass of the UI suite.** The flag is real behaviour — it changes the API schema — which is exactly why **both unit-test flag values stay in the light tier**. But the UI suite pays 11 jobs to re-walk the same pages under the second flag value, and the queue still runs both.

## Mechanics worth reviewing

- **Tiering shrinks matrices, never skips jobs.** `unit-tests-complete` requires every job in its `needs` to report `success`, and a skipped job reports `skipped`. Conditional matrices keep every job present and every context earned on both event paths — the ruleset sees identical strings either way. This constraint is written into the workflow comments so future tiering follows it.
- The `cond && fromJSON(light) || fromJSON(full)` idiom is safe here because the light values are non-empty arrays (truthy); the classic falsy-middle footgun needs `''` or `0` as the middle operand.
- `integration-tests.yml` reads `github.event_name` from the **caller's** event (`workflow_call` inherits the calling workflow's context), so its tier follows `unit-tests.yml` automatically.
- The `v3=true` / `endpoint_test.py` exclude matches nothing on the light tier — a legal no-op — and keeps working in the queue.
- **k8s stays untiered deliberately**: its matrix entries carry renovate datasource comments on each version pin, and folding them into a `fromJSON` string would silently detach renovate. Two short jobs aren't worth breaking version automation.

## Verification

- Both tier expressions emulated for both event names; job counts above are computed from the parsed workflows, not estimated.
- `actionlint` clean; YAML parses; the exclude no-op confirmed against GitHub's partial-match semantics.
- This PR's own run demonstrates the light tier (23 jobs). The full tier can be demonstrated pre-queue with a `workflow_dispatch`, which takes the `|| full` branch of every expression.

## Suggested rollout (after this lands)

1. `workflow_dispatch` once to prove the full tier end to end.
2. Apply the merge-queue ruleset on `bugfix`: require `ruff-linting` + `Unit Tests Complete` (both live-verified in both directions this week), squash method, org-admin bypass for release merge-backs.
3. Canary PR through the queue, then extend the ruleset to `dev`.