### PR TITLE
docs(ci): record the live merge-queue ruleset beside the trigger it feeds

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,8 +14,24 @@ on:
   # each be green on their own and broken in combination, and nothing before this
   # point ever evaluates their union.
   #
-  # Inert until a merge queue is configured -- nothing emits merge_group events
-  # otherwise -- so this can land well ahead of the ruleset that enables one.
+  # The queue that emits these events is the "Merge Queue" ruleset (id 20466211),
+  # active on bugfix: SQUASH, ALLGREEN grouping, max 3 entries building, and it
+  # requires `ruff-linting` and `Unit Tests Complete` on the merge group. Two
+  # operational notes recorded here so they survive the people who know them:
+  #
+  #   - The queue applies ONE merge method (squash) to everything it lands.
+  #     Release merge-backs must stay real merge commits, so they go around the
+  #     queue via the ruleset's bypass actors (repo admins + the maintainer
+  #     teams), exactly as they bypass branch protection today. Nothing in this
+  #     repository's automation calls `gh pr merge`, and that is load-bearing:
+  #     on a queue-enabled branch that command can exit 0 WITHOUT merging (it
+  #     arms auto-merge and the queue lands the PR later, with the queue's
+  #     method), so any future script must read the PR's merged state back
+  #     rather than trusting the exit code.
+  #
+  #   - Under the two-tier matrices below, pull requests run the light tier and
+  #     the queue re-runs the full tier on the speculative merge commit, so a
+  #     queued PR's checks taking longer than its own PR run is expected.
   merge_group:
 
 jobs:


### PR DESCRIPTION
Comment-only change, and deliberately the **first pull request through the merge queue** — the canary validating the chain end to end:

1. PR goes green on the light tier and gets queued.
2. The queue builds a speculative merge commit and emits `merge_group`.
3. `unit-tests.yml` and `ruff.yml` run the **full tier** against that commit.
4. `ruff-linting` and `Unit Tests Complete` report on it.
5. The queue merges automatically on green.

If any link in that chain is broken, this PR sits in the queue and the diff at risk is a comment.

The comment itself replaces the "inert until a merge queue is configured" note with what is now true: the **Merge Queue ruleset (id 20466211)** is active on `bugfix` — SQUASH, ALLGREEN, max 3 entries building, requiring `ruff-linting` + `Unit Tests Complete` on the merge group. It records the two operational facts most likely to be lost: release merge-backs stay real merge commits by using the ruleset's bypass actors, and `gh pr merge`'s exit code is untrustworthy on a queue-enabled branch (0 can mean "armed auto-merge", not "merged"), so future automation must read the merged state back.