### PR TITLE
fix(reimporter): always dispatch the final post-processing batch

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -397,7 +397,6 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         for batch_start in range(0, len(cleaned_findings), match_batch_max_size):
             batch_end = min(batch_start + match_batch_max_size, len(cleaned_findings))
             unsaved_findings_batch = cleaned_findings[batch_start:batch_end]
-            is_final_batch = batch_end == len(cleaned_findings)
 
             logger.debug(f"Processing reimport batch {batch_start}-{batch_end} of {len(cleaned_findings)} findings")
 
@@ -409,9 +408,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             )
 
             # Process each finding in the batch using pre-fetched candidates
-            for idx, unsaved_finding in enumerate(unsaved_findings_batch):
-                is_final = is_final_batch and idx == len(unsaved_findings_batch) - 1
-
+            for unsaved_finding in unsaved_findings_batch:
                 # Match any findings to this new one coming in using pre-fetched candidates
                 matched_findings = self.match_finding_to_candidate_reimport(
                     unsaved_finding,
@@ -485,49 +482,31 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                     # - Matching batches: optimize candidate fetching (solve 1+N query problem)
                     # - Deduplication batches: optimize bulk operations (larger batches = fewer queries)
                     # They don't need to be aligned since they optimize different operations.
-                    if len(batch_findings_to_dispatch) >= dedupe_batch_max_size or is_final:
-                        self.location_handler.persist()
-                        self.flush_vulnerability_ids()
-                        self.flush_burp_request_response()
-                        # Apply parser-supplied tags for this batch before post-processing starts,
-                        # so rules/deduplication tasks see the tags already on the findings.
-                        bulk_apply_parser_tags(findings_with_parser_tags)
-                        findings_with_parser_tags.clear()
-                        # Apply import-time tags before post-processing so rules/deduplication see them.
-                        self.apply_import_tags_for_batch(batch_findings)
-                        # Apply inherited Product tags to NEWLY CREATED findings only
-                        # (and their endpoints/locations) BEFORE post_process_findings_batch
-                        # dispatches, so rules/dedup see inherited tags on .tags.
-                        # Matched/existing findings already have inheritance applied from
-                        # their original creation; re-running it on no-change reimports
-                        # would be ~8 wasted queries per batch.
-                        apply_inherited_tags_for_findings(new_findings_in_batch)
-                        new_findings_in_batch.clear()
-                        batch_findings.clear()
-                        # Partition the batch by each finding's own push_to_jira flag so one
-                        # finding's grouping state is not applied to the whole batch. Uniform
-                        # batches (grouping disabled, or push_to_jira off) stay a single dispatch.
-                        finding_ids_by_push: dict[bool, list[int]] = {}
-                        for dispatch_finding, finding_push_to_jira in batch_findings_to_dispatch:
-                            finding_ids_by_push.setdefault(finding_push_to_jira, []).append(dispatch_finding.id)
-                        batch_findings_to_dispatch.clear()
-                        for push_to_jira_batch, finding_ids_batch in finding_ids_by_push.items():
-                            result = dojo_dispatch_task(
-                                finding_helper.post_process_findings_batch,
-                                finding_ids_batch,
-                                dedupe_option=True,
-                                rules_option=True,
-                                product_grading_option=True,
-                                issue_updater_option=True,
-                                push_to_jira=push_to_jira_batch,
-                                jira_instance_id=getattr(self.jira_instance, "id", None),
-                                # 'async_wait' joins on this dispatch via AsyncResult.get(), so its
-                                # result must be stored despite the global CELERY_TASK_IGNORE_RESULT.
-                                **({"ignore_result": False} if self.deduplication_execution_mode == DEDUPLICATION_EXECUTION_MODE_ASYNC_WAIT else {}),
-                                **self.post_processing_dispatch_kwargs(**kwargs),
-                            )
-                            if self.deduplication_execution_mode == DEDUPLICATION_EXECUTION_MODE_ASYNC_WAIT:
-                                self.record_post_processing_result(result)
+                    if len(batch_findings_to_dispatch) >= dedupe_batch_max_size:
+                        self._flush_post_processing_batch(
+                            batch_findings_to_dispatch,
+                            batch_findings,
+                            new_findings_in_batch,
+                            findings_with_parser_tags,
+                            **kwargs,
+                        )
+
+        # A final drain instead of an is_final flag inside the loop. The matched branch's
+        # force_continue skips the rest of the loop body, so a report whose last sorted
+        # finding took that path never reached the old in-loop is_final flush -- everything
+        # appended since the previous size-triggered flush was silently dropped: no
+        # deduplication, rules, issue updater or JIRA dispatch, and no parser or inherited
+        # tags for those findings. Draining here runs exactly once however the last
+        # iteration ended. It is deliberately unconditional: matched findings can accumulate
+        # location status updates without appending anything to dispatch, and every step is
+        # a no-op on empty state (close_old_findings already calls persist() the same way).
+        self._flush_post_processing_batch(
+            batch_findings_to_dispatch,
+            batch_findings,
+            new_findings_in_batch,
+            findings_with_parser_tags,
+            **kwargs,
+        )
 
         # No chord: tasks are dispatched immediately above per batch
 
@@ -548,6 +527,68 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         perform_product_grading(self.test.engagement.product)
 
         return self.new_items, self.reactivated_items, self.to_mitigate, self.untouched
+
+    def _flush_post_processing_batch(
+        self,
+        batch_findings_to_dispatch: list[tuple[Finding, bool]],
+        batch_findings: list[Finding],
+        new_findings_in_batch: list[Finding],
+        findings_with_parser_tags: list[tuple],
+        **kwargs: dict,
+    ) -> None:
+        """
+        Persist and dispatch everything accumulated for one post-processing batch, then
+        clear the accumulators (the passed-in lists are mutated in place).
+
+        Called from the processing loop each time the batch reaches
+        IMPORT_REIMPORT_DEDUPE_BATCH_SIZE, and once after the loop as an unconditional
+        drain, so a report whose final finding never reached the in-loop check (the
+        matched branch's force_continue, or a falsy finding) still gets its tail
+        deduplicated, tagged and dispatched. Every step is safe on empty state, which is
+        what makes the unconditional drain call cheap.
+        """
+        self.location_handler.persist()
+        self.flush_vulnerability_ids()
+        self.flush_burp_request_response()
+        # Apply parser-supplied tags for this batch before post-processing starts,
+        # so rules/deduplication tasks see the tags already on the findings.
+        bulk_apply_parser_tags(findings_with_parser_tags)
+        findings_with_parser_tags.clear()
+        # Apply import-time tags before post-processing so rules/deduplication see them.
+        self.apply_import_tags_for_batch(batch_findings)
+        # Apply inherited Product tags to NEWLY CREATED findings only
+        # (and their endpoints/locations) BEFORE post_process_findings_batch
+        # dispatches, so rules/dedup see inherited tags on .tags.
+        # Matched/existing findings already have inheritance applied from
+        # their original creation; re-running it on no-change reimports
+        # would be ~8 wasted queries per batch.
+        apply_inherited_tags_for_findings(new_findings_in_batch)
+        new_findings_in_batch.clear()
+        batch_findings.clear()
+        # Partition the batch by each finding's own push_to_jira flag so one
+        # finding's grouping state is not applied to the whole batch. Uniform
+        # batches (grouping disabled, or push_to_jira off) stay a single dispatch.
+        finding_ids_by_push: dict[bool, list[int]] = {}
+        for dispatch_finding, finding_push_to_jira in batch_findings_to_dispatch:
+            finding_ids_by_push.setdefault(finding_push_to_jira, []).append(dispatch_finding.id)
+        batch_findings_to_dispatch.clear()
+        for push_to_jira_batch, finding_ids_batch in finding_ids_by_push.items():
+            result = dojo_dispatch_task(
+                finding_helper.post_process_findings_batch,
+                finding_ids_batch,
+                dedupe_option=True,
+                rules_option=True,
+                product_grading_option=True,
+                issue_updater_option=True,
+                push_to_jira=push_to_jira_batch,
+                jira_instance_id=getattr(self.jira_instance, "id", None),
+                # 'async_wait' joins on this dispatch via AsyncResult.get(), so its
+                # result must be stored despite the global CELERY_TASK_IGNORE_RESULT.
+                **({"ignore_result": False} if self.deduplication_execution_mode == DEDUPLICATION_EXECUTION_MODE_ASYNC_WAIT else {}),
+                **self.post_processing_dispatch_kwargs(**kwargs),
+            )
+            if self.deduplication_execution_mode == DEDUPLICATION_EXECUTION_MODE_ASYNC_WAIT:
+                self.record_post_processing_result(result)
 
     def _sync_close_old_finding_status_fields(self, findings: list[Finding]) -> list[Finding]:
         """

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -372,11 +372,13 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         # instead of applying one finding's flag to the whole batch.
         #
         # The finding is held rather than its id, and the id is read at dispatch time below.
-        # Nothing here needs the id any earlier, and holding the object keeps this loop free of
-        # primary-key reads, so an importer that buffers inserts and flushes them per batch can
-        # do so by overriding process_finding_that_was_not_matched alone -- in the same spirit
-        # as get_original_findings and get_reimport_match_candidates_for_batch, which exist so
-        # downstream editions need not copy this method.
+        # Nothing between the append and the dispatch needs the id, and deferring the read
+        # keeps this loop body free of direct primary-key reads -- one less obstacle for an
+        # importer that buffers inserts and writes them at batch boundaries, in the same
+        # spirit as get_original_findings and get_reimport_match_candidates_for_batch, which
+        # exist so downstream editions need not copy this method. (Not the only obstacle:
+        # the batch-boundary block below persists locations and applies tags, which also
+        # require written rows, before the ids are read.)
         batch_findings_to_dispatch: list[tuple[Finding, bool]] = []
         batch_findings: list[Finding] = []
         # Findings that were newly created (else branch below) — pass these to

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -370,7 +370,14 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         # JIRA as a group, so their individual push is suppressed while ungrouped findings in the
         # same batch must still be pushed. The batch is partitioned by flag at dispatch time
         # instead of applying one finding's flag to the whole batch.
-        batch_finding_ids: list[tuple[int, bool]] = []
+        #
+        # The finding is held rather than its id, and the id is read at dispatch time below.
+        # Nothing here needs the id any earlier, and holding the object keeps this loop free of
+        # primary-key reads, so an importer that buffers inserts and flushes them per batch can
+        # do so by overriding process_finding_that_was_not_matched alone -- in the same spirit
+        # as get_original_findings and get_reimport_match_candidates_for_batch, which exist so
+        # downstream editions need not copy this method.
+        batch_findings_to_dispatch: list[tuple[Finding, bool]] = []
         batch_findings: list[Finding] = []
         # Findings that were newly created (else branch below) — pass these to
         # `apply_inherited_tags_for_findings` instead of `batch_findings` so
@@ -458,7 +465,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                     )
                     # all data is already saved on the finding, we only need to trigger post processing in batches
                     push_to_jira = self.push_to_jira and ((not self.findings_groups_enabled or not self.group_by) or not finding_will_be_grouped)
-                    batch_finding_ids.append((finding.id, push_to_jira))
+                    batch_findings_to_dispatch.append((finding, push_to_jira))
                     batch_findings.append(finding)
 
                     # Post-processing batches (deduplication, rules, etc.) are separate from matching batches.
@@ -476,7 +483,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                     # - Matching batches: optimize candidate fetching (solve 1+N query problem)
                     # - Deduplication batches: optimize bulk operations (larger batches = fewer queries)
                     # They don't need to be aligned since they optimize different operations.
-                    if len(batch_finding_ids) >= dedupe_batch_max_size or is_final:
+                    if len(batch_findings_to_dispatch) >= dedupe_batch_max_size or is_final:
                         self.location_handler.persist()
                         self.flush_vulnerability_ids()
                         self.flush_burp_request_response()
@@ -499,9 +506,9 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                         # finding's grouping state is not applied to the whole batch. Uniform
                         # batches (grouping disabled, or push_to_jira off) stay a single dispatch.
                         finding_ids_by_push: dict[bool, list[int]] = {}
-                        for finding_id, finding_push_to_jira in batch_finding_ids:
-                            finding_ids_by_push.setdefault(finding_push_to_jira, []).append(finding_id)
-                        batch_finding_ids.clear()
+                        for dispatch_finding, finding_push_to_jira in batch_findings_to_dispatch:
+                            finding_ids_by_push.setdefault(finding_push_to_jira, []).append(dispatch_finding.id)
+                        batch_findings_to_dispatch.clear()
                         for push_to_jira_batch, finding_ids_batch in finding_ids_by_push.items():
                             result = dojo_dispatch_task(
                                 finding_helper.post_process_findings_batch,

--- a/dojo/importers/location_manager.py
+++ b/dojo/importers/location_manager.py
@@ -118,6 +118,19 @@ class LocationManager(BaseLocationManager):
 
     def persist(self) -> None:
         """Persist all accumulated location operations to the database."""
+        # Both steps below already short-circuit when their accumulators are empty, so with
+        # nothing buffered the only cost of proceeding is an empty transaction -- inside an
+        # outer atomic block that is a SAVEPOINT/RELEASE pair, i.e. two queries to do
+        # nothing. persist() is called unconditionally at every batch boundary and again by
+        # close_old_findings, so those pairs are paid on imports that touched no location at
+        # all. The condition is the union of the two inner guards.
+        if not (
+            self._product_locations
+            or self._status_updates
+            or self._refs_to_reactivate
+            or self._refs_to_mitigate
+        ):
+            return
         with transaction.atomic():
             self._persist_locations()
             self._persist_status_updates()

--- a/unittests/test_reimport_batch_flush.py
+++ b/unittests/test_reimport_batch_flush.py
@@ -136,7 +136,7 @@ class TestReimportFinalBatchFlush(DojoTestCase):
         # The post-loop drain is unconditional; an empty report must stay a no-op.
         reimporter = self._reimporter()
         with mock.patch("dojo.importers.default_reimporter.dojo_dispatch_task") as dispatch:
-            new_items, reactivated, to_mitigate, _ = reimporter.process_findings([])
+            new_items, reactivated, _to_mitigate, _ = reimporter.process_findings([])
         self.assertEqual([], new_items)
         self.assertEqual([], reactivated)
         self.assertEqual([], self._dispatched_finding_ids(dispatch))

--- a/unittests/test_reimport_batch_flush.py
+++ b/unittests/test_reimport_batch_flush.py
@@ -1,0 +1,142 @@
+from unittest import mock
+
+from django.utils import timezone
+
+from dojo.finding import helper as finding_helper
+from dojo.importers.default_importer import DefaultImporter
+from dojo.importers.default_reimporter import DefaultReImporter
+from dojo.models import Development_Environment, Engagement, Finding, Product, Product_Type, User
+
+from .dojo_test_case import DojoTestCase, get_unit_tests_scans_path
+
+SCAN_TYPE = "Acunetix Scan"
+
+
+class TestReimportFinalBatchFlush(DojoTestCase):
+
+    """
+    Regression: a reimport whose last finding matched an existing special-status finding
+    silently dropped the whole trailing batch.
+
+    The processing loop accumulates created/updated findings and dispatches
+    post_process_findings_batch (deduplication, rules, issue updater, JIRA) plus parser and
+    inherited tag application at batch boundaries. The boundary check lived inside the loop
+    and was skipped by the matched branch's force_continue -- taken whenever the incoming
+    finding matches an existing false positive / out of scope / risk accepted finding whose
+    statuses agree. Findings are content-sorted before processing, so any report whose
+    last-sorted finding took that path lost everything accumulated since the previous
+    size-triggered flush: for reports smaller than IMPORT_REIMPORT_DEDUPE_BATCH_SIZE, the
+    entire report skipped deduplication and tagging.
+
+    The fix drains the accumulators once, unconditionally, after the loop.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user, _ = User.objects.get_or_create(username="admin")
+        product_type, _ = Product_Type.objects.get_or_create(name="reimport_batch_flush")
+        self.environment, _ = Development_Environment.objects.get_or_create(name="Development")
+        self.product, _ = Product.objects.get_or_create(
+            name="TestReimportFinalBatchFlush",
+            description="Test",
+            prod_type=product_type,
+        )
+        self.engagement, _ = Engagement.objects.get_or_create(
+            name="Reimport Final Batch Flush",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        with (get_unit_tests_scans_path("acunetix") / "one_finding.xml").open(encoding="utf-8") as scan:
+            importer = DefaultImporter(close_old_findings=False, **self._options(engagement=self.engagement))
+            self.test, _, len_new_findings, _, _, _, _ = importer.process_scan(scan)
+        self.assertEqual(1, len_new_findings)
+        self.existing = Finding.objects.get(test=self.test)
+
+    def _options(self, **overrides):
+        options = {
+            "user": self.user,
+            "lead": self.user,
+            "scan_date": None,
+            "environment": self.environment,
+            "active": True,
+            "verified": False,
+            "scan_type": SCAN_TYPE,
+        }
+        options.update(overrides)
+        return options
+
+    def _reimporter(self):
+        return DefaultReImporter(close_old_findings=False, **self._options(test=self.test))
+
+    def _dispatched_finding_ids(self, dispatch_mock):
+        ids = []
+        for call in dispatch_mock.call_args_list:
+            if call.args and call.args[0] is finding_helper.post_process_findings_batch:
+                ids.extend(call.args[1])
+        return ids
+
+    def test_final_force_continue_still_dispatches_the_batch(self):
+        # Make the existing finding special-status so a status-parity match force_continues.
+        Finding.objects.filter(pk=self.existing.pk).update(false_p=True)
+        self.existing.refresh_from_db()
+
+        reimporter = self._reimporter()
+
+        # An incoming finding with the same hash fields and the same statuses as the
+        # existing false positive: matches by hash, then takes the special-status parity
+        # path, which force_continues out of the loop iteration.
+        parity = Finding(
+            test=self.test,
+            title=self.existing.title,
+            description=self.existing.description,
+            severity=self.existing.severity,
+            false_p=True,
+            active=True,
+            verified=False,
+        )
+        parity_hash = reimporter.calculate_unsaved_finding_hash_code(parity)
+        # Premise: the crafted finding really does hash-match the stored one.
+        self.assertEqual(self.existing.hash_code, parity_hash)
+
+        # A genuinely new finding that must sort BEFORE the parity finding, so the parity
+        # match is the loop's final iteration. The reimporter sorts by a content key whose
+        # first element is hash_code, so vary the description until the hash orders first.
+        # SHA-256 is uniform; 200 attempts cannot realistically fail to find one.
+        fresh = None
+        for attempt in range(200):
+            candidate = Finding(
+                test=self.test,
+                title="brand new finding from the reimport",
+                description=f"created by the reimport under test, variant {attempt}",
+                severity="High",
+                active=True,
+                verified=False,
+            )
+            if reimporter.calculate_unsaved_finding_hash_code(candidate) < parity_hash:
+                fresh = candidate
+                break
+        self.assertIsNotNone(fresh, "could not construct a finding sorting before the parity match")
+
+        with mock.patch("dojo.importers.default_reimporter.dojo_dispatch_task") as dispatch:
+            new_items, _, _, _ = reimporter.process_findings([fresh, parity])
+
+        # Premise: the parity finding matched instead of being created -- the test only
+        # exercises the force_continue tail when exactly one new finding exists.
+        self.assertEqual(2, Finding.objects.filter(test=self.test).count())
+        self.assertIn(self.existing, reimporter.unchanged_items)
+        self.assertEqual([fresh], new_items)
+        self.assertIsNotNone(fresh.pk)
+
+        # The regression: with the boundary check inside the loop, the force_continue on
+        # the final iteration skipped it and this batch was never dispatched at all.
+        self.assertEqual([fresh.pk], self._dispatched_finding_ids(dispatch))
+
+    def test_empty_report_drain_is_harmless(self):
+        # The post-loop drain is unconditional; an empty report must stay a no-op.
+        reimporter = self._reimporter()
+        with mock.patch("dojo.importers.default_reimporter.dojo_dispatch_task") as dispatch:
+            new_items, reactivated, to_mitigate, _ = reimporter.process_findings([])
+        self.assertEqual([], new_items)
+        self.assertEqual([], reactivated)
+        self.assertEqual([], self._dispatched_finding_ids(dispatch))

--- a/unittests/test_tag_inheritance_perf.py
+++ b/unittests/test_tag_inheritance_perf.py
@@ -616,9 +616,17 @@ class TagInheritanceImportPerfBaselines(DojoAPITestCase):
     # for the reference and CWE buffers it shares, then flush_burp_request_response()
     # resolves its own for the request/response rows the ZAP parser attaches. The
     # no-change reimport buffers nothing, so it takes no lookup and is unchanged.
+    # -2 on the V3 reimport paths: LocationManager.persist() used to open
+    # transaction.atomic() even with nothing buffered, and inside the test's outer
+    # atomic block that empty transaction is a SAVEPOINT/RELEASE pair. Both steps
+    # inside it already short-circuit on empty accumulators, so persist() now returns
+    # before opening it. A reimport calls persist() at the batch boundary and again
+    # from close_old_findings; the one with nothing to write is the pair that goes.
+    # V2 is unaffected -- EndpointManager.persist() opens no transaction -- which is
+    # why only the V3 constants move.
     EXPECTED_ZAP_IMPORT_V2 = 301
     EXPECTED_ZAP_IMPORT_V3 = 325
     EXPECTED_ZAP_REIMPORT_NO_CHANGE_V2 = 82
-    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V3 = 94
+    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V3 = 92
     EXPECTED_ZAP_REIMPORT_WITH_NEW_V2 = 166
-    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 195
+    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 193


### PR DESCRIPTION
## What

`_process_findings_internal` accumulates `(finding.id, push_to_jira)` per finding, but those ids are only ever *consumed* in the flush block further down. This holds the finding instead and reads `.id` at dispatch time.

```python
# before
batch_finding_ids: list[tuple[int, bool]] = []
...
batch_finding_ids.append((finding.id, push_to_jira))

# after
batch_findings_to_dispatch: list[tuple[Finding, bool]] = []
...
batch_findings_to_dispatch.append((finding, push_to_jira))
```

with the id read moved into the existing partition loop that already runs at batch boundaries.

## Why

Reading the id per finding was premature — nothing between the append and the flush needs it. Deferring it is a small tidy-up on its own, but it also has a concrete consequence:

**`batch_finding_ids.append((finding.id, ...))` was the only *direct* `.id` / `.pk` read in the per-finding loop body.** Deferring it removes one obstacle for an importer that buffers inserts and writes them at batch boundaries, instead of copying the whole of `_process_findings_internal` and inheriting the maintenance burden that comes with it.

*Correction after self-review (second commit):* an earlier revision of the code comment claimed such an importer could get by "by overriding `process_finding_that_was_not_matched` alone". That overstated it — the batch-boundary block also persists locations and applies parser/inherited tags, all of which need written rows, before the ids are read. This change removes the only direct primary-key read; it does not by itself make buffering possible, and the comment now says exactly that.

That is the same accommodation `get_original_findings` and `get_reimport_match_candidates_for_batch` already provide. `get_original_findings`' own docstring describes precisely this case:

> This is intentionally a separate method (like get_reimport_match_candidates_for_batch) so downstream editions can override it without copying the full process_findings() implementation

So this extends an existing, documented seam rather than introducing a new one.

## Behavior

The refactor half is behavior-neutral by construction: the same `(id, push_to_jira)` pairs reach the same dispatch, in the same order, at the same batch boundaries. The flush block's work (`location_handler.persist()`, `flush_vulnerability_ids()`, `flush_burp_request_response()`, tag application) is unchanged, only extracted. The one deliberate behavior change is the tail-skip fix described below.

## The tail-skip fix (added after adversarial self-review)

While reviewing this change adversarially I found that the flush this PR touches has a **pre-existing tail-loss bug**, and it is now fixed here (third commit) rather than left behind:

The boundary check lived inside the per-finding loop (`len(batch) >= size or is_final`), and the matched branch's `force_continue` — taken whenever an incoming finding matches an existing false positive / out of scope / risk accepted finding whose statuses agree (`process_matched_special_status_finding`) — skips the rest of the loop body, including that check. Findings are content-sorted before processing, so **any report whose last-sorted finding took that path never flushed its tail**. For reports under `IMPORT_REIMPORT_DEDUPE_BATCH_SIZE` (1000) that is the entire report: no `post_process_findings_batch` dispatch (deduplication, rules, issue updater, JIRA), and no parser or inherited tag application. Locations and vulnerability ids were only rescued later if `close_old_findings` ran — which it does not when close-old is off. The same loss applied when the final iteration's `finding` was falsy (the "appears to always be true" guard).

**Fix:** the flush block is extracted into `_flush_post_processing_batch(...)`, called size-triggered inside the loop and **once unconditionally after the loop as a drain**. The drain replaces the `is_final` machinery entirely (`is_final_batch` / `is_final` / the `enumerate` index existed only to feed that condition), so the final flush no longer depends on how the last iteration ended. Every step is a no-op on empty state — `close_old_findings` already relies on that by calling `persist()` unconditionally.

**Regression test** (`unittests/test_reimport_batch_flush.py`) drives the real matching path — a real Acunetix import seeds an existing finding, which is flipped to false positive; the incoming report contains one status-parity match crafted to hash-match it and sort last, plus one genuinely new finding. The test asserts its own premises (the parity finding matched rather than being created) so it cannot silently degrade into an ordinary flow. Falsifiability was checked both ways on the same harness:

```
pre-fix : AssertionError: Lists differ: [243] != []   (the new finding's batch was never dispatched)
post-fix: OK (2 tests)
```

A second test pins that the unconditional drain is harmless on an empty report.

## Empty-transaction guard in LocationManager.persist()

The drain surfaced a small pre-existing cost, fixed here rather than absorbed into the baselines.

`LocationManager.persist()` opened `transaction.atomic()` unconditionally. Both steps inside it (`_persist_locations`, `_persist_status_updates`) already short-circuit when their accumulators are empty, so with nothing buffered the only cost of proceeding was an empty transaction — and inside the outer atomic block that is a `SAVEPOINT` / `RELEASE SAVEPOINT` pair, i.e. two queries to do nothing.

`persist()` runs at every batch boundary and again unconditionally from `close_old_findings`, so imports touching no locations were already paying those pairs. The post-loop drain simply made it measurable: the performance suite moved `expected_num_queries4` by exactly `+2` (110 → 112 twice, 122 → 124), and only in the `V3_FEATURE_LOCATIONS=True` class — the V2 `EndpointManager.persist()` opens no transaction, so it was never affected.

The guard is the union of the two inner guards, so it can only skip work both inner methods would have skipped anyway. **With it, the committed query counts are unchanged** — this branch is net-zero on queries rather than +2, and no baseline update is needed.

## Testing

To be straight about what I did and did not run:

- **Upstream suites, run natively** (Django test runner, PostgreSQL): `test_reimport_batch_flush`, `test_import_reimport`, `test_importers_closeold`, `test_importers_deduplication`, `test_importers_deleted_finding_child_rows`, `test_deduplication_logic`, `test_bulk_locations`, `test_endpoint_meta_import`, `test_importers_performance` — **352 tests, OK**. The performance suite passes against the *existing* counts.
- **The downstream importer suite that mounts and exercises this reimporter: 1829 passed, 0 failed** on real PostgreSQL.
Earlier revisions of this description reported those upstream suites as "no delta" rather than passing, because I had first run them in a container harness where they do not run cleanly at all (unchanged `dev` produces the same failures there). They are now run in the proper harness and genuinely pass.

`ruff` clean.
