### PR TITLE
ci: follow-ups from the migration-graph review — push scoping and the misdiagnosing heredoc

### DIFF
--- a/.github/workflows/migration-graph.yml
+++ b/.github/workflows/migration-graph.yml
@@ -23,7 +23,18 @@ name: Migration Graph
 
 on:
   workflow_dispatch:
+  # The push trigger exists for the post-merge case described above, and that
+  # case only happens on the release lines -- so it is scoped to them. Unfiltered
+  # it also fired on every push to every PR branch, where it duplicated the
+  # pull_request run of the same commit (and the pull_request run is the better
+  # of the two there: it sees the branch merged with its base).
   push:
+    branches:
+      - master
+      - dev
+      - bugfix
+      - release/**
+      - hotfix/**
   pull_request:
 
 jobs:

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,7 +4,16 @@ on:
   workflow_dispatch:
   # called by unit-tests.yml as a gate: nothing else runs until ruff passes
   workflow_call:
+  # push is for the release lines: it is what lints the merged result after a
+  # pull request lands. Unfiltered it also fired on every push to every PR
+  # branch, doubling up with the pull_request trigger below on the same commit.
   push:
+    branches:
+      - master
+      - dev
+      - bugfix
+      - release/**
+      - hotfix/**
   pull_request:
   # A merge queue tests each speculative merge commit and waits for the required
   # status checks to report against it. `ruff-linting` is a required check, so it

--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -23,9 +23,21 @@ python3 manage.py makemigrations --no-input --check --dry-run --verbosity 3 || {
 
 ********************************************************************************
 
-You made changes to the models without creating a DB migration for them.
+The makemigrations check failed. This happens for two different reasons,
+and the error Django printed above says which one you have:
 
-**NEVER** change existing migrations, create a new one.
+1) "Your models ... have changes that are not yet reflected in a migration"
+   -- you changed models without creating a migration for them. Create one
+   with 'python3 manage.py makemigrations'.
+   **NEVER** change existing migrations, create a new one.
+
+2) "Conflicting migrations detected; multiple leaf nodes in the migration
+   graph" -- the graph is forked: two migrations declare the same parent,
+   usually after merging or rebasing onto a base branch that had already
+   moved. No model change of yours is involved. Fix it by re-parenting the
+   later migration onto the other leaf (renumbering it if the numbers
+   collide), or with an empty merge migration that depends on both. The
+   Migration Graph Check on the pull request names the offending files.
 
 If you're not familiar with migrations in Django, please read the
 great documentation thoroughly:

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -57,9 +57,21 @@ python3 manage.py makemigrations --no-input --check --dry-run --verbosity 3 || {
 
 ********************************************************************************
 
-You made changes to the models without creating a DB migration for them.
+The makemigrations check failed. This happens for two different reasons,
+and the error Django printed above says which one you have:
 
-**NEVER** change existing migrations, create a new one.
+1) "Your models ... have changes that are not yet reflected in a migration"
+   -- you changed models without creating a migration for them. Create one
+   with 'python3 manage.py makemigrations'.
+   **NEVER** change existing migrations, create a new one.
+
+2) "Conflicting migrations detected; multiple leaf nodes in the migration
+   graph" -- the graph is forked: two migrations declare the same parent,
+   usually after merging or rebasing onto a base branch that had already
+   moved. No model change of yours is involved. Fix it by re-parenting the
+   later migration onto the other leaf (renumbering it if the numbers
+   collide), or with an empty merge migration that depends on both. The
+   Migration Graph Check on the pull request names the offending files.
 
 If you're not familiar with migrations in Django, please read the
 great documentation thoroughly:


### PR DESCRIPTION
Two small items promised in the #15504 review thread, independent of the larger script-trim (which comes separately).

## 1. Scope `push:` to the release lines

`ruff.yml` and `migration-graph.yml` trigger on both bare `push:` and `pull_request`, so every push to a PR branch ran each **twice** on the same commit. Measured while debugging queue starvation: a single PR push spawned 13 workflow runs, these two among the duplicates — and that contributed to exhausting the org's concurrent-job allowance while full suites sat queued.

The push trigger's real job is the release lines, where it's the only thing that checks the **merged result** after a PR lands — for the migration graph that post-merge union is the entire point. Scoping keeps exactly that case; on PR branches the `pull_request` event was the better run anyway (it sees the branch merged with its base, not the branch alone). Matches the pattern `gh-pages.yml` already uses.

## 2. The heredoc that misdiagnosed forked graphs

When `makemigrations --check` fails, both unit-test entrypoints printed one explanation: *"You made changes to the models without creating a DB migration for them."* For the other failure mode — `Conflicting migrations detected; multiple leaf nodes` — that's an active misdiagnosis: no model change of the author's is involved, and the fix is re-parenting, not creating. Anyone hitting a fork was sent hunting for a model change that doesn't exist, which is plausibly most of why forked-graph failures historically read as unrelated to migrations.

The message now names both causes, keyed to the error text Django prints directly above it, with the actual fix for each. Both copies updated (CI + devDocker entrypoints).

## Verification

`shellcheck` and `bash -n` clean on both entrypoints; `actionlint` clean on both workflows; LF endings preserved. The trigger change is observable on this PR itself: its branch pushes should spawn **no** `push`-event runs of ruff or the graph check, while the `pull_request` runs appear as usual.

Credit: both items are from @valentijnscholten's review on #15504.