### PR TITLE
ci: port the bugfix CI stack to dev

### DIFF
--- a/.github/workflows/ci-warm-caches.yml
+++ b/.github/workflows/ci-warm-caches.yml
@@ -1,0 +1,142 @@
+name: "CI: Warm Caches"
+
+# Why this workflow exists at all.
+#
+# GitHub scopes every Actions cache entry to the ref that saved it. A run can
+# restore entries saved by its own ref, by its base branch (pull_request events
+# only), and by the repository's default branch -- nothing else. So a pull
+# request cannot leave behind a cache that any *other* pull request can use: it
+# saves into its own PR scope, and that scope dies with the PR.
+#
+# Without a workflow like this one, caching the migrated database would therefore
+# do nothing at all for the first push of a new branch, which is most branches
+# most of the time. Something has to save an entry into a scope pull requests are
+# allowed to read, and only a run triggered from a release line can do that.
+#
+# Note what is deliberately absent: a `schedule:` trigger. Scheduled workflows
+# only ever run against the default branch, so a cron here would run with ref
+# refs/heads/master and warm the master scope -- not the release-line scopes this
+# is for. Eviction is handled instead by reads: GitHub drops an entry it has not
+# seen used for 7 days, and every pull request based on a release line reads this
+# one, which keeps it alive without a timer.
+#
+# Warming the default-branch scope is worth doing too, since every run can read
+# it regardless of base, but that needs a workflow file on master and is a
+# separate change.
+
+on:
+  push:
+    branches:
+      - bugfix
+      - dev
+    # Exactly the paths the snapshot key hashes -- anything else leaves the key
+    # unchanged, so there would be nothing to warm.
+    paths:
+      - 'requirements.txt'
+      - 'dojo/db_migrations/**'
+      - 'dojo/models.py'
+      - 'dojo/base_models/**'
+      - 'dojo/pghistory_models.py'
+      - 'dojo/settings/settings.dist.py'
+      - 'docker-compose.yml'
+      - 'docker-compose.override.unit_tests_cicd.yml'
+      - 'docker/entrypoint-unit-tests.sh'
+      - '.github/workflows/ci-warm-caches.yml'
+  workflow_dispatch:
+
+concurrency:
+  # Two pushes in quick succession would warm the same key twice.
+  group: warm-caches-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warm-migrated-db:
+    name: Warm Migrated Database Snapshot
+    # A fork has its own cache scope and its own billing, so there is nothing
+    # here for it to warm. Same guard as release-nightly-dev.yml.
+    if: github.repository == 'DefectDojo/django-DefectDojo'
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_VERSION: debian
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Computed once, before anything runs Python, and referenced by both the
+      # probe and the save. Not written inline in both places: hashFiles is
+      # evaluated per step, and `dojo/db_migrations/**` picks up the
+      # __pycache__/*.pyc that migrating writes into the bind-mounted workspace,
+      # so the save would land under a key the probe will never ask for.
+      #
+      # KEEP IN SYNC with the same block in rest-framework-tests.yml. If they
+      # drift, this job warms an entry nothing reads and every pull request goes
+      # on paying the full migrate, with nothing failing to say so.
+      - name: Compute migrated database snapshot key
+        id: db-key
+        run: echo "key=migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Probe for an existing snapshot
+        id: probe
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migrated-db.dump
+          key: ${{ steps.db-key.outputs.key }}
+          # Do not download it -- whether the key exists is the whole question,
+          # and on most runs the answer is usually yes.
+          lookup-only: true
+
+      - name: Set unit-test mode
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: docker/setEnv.sh unit_tests_cicd
+
+      # Built here rather than pulled from the build job's artifacts: this needs
+      # one image on one platform, and building it directly keeps the job
+      # self-contained instead of coupling it to that job's upload.
+      - name: Build the unit-test image
+        if: steps.probe.outputs.cache-hit != 'true'
+        timeout-minutes: 30
+        run: docker compose build uwsgi
+
+      - name: Start Postgres
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: docker compose up --no-deps -d postgres
+
+      - name: Wait for Postgres to accept connections
+        if: steps.probe.outputs.cache-hit != 'true'
+        run: |
+          for _ in $(seq 1 60); do
+            if docker compose exec -T postgres pg_isready -q -U defectdojo -d test_defectdojo; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Postgres did not become ready in 120s" >&2
+          exit 1
+
+      - name: Migrate and dump
+        if: steps.probe.outputs.cache-hit != 'true'
+        timeout-minutes: 20
+        run: |
+          docker compose run --rm -T --no-deps uwsgi
+          docker compose exec -T postgres pg_dump \
+            --username defectdojo --dbname test_defectdojo --format=custom > migrated-db.dump
+          ls -lh migrated-db.dump
+        env:
+          DD_TEST_DB_MODE: prepare
+
+      - name: Save the snapshot
+        if: steps.probe.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migrated-db.dump
+          key: ${{ steps.db-key.outputs.key }}
+
+      - name: Logs
+        if: failure()
+        run: docker compose logs --tail="2500"
+
+      - name: Shutdown
+        if: always()
+        run: docker compose down

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -12,68 +12,48 @@ jobs:
       matrix:
         test-case: [
           "openapi-validatator",
-          "tests/action_history_test.py",
-          "tests/alerts_test.py",
-          "tests/announcement_banner_test.py",
-          "tests/banner_test.py",
-          "tests/base_test_class.py",
-          "tests/benchmark_test.py",
-          "tests/calendar_test.py",
-          "tests/check_various_pages.py",
-          "tests/close_old_findings_dedupe_test.py",
-          "tests/close_old_findings_test.py",
-          "tests/dashboard_test.py",
-          "tests/dedupe_test.py",
-          "tests/endpoint_extended_test.py",
+          # endpoint_test.py stays alone so the v3 exclude below still matches it.
           "tests/endpoint_test.py",
-          "tests/engagement_checklist_test.py",
-          "tests/engagement_export_test.py",
-          "tests/engagement_extended_test.py",
-          "tests/engagement_presets_test.py",
-          "tests/engagement_test.py",
-          "tests/environment_test.py",
-          "tests/false_positive_history_test.py",
-          "tests/file_test.py",
-          "tests/finding_extended_test.py",
-          "tests/finding_group_test.py",
-          "tests/finding_test.py",
-          "tests/login_test.py",
-          "tests/metrics_extended_test.py",
-          "tests/note_type_test.py",
-          "tests/notes_test.py",
-          "tests/notification_webhook_test.py",
-          "tests/notifications_test.py",
-          "tests/object_test.py",
-          "tests/product_member_test.py",
-          "tests/product_metadata_test.py",
-          "tests/product_tag_metrics_test.py",
-          "tests/product_test.py",
-          "tests/product_type_member_test.py",
-          "tests/product_type_test.py",
-          "tests/questionnaire_advanced_test.py",
-          "tests/questionnaire_test.py",
-          "tests/regulations_test.py",
-          "tests/reimport_scan_test.py",
-          "tests/report_builder_test.py",
-          "tests/risk_acceptance_test.py",
-          "tests/search_test.py",
-          "tests/sla_configuration_test.py",
-          "tests/system_settings_test.py",
-          "tests/test_copy_test.py",
-          "tests/test_test.py",
-          "tests/test_type_test.py",
-          "tests/threat_model_test.py",
-          "tests/tool_config.py",
-          "tests/tool_product_test.py",
-          "tests/tool_type_test.py",
-          "tests/user_profile_test.py",
-          "tests/user_test.py",
-          # "tests/zap.py",
+          # Each entry below is a GROUP of test files, run sequentially in one
+          # compose stack by docker/entrypoint-integration-tests.sh. The groups
+          # are contiguous slices of the order the entrypoint's legacy no-filter
+          # branch has always run -- every adjacency here has years of history
+          # running back-to-back in ONE stack, and each group gets a FRESH stack,
+          # so this is strictly more isolation than the legacy path, not less.
+          # Do not reorder files across groups without that history in mind;
+          # appending a NEW file to the last group (or its own group) is safe.
+          # tests/zap.py stays disabled, as it was in the per-file matrix.
+          # group 01
+          "tests/finding_test.py tests/report_builder_test.py tests/notes_test.py tests/regulations_test.py tests/product_type_test.py tests/product_test.py",
+          # group 02
+          "tests/engagement_test.py tests/environment_test.py tests/test_test.py tests/user_test.py tests/product_member_test.py tests/product_type_member_test.py",
+          # group 03
+          "tests/search_test.py tests/file_test.py tests/dedupe_test.py tests/announcement_banner_test.py tests/close_old_findings_dedupe_test.py tests/close_old_findings_test.py",
+          # group 04
+          "tests/false_positive_history_test.py tests/check_various_pages.py tests/notifications_test.py tests/note_type_test.py tests/sla_configuration_test.py tests/dashboard_test.py",
+          # group 05
+          "tests/login_test.py tests/alerts_test.py tests/system_settings_test.py tests/engagement_extended_test.py tests/finding_extended_test.py tests/test_copy_test.py",
+          # group 06
+          "tests/endpoint_extended_test.py tests/calendar_test.py tests/finding_group_test.py tests/engagement_presets_test.py tests/questionnaire_test.py tests/benchmark_test.py",
+          # group 07
+          "tests/notification_webhook_test.py tests/threat_model_test.py tests/product_tag_metrics_test.py tests/object_test.py tests/tool_type_test.py tests/tool_product_test.py",
+          # group 08
+          "tests/risk_acceptance_test.py tests/product_metadata_test.py tests/test_type_test.py tests/user_profile_test.py tests/engagement_checklist_test.py tests/questionnaire_advanced_test.py",
+          # group 09
+          "tests/engagement_export_test.py tests/action_history_test.py tests/reimport_scan_test.py tests/banner_test.py tests/metrics_extended_test.py tests/tool_config.py",
+          # group 10
+          "tests/base_test_class.py",
         ]
         os: [debian]
-        v3_feature_locations: [true, false]
+        # Two tiers: pull requests run the UI suite once, with the flag in its
+        # default (false) position; the merge queue and manual dispatch run both
+        # values against the exact commit that will land. github.event_name is
+        # the CALLING workflow's event -- workflow_call inherits the caller's
+        # context -- so this follows unit-tests.yml's tiering automatically.
+        v3_feature_locations: ${{ github.event_name == 'pull_request' && fromJSON('[false]') || fromJSON('[true, false]') }}
         exclude:
-          # standalone create endpoint page is gone in v3
+          # standalone create endpoint page is gone in v3. On the light tier
+          # v3=true is absent and this exclude simply matches nothing.
           - v3_feature_locations: true
             test-case: "tests/endpoint_test.py"
       fail-fast: false
@@ -103,6 +83,37 @@ jobs:
       - name: Set integration-test mode
         run: ln -s docker-compose.override.integration_tests.yml docker-compose.override.yml
 
+      # mailhog and webhook.endpoint are the only two images this job fetches from
+      # Docker Hub; django, nginx and integration-tests all arrive as artifacts
+      # from the build job. Pulling those two is the single most common cause of a
+      # red check here -- four runs on one branch failed as
+      #
+      #   mailhog Error Get "https://registry-1.docker.io/v2/": context deadline exceeded
+      #
+      # with no test failure anywhere in the log. `docker compose up` gives a pull
+      # exactly one attempt, so a transient timeout takes the whole job with it,
+      # and this matrix plays that lottery 113 times per pull request.
+      #
+      # Retrying here rather than adding a step to fetch them as artifacts: this is
+      # three lines and fixes the observed failure, where plumbing two more images
+      # through the build-and-upload path touches four workflows. If Docker Hub
+      # rate limits become the problem rather than timeouts, the artifact route is
+      # the better answer.
+      - name: Pull external images
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose pull --quiet mailhog webhook.endpoint; then
+              exit 0
+            fi
+            echo "::warning::pull attempt ${attempt} failed; retrying in 15s"
+            sleep 15
+          done
+          echo "::error::could not pull mailhog / webhook.endpoint after 3 attempts"
+          exit 1
+        env:
+          DJANGO_VERSION: ${{ matrix.os }}
+          NGINX_VERSION: alpine
+
       - name: Start Dojo
         run: docker compose up --no-deps -d postgres nginx celerybeat celeryworker mailhog uwsgi valkey webhook.endpoint
         env:
@@ -117,7 +128,11 @@ jobs:
           NGINX_VERSION: alpine
 
       - name: Integration tests
-        timeout-minutes: 10
+        # 30 rather than 10: a grouped entry runs up to six files sequentially,
+        # and the largest groups sum to ~11 minutes of test time on a warm stack
+        # before any slowness. Single-file entries are unaffected by the higher
+        # ceiling -- it is a backstop, not a target.
+        timeout-minutes: 30
         run: docker compose up --no-deps --exit-code-from integration-tests integration-tests
         env:
           DD_INTEGRATION_TEST_FILENAME: ${{ matrix.test-case }}

--- a/.github/workflows/migration-graph.yml
+++ b/.github/workflows/migration-graph.yml
@@ -23,7 +23,18 @@ name: Migration Graph
 
 on:
   workflow_dispatch:
+  # The push trigger exists for the post-merge case described above, and that
+  # case only happens on the release lines -- so it is scoped to them. Unfiltered
+  # it also fired on every push to every PR branch, where it duplicated the
+  # pull_request run of the same commit (and the pull_request run is the better
+  # of the two there: it sees the branch merged with its base).
   push:
+    branches:
+      - master
+      - dev
+      - bugfix
+      - release/**
+      - hotfix/**
   pull_request:
 
 jobs:

--- a/.github/workflows/rest-framework-tests.yml
+++ b/.github/workflows/rest-framework-tests.yml
@@ -31,6 +31,23 @@ jobs:
         with:
           persist-credentials: false
 
+      # Computed once, immediately after checkout, and referenced by both the
+      # restore and the save below.
+      #
+      # It has to be computed once rather than written inline in both places,
+      # because hashFiles is evaluated per step and these patterns do not hash to
+      # the same value all job long. `dojo/db_migrations/**` matches whatever is
+      # on disk when it runs, and migrating imports every migration module, which
+      # writes __pycache__/*.pyc into the workspace -- the repository is bind
+      # mounted into the container, so those land here. An inline key therefore
+      # saves under a different key than it restored with, and the entry is one
+      # nothing ever looks up again.
+      #
+      # KEEP IN SYNC with the same block in ci-warm-caches.yml.
+      - name: Compute migrated database snapshot key
+        id: db-key
+        run: echo "key=migrated-db-v1-${{ hashFiles('requirements.txt', 'dojo/db_migrations/**', 'dojo/models.py', 'dojo/base_models/**', 'dojo/pghistory_models.py', 'dojo/settings/settings.dist.py', 'docker-compose.yml', 'docker-compose.override.unit_tests_cicd.yml', 'docker/entrypoint-unit-tests.sh') }}" >> "$GITHUB_OUTPUT"
+
       # load docker images from build jobs
       - name: Load images from artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -53,13 +70,79 @@ jobs:
       - name: Start Postgres and webhook.endpoint
         run: docker compose up --no-deps -d postgres webhook.endpoint
 
+      - name: Wait for Postgres to accept connections
+        run: |
+          for _ in $(seq 1 60); do
+            if docker compose exec -T postgres pg_isready -q -U defectdojo -d test_defectdojo; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Postgres did not become ready in 120s" >&2
+          exit 1
+
+      # Applying 264 migrations takes ~100 seconds and produces the same schema
+      # every time, so restore that result instead of recomputing it. The key is
+      # the migration state: models included, not just migrations, which is what
+      # makes it safe for the entrypoint to skip its makemigrations guard on a
+      # hit (see docker/entrypoint-unit-tests.sh).
+      #
+      # ci-warm-caches.yml is what puts an entry in the base branch's cache scope
+      # for pull requests to find.
+      - name: Restore migrated database snapshot
+        id: db-snapshot
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migrated-db.dump
+          key: ${{ steps.db-key.outputs.key }}
+
+      # pg_restore runs inside the postgres container because it has to match the
+      # server: this one is 18, and the runner's own client is not guaranteed to
+      # be. --single-transaction makes the restore atomic, so a failure leaves the
+      # database empty rather than half-populated, and the migrate below can then
+      # take over cleanly. That is why this step is allowed to fail.
+      - name: Restore snapshot into Postgres
+        id: db-restore
+        if: steps.db-snapshot.outputs.cache-hit == 'true'
+        continue-on-error: true
+        run: |
+          docker compose exec -T postgres pg_restore \
+            --username defectdojo --dbname test_defectdojo \
+            --no-owner --no-privileges --single-transaction < migrated-db.dump
+
+      - name: Migrate and snapshot the database
+        id: db-prepare
+        if: steps.db-snapshot.outputs.cache-hit != 'true' || steps.db-restore.outcome == 'failure'
+        run: |
+          docker compose run --rm -T --no-deps uwsgi
+          docker compose exec -T postgres pg_dump \
+            --username defectdojo --dbname test_defectdojo --format=custom > migrated-db.dump
+        env:
+          DJANGO_VERSION: ${{ matrix.os }}
+          DD_TEST_DB_MODE: prepare
+
+      # Saving here rather than in a post-job step means a snapshot survives a
+      # test failure: it is a function of the migration state, not of whether the
+      # suite passed. Four matrix jobs race for the same key and three of them
+      # lose, which the action reports as a warning, hence continue-on-error.
+      - name: Save migrated database snapshot
+        if: steps.db-prepare.outcome == 'success'
+        continue-on-error: true
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: migrated-db.dump
+          key: ${{ steps.db-key.outputs.key }}
+
       # no celery or initializer needed for unit tests
+      # The database is migrated by this point on both paths -- restored from the
+      # snapshot, or migrated by the step above -- so the entrypoint reuses it.
       - name: Unit tests
         timeout-minutes: 25
         run: docker compose up --no-deps --exit-code-from uwsgi uwsgi
         env:
           DJANGO_VERSION: ${{ matrix.os }}
           DD_V3_FEATURE_LOCATIONS: ${{ inputs.v3_feature_locations }}
+          DD_TEST_DB_MODE: reuse
 
       - name: Logs
         if: failure()

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -4,8 +4,27 @@ on:
   workflow_dispatch:
   # called by unit-tests.yml as a gate: nothing else runs until ruff passes
   workflow_call:
+  # push is for the release lines: it is what lints the merged result after a
+  # pull request lands. Unfiltered it also fired on every push to every PR
+  # branch, doubling up with the pull_request trigger below on the same commit.
   push:
+    branches:
+      - master
+      - dev
+      - bugfix
+      - release/**
+      - hotfix/**
   pull_request:
+  # A merge queue tests each speculative merge commit and waits for the required
+  # status checks to report against it. `ruff-linting` is a required check, so it
+  # has to be produced on merge_group events too -- otherwise the queue waits for
+  # a context that is never going to appear, with no error to say why.
+  #
+  # This trigger must live here rather than relying on the nested call from
+  # unit-tests.yml: a called workflow's context is prefixed with the caller's job
+  # name, so that path reports something other than `ruff-linting` and would not
+  # satisfy the requirement.
+  merge_group:
 jobs:
   ruff-linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,30 @@ on:
       - bugfix
       - release/**
       - hotfix/**
+  # Run the suite against the speculative merge commit a merge queue builds, which
+  # is the only thing that tests what will actually land: two pull requests can
+  # each be green on their own and broken in combination, and nothing before this
+  # point ever evaluates their union.
+  #
+  # The queue that emits these events is the "Merge Queue" ruleset (id 20466211),
+  # active on bugfix: SQUASH, ALLGREEN grouping, max 3 entries building, and it
+  # requires `ruff-linting` and `Unit Tests Complete` on the merge group. Two
+  # operational notes recorded here so they survive the people who know them:
+  #
+  #   - The queue applies ONE merge method (squash) to everything it lands.
+  #     Release merge-backs must stay real merge commits, so they go around the
+  #     queue via the ruleset's bypass actors (repo admins + the maintainer
+  #     teams), exactly as they bypass branch protection today. Nothing in this
+  #     repository's automation calls `gh pr merge`, and that is load-bearing:
+  #     on a queue-enabled branch that command can exit 0 WITHOUT merging (it
+  #     arms auto-merge and the queue lands the PR later, with the queue's
+  #     method), so any future script must read the PR's merged state back
+  #     rather than trusting the exit code.
+  #
+  #   - Under the two-tier matrices below, pull requests run the light tier and
+  #     the queue re-runs the full tier on the speculative merge commit, so a
+  #     queued PR's checks taking longer than its own PR run is expected.
+  merge_group:
 
 jobs:
   # hard gate: linting must pass before we spend any time building images or running tests
@@ -20,7 +44,17 @@ jobs:
     needs: ruff
     strategy:
         matrix:
-          platform: ['linux/amd64', 'linux/arm64']
+          # Two tiers, one workflow. Pull requests build amd64 only; the merge
+          # queue (and manual dispatch) builds both platforms and tests the
+          # speculative merge commit with everything. The queue is the gate, the
+          # pull-request run is feedback -- an arm64-only breakage surfaces when
+          # the queue tests the exact commit that would land, where it costs one
+          # queue ejection instead of a bad merge.
+          #
+          # Tiering must shrink MATRICES, never skip whole jobs: the
+          # unit-tests-complete gate requires every job in its `needs` to report
+          # success, and a skipped job reports skipped. Same jobs, fewer cells.
+          platform: ${{ github.event_name == 'pull_request' && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64", "linux/arm64"]') }}
         fail-fast: false
     uses: ./.github/workflows/build-docker-images-for-testing.yml
     secrets: inherit
@@ -35,7 +69,12 @@ jobs:
   test-rest-framework:
     strategy:
       matrix:
-        platform: ['linux/amd64', 'linux/arm64']
+        # Light tier drops the arm64 cells, matching the build tiering above (a
+        # pull-request run has no arm64 image artifact to test anyway). Both
+        # v3_feature_locations values stay in BOTH tiers: the flag changes the
+        # API schema and endpoint behaviour, so the two runs are genuinely
+        # different suites, not a platform duplicate.
+        platform: ${{ github.event_name == 'pull_request' && fromJSON('["linux/amd64"]') || fromJSON('["linux/amd64", "linux/arm64"]') }}
         v3_feature_locations: [ false, true ]
       fail-fast: false
     needs: build-docker-containers
@@ -56,4 +95,48 @@ jobs:
     needs: build-docker-containers
     uses: ./.github/workflows/k8s-tests.yml
     secrets: inherit
+
+  # One stable context for a branch ruleset or merge queue to require.
+  #
+  # The jobs above report contexts like
+  #   "test-rest-framework (linux/amd64, true) / Rest Framework Unit Tests (debian)"
+  # which change whenever a matrix entry is added, removed or renamed. Requiring
+  # those individually means the ruleset silently stops covering a job the moment
+  # the matrix moves; requiring this one job cannot drift, because its `needs`
+  # list is checked by the workflow itself.
+  #
+  # Why this matters more under a merge queue than it does today: right now a
+  # human reads the checks and decides to merge, so a failing-but-not-required
+  # job still gets seen. A queue merges as soon as the *required* checks pass, so
+  # anything not required stops being a gate at all. Requiring this context is
+  # what keeps the suite meaningful once merging is automatic.
+  unit-tests-complete:
+    name: Unit Tests Complete
+    # always() so this still reports when something upstream fails -- without it
+    # the job would be skipped, and a skipped required check blocks the queue
+    # instead of failing it.
+    if: always()
+    needs:
+      - ruff
+      - build-docker-containers
+      - test-performance
+      - test-rest-framework
+      - test-user-interface
+      - test-k8s
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify every job succeeded
+        # A skipped or cancelled dependency is not a pass. Checking explicitly
+        # rather than relying on this job's own conclusion, because a job whose
+        # needs were skipped can otherwise report success by omission.
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "dependency results: ${results}"
+          for result in ${results}; do
+            if [ "${result}" != "success" ]; then
+              echo "::error::At least one job did not succeed (${results})"
+              exit 1
+            fi
+          done
+          echo "All jobs succeeded."
 

--- a/docker-compose.override.unit_tests_cicd.yml
+++ b/docker-compose.override.unit_tests_cicd.yml
@@ -20,9 +20,27 @@ services:
       DD_DATABASE_ENGINE: ${DD_DATABASE_ENGINE:-django.db.backends.postgresql}
       DD_DATABASE_HOST: ${DD_DATABASE_HOST:-postgres}
       DD_DATABASE_PORT: ${DD_DATABASE_PORT:-5432}
-      DD_CELERY_BROKER_URL: 'sqla+sqlite:///dojo.celerydb.sqlite'
+      # An in-process broker rather than the default sqlite file. Nothing consumes
+      # the queue in unit tests -- celeryworker and celerybeat are both reset
+      # above -- so a real broker contributes nothing but contention: under
+      # --parallel every worker process opens the same sqlite file and they race
+      # to declare the queue, which fails in whichever loses with
+      # "UNIQUE constraint failed: kombu_queue.name".
+      #
+      # Set through the scheme, because settings.dist.py only assembles a URL from
+      # the parts when DD_CELERY_BROKER_URL is empty. double_slashes=True there
+      # turns these two into exactly "memory://". The entrypoint also unsets
+      # DD_CELERY_BROKER_URL, but blanking it here means the broker does not
+      # depend on that happening -- and it stops the base compose file's
+      # redis://valkey URL, which no unit test has a valkey for, showing through.
+      DD_CELERY_BROKER_URL: ''
+      DD_CELERY_BROKER_SCHEME: 'memory'
+      DD_CELERY_BROKER_PATH: ''
       DD_JIRA_EXTRA_ISSUE_TYPES: 'Vulnerability' # Shouldn't trigger a migration error
       DD_V3_FEATURE_LOCATIONS: ${DD_V3_FEATURE_LOCATIONS:-False}
+      # full | prepare | reuse -- see docker/entrypoint-unit-tests.sh. CI sets
+      # this to replace the migrate with restoring a snapshot of its result.
+      DD_TEST_DB_MODE: ${DD_TEST_DB_MODE:-full}
       # No Redis/valkey in unit tests -> default django cache is LocMemCache.
       DD_CACHE_URL: ''
       # In-process singleton cache (dojo/caching.py) stays ON: a singleton is read

--- a/docker/entrypoint-integration-tests.sh
+++ b/docker/entrypoint-integration-tests.sh
@@ -57,13 +57,27 @@ if [[ -n "$DD_INTEGRATION_TEST_FILENAME" ]]; then
             fail "$test"
         fi
     else
-        test=$DD_INTEGRATION_TEST_FILENAME
-        echo "Running: $test"
-        if python3 "$DD_INTEGRATION_TEST_FILENAME"; then
-            success "$test"
-        else
-            fail "$test"
-        fi
+        # DD_INTEGRATION_TEST_FILENAME may name several files separated by
+        # whitespace; CI passes groups of files that share one compose stack.
+        # The unquoted expansion below is the split, which is safe because
+        # every value is a repo-relative path with no spaces in it.
+        #
+        # Files run in order and the first failure exits (fail() exits 1),
+        # exactly like the full-suite branch below: a test that fails can
+        # leave state behind that would make everything after it fail too,
+        # and one clean failure beats five cascading ones. The log names each
+        # file as it starts, so the failing file is always the last "Running:"
+        # line.
+        # shellcheck disable=SC2086
+        for test_file in $DD_INTEGRATION_TEST_FILENAME; do
+            test=$test_file
+            echo "Running: $test"
+            if python3 "$test_file"; then
+                success "$test"
+            else
+                fail "$test"
+            fi
+        done
     fi
 
 else

--- a/docker/entrypoint-unit-tests-devDocker.sh
+++ b/docker/entrypoint-unit-tests-devDocker.sh
@@ -23,9 +23,21 @@ python3 manage.py makemigrations --no-input --check --dry-run --verbosity 3 || {
 
 ********************************************************************************
 
-You made changes to the models without creating a DB migration for them.
+The makemigrations check failed. This happens for two different reasons,
+and the error Django printed above says which one you have:
 
-**NEVER** change existing migrations, create a new one.
+1) "Your models ... have changes that are not yet reflected in a migration"
+   -- you changed models without creating a migration for them. Create one
+   with 'python3 manage.py makemigrations'.
+   **NEVER** change existing migrations, create a new one.
+
+2) "Conflicting migrations detected; multiple leaf nodes in the migration
+   graph" -- the graph is forked: two migrations declare the same parent,
+   usually after merging or rebasing onto a base branch that had already
+   moved. No model change of yours is involved. Fix it by re-parenting the
+   later migration onto the other leaf (renumbering it if the numbers
+   collide), or with an empty merge migration that depends on both. The
+   Migration Graph Check on the pull request names the offending files.
 
 If you're not familiar with migrations in Django, please read the
 great documentation thoroughly:

--- a/docker/entrypoint-unit-tests.sh
+++ b/docker/entrypoint-unit-tests.sh
@@ -24,6 +24,33 @@ unset DD_CELERY_BROKER_URL
 
 wait_for_database_to_be_reachable
 
+# What this script should do about the database before it runs anything.
+#
+#   full     (default) check the migration state, apply it, then run the tests.
+#   prepare  apply migrations and exit, leaving a migrated database behind for
+#            the caller to snapshot. Keeps the makemigrations guard.
+#   reuse    the database is already migrated -- restored from a snapshot by the
+#            caller -- so go straight to the tests.
+#
+# `reuse` skips the makemigrations guard along with the migrate, which is only
+# safe because the snapshot is keyed on the models as well as on the migrations:
+# a model change with no migration for it cannot happen without changing that
+# key, and a changed key means there is no snapshot to restore and therefore no
+# way to reach this branch. Do not key a snapshot on migrations alone.
+DD_TEST_DB_MODE="${DD_TEST_DB_MODE:-full}"
+
+case "${DD_TEST_DB_MODE}" in
+    full|prepare|reuse) ;;
+    *)
+        echo "DD_TEST_DB_MODE must be one of full, prepare, reuse (got '${DD_TEST_DB_MODE}')" >&2
+        exit 1
+        ;;
+esac
+
+# Nothing to do with the database: this checks the API schema, and it has to run
+# per test job because DD_V3_FEATURE_LOCATIONS changes the schema it produces.
+# Skipped only when preparing a database, which runs no tests.
+if [ "${DD_TEST_DB_MODE}" != "prepare" ]; then
 python3 manage.py spectacular --fail-on-warn > /dev/null || {
     cat <<-EOF
 
@@ -51,15 +78,32 @@ EOF
     python3 manage.py spectacular > /dev/null
     exit 1
 }
+fi  # DD_TEST_DB_MODE != prepare
 
+# The bodies below are deliberately left unindented: they contain `<<-EOF`
+# heredocs, which strip leading tabs but not spaces, so indenting them would
+# change the message text they print.
+if [ "${DD_TEST_DB_MODE}" != "reuse" ]; then
 python3 manage.py makemigrations --no-input --check --dry-run --verbosity 3 || {
     cat <<-EOF
 
 ********************************************************************************
 
-You made changes to the models without creating a DB migration for them.
+The makemigrations check failed. This happens for two different reasons,
+and the error Django printed above says which one you have:
 
-**NEVER** change existing migrations, create a new one.
+1) "Your models ... have changes that are not yet reflected in a migration"
+   -- you changed models without creating a migration for them. Create one
+   with 'python3 manage.py makemigrations'.
+   **NEVER** change existing migrations, create a new one.
+
+2) "Conflicting migrations detected; multiple leaf nodes in the migration
+   graph" -- the graph is forked: two migrations declare the same parent,
+   usually after merging or rebasing onto a base branch that had already
+   moved. No model change of yours is involved. Fix it by re-parenting the
+   later migration onto the other leaf (renumbering it if the numbers
+   collide), or with an empty merge migration that depends on both. The
+   Migration Graph Check on the pull request names the offending files.
 
 If you're not familiar with migrations in Django, please read the
 great documentation thoroughly:
@@ -72,15 +116,30 @@ EOF
 }
 
 python3 manage.py migrate
+fi  # DD_TEST_DB_MODE != reuse
 
-# --parallel fails on GitHub Actions
-#python3 manage.py test unittests -v 3 --no-input --parallel
+if [ "${DD_TEST_DB_MODE}" = "prepare" ]; then
+    echo "Database migrated; DD_TEST_DB_MODE=prepare, so not running any tests."
+    exit 0
+fi
 
 echo "Unit Tests"
 echo "------------------------------------------------------------"
 
-# Removing parallel and shuffle for now to maintain stability
-python3 manage.py test unittests --keepdb --no-input --exclude-tag="non-parallel" --exclude-tag="transactional" --exclude-tag="performance" || {
+# This phase is already defined as "everything that does not need to run on its
+# own": the two tags excluded here are exactly the suites that were quarantined
+# because they interfere with their neighbours. That is the same property
+# --parallel needs, so it is enabled here and nowhere else.
+#
+# "auto" rather than a count from nproc: Django's get_max_test_processes() falls
+# back to a single process if the multiprocessing start method is one its worker
+# initialisation cannot handle, and only "auto" consults it. An explicit count
+# bypasses that check and fails instead. See the note in manage.py.
+#
+# Set DD_TEST_PARALLEL=1 to go back to a single process -- useful locally when a
+# failure's traceback matters more than the wall clock, and the one-line revert
+# if this turns out to cost more in flakes than it saves in minutes.
+python3 manage.py test unittests --keepdb --no-input --parallel="${DD_TEST_PARALLEL:-auto}" --exclude-tag="non-parallel" --exclude-tag="transactional" --exclude-tag="performance" || {
     exit 1;
 }
 python3 manage.py test unittests --keepdb --no-input --tag="non-parallel" --exclude-tag="performance" || {

--- a/manage.py
+++ b/manage.py
@@ -5,6 +5,26 @@ import sys
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dojo.settings.settings")
 
+    if len(sys.argv) > 1 and sys.argv[1] == "test":
+        # Django's parallel test runner supports two multiprocessing start
+        # methods, and Python 3.14 defaults to neither of them on Linux: it
+        # switched from "fork" to "forkserver". Under forkserver, django/test/
+        # runner.py::_init_worker calls django.setup() only when the method is
+        # "spawn", so a worker unpickles its subsuite with no app registry and
+        # dies on "AppRegistryNotReady: Apps aren't loaded yet."
+        #
+        # Choose spawn rather than restoring fork: it is the start method whose
+        # worker initialisation Django actually implements, and forking a
+        # process that may already have threads is what Python moved away from.
+        #
+        # Only for `test`, so nothing else that runs through manage.py is
+        # affected. Django's own get_max_test_processes() falls back to a single
+        # process for any other start method, so if this ever stops applying,
+        # `--parallel auto` degrades to serial instead of failing.
+        import multiprocessing
+
+        multiprocessing.set_start_method("spawn", force=True)
+
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,11 @@ vcrpy==8.3.0
 vcrpy-unittest==0.1.7
 django-test-migrations==1.5.0
 parameterized==0.9.0
+# Django's parallel test runner returns failures from its worker processes by
+# pickling them, and a traceback is not picklable on its own. Without tblib
+# installed, a failure under --parallel arrives without the traceback that
+# would explain it.
+tblib==3.2.2
 
 # Development file watching (hot reload)
 watchdog[watchmedo]==6.0.0

--- a/tests/close_old_findings_dedupe_test.py
+++ b/tests/close_old_findings_dedupe_test.py
@@ -69,22 +69,29 @@ class CloseOldDedupeTest(BaseTestCase):
         driver = self.driver
         driver.get(self.base_url + "finding?page=1")
 
-        if self.element_exists_by_id("no_findings"):
-            text = driver.find_element(By.ID, "no_findings").text
-            if "No findings found." in text:
-                return
+        # Files sharing this stack may have left more than one page of findings
+        # behind, and the bulk-delete action only covers the page it is on, so
+        # delete page by page until the empty state appears. Bounded, so a
+        # delete that stops shrinking the list fails loudly instead of looping.
+        for _ in range(10):
+            if self.element_exists_by_id("no_findings"):
+                break
+            driver.find_element(By.ID, "select_all").click()
+            driver.find_element(By.CSS_SELECTOR, "i.fa-solid.fa-trash").click()
+            try:
+                WebDriverWait(driver, 2).until(expected_conditions.alert_is_present(),
+                    "Timed out waiting for finding delete confirmation popup to appear.")
+                driver.switch_to.alert.accept()
+            except TimeoutException:
+                self.fail("Confirmation dialogue not shown, cannot delete previous findings")
+            # The delete POSTs and redirects. Wait for the reloaded page to show
+            # either the empty state or the next page's table, rather than
+            # probing the old DOM with only the 1-second implicit wait -- a
+            # bulk delete of a full page is not done in 1 second.
+            WebDriverWait(driver, 30).until(
+                lambda d: d.find_elements(By.ID, "no_findings") or d.find_elements(By.ID, "select_all"),
+                "Timed out waiting for the findings list to reload after bulk delete.")
 
-        driver.find_element(By.ID, "select_all").click()
-        driver.find_element(By.CSS_SELECTOR, "i.fa-solid.fa-trash").click()
-        try:
-            WebDriverWait(driver, 1).until(expected_conditions.alert_is_present(),
-                "Timed out waiting for finding delete confirmation popup to appear.")
-            driver.switch_to.alert.accept()
-        except TimeoutException:
-            self.fail("Confirmation dialogue not shown, cannot delete previous findings")
-
-        logger.debug("page source when checking for no_findings element")
-        logger.debug(self.driver.page_source)
         text = driver.find_element(By.ID, "no_findings").text
 
         self.assertIsNotNone(text)

--- a/tests/close_old_findings_test.py
+++ b/tests/close_old_findings_test.py
@@ -29,22 +29,29 @@ class CloseOldTest(BaseTestCase):
         driver = self.driver
         driver.get(self.base_url + "finding?page=1")
 
-        if self.element_exists_by_id("no_findings"):
-            text = driver.find_element(By.ID, "no_findings").text
-            if "No findings found." in text:
-                return
+        # Files sharing this stack may have left more than one page of findings
+        # behind, and the bulk-delete action only covers the page it is on, so
+        # delete page by page until the empty state appears. Bounded, so a
+        # delete that stops shrinking the list fails loudly instead of looping.
+        for _ in range(10):
+            if self.element_exists_by_id("no_findings"):
+                break
+            driver.find_element(By.ID, "select_all").click()
+            driver.find_element(By.CSS_SELECTOR, "i.fa-solid.fa-trash").click()
+            try:
+                WebDriverWait(driver, 2).until(expected_conditions.alert_is_present(),
+                    "Timed out waiting for finding delete confirmation popup to appear.")
+                driver.switch_to.alert.accept()
+            except TimeoutException:
+                self.fail("Confirmation dialogue not shown, cannot delete previous findings")
+            # The delete POSTs and redirects. Wait for the reloaded page to show
+            # either the empty state or the next page's table, rather than
+            # probing the old DOM with only the 1-second implicit wait -- a
+            # bulk delete of a full page is not done in 1 second.
+            WebDriverWait(driver, 30).until(
+                lambda d: d.find_elements(By.ID, "no_findings") or d.find_elements(By.ID, "select_all"),
+                "Timed out waiting for the findings list to reload after bulk delete.")
 
-        driver.find_element(By.ID, "select_all").click()
-        driver.find_element(By.CSS_SELECTOR, "i.fa-solid.fa-trash").click()
-        try:
-            WebDriverWait(driver, 1).until(expected_conditions.alert_is_present(),
-                "Timed out waiting for finding delete confirmation popup to appear.")
-            driver.switch_to.alert.accept()
-        except TimeoutException:
-            self.fail("Confirmation dialogue not shown, cannot delete previous findings")
-
-        logger.debug("page source when checking for no_findings element")
-        logger.debug(self.driver.page_source)
         text = driver.find_element(By.ID, "no_findings").text
 
         self.assertIsNotNone(text)

--- a/tests/dedupe_test.py
+++ b/tests/dedupe_test.py
@@ -583,6 +583,11 @@ class ImportAsyncWaitApiTest(unittest.TestCase):
         r.raise_for_status()
         return r.json()
 
+    @classmethod
+    def _delete(cls, path):
+        r = requests.delete(cls.api + path, headers=cls.headers, timeout=60)
+        r.raise_for_status()
+
     # --- fixtures ---------------------------------------------------------
     def _make_engagement(self, name):
         """Create a product + dedup-on-engagement engagement, return its id."""
@@ -597,6 +602,15 @@ class ImportAsyncWaitApiTest(unittest.TestCase):
             "description": "async_wait integration test",
             "prod_type": prod_type_id,
         })
+        # Deleting the product cascades the engagement, its tests, and every
+        # imported finding. Without this the ~100 findings these two tests
+        # import outlive the file, and the next file to run in the same stack
+        # inherits them -- test_delete_findings in the close_old files bulk
+        # deletes one page and then asserts the list is empty, so more than a
+        # page of leftovers fails it. These API tests are the only part of
+        # this suite that runs after the suite's own delete_product cleanup.
+        # addCleanup rather than tearDown so a failing test still cleans up.
+        self.addCleanup(self._delete, f"/products/{product['id']}/")
         engagement = self._post("/engagements/", {
             "name": f"async_wait eng {suffix}",
             "product": product["id"],


### PR DESCRIPTION
## Why now rather than waiting for the release merge-back

`dev` still runs last week's CI: the 113-job per-file Selenium matrix, serial unit tests migrating from scratch, no grouping, no tiers, no gate. Every `dev` PR pays ~565 runner-minutes and the queue-bound wall clock that `bugfix` stopped paying — and the org's concurrent-job allowance is shared, so heavy `dev` runs also slow `bugfix` PRs. One port closes the gap this week instead of whenever the next release lands.

## What this is

**Fifteen files, each checked out verbatim from `bugfix` and verified blob-identical to it** — so the next release merge-back reduces to a no-op for all of them. It is the union of #15505, #15507, #15521, #15522, #15524, #15528, #15529 and #15545, whose individual rationales and measurements live on those PRs.

Divergence was checked per file against the merge-base before copying: `dev` had not touched any of the fifteen since the branches diverged, except `migration-graph.yml` — and its only difference is that dev's copy (#15504) predates the push-trigger scoping, so bugfix's copy is exactly dev's copy plus that scoping.

## What changes for dev PRs

| | before | after |
|---|---|---|
| jobs per push | ~128 | **23** (light tier) |
| runner-min per push | ~565 | **~130** |
| unit job | 15.7–17 min serial | ~7 min parallel, snapshot-restored |
| Selenium | 113 × 1-file stacks | 12 grouped stacks (v3=false tier) |

## What deliberately does NOT change

**The merge queue is not enabled on `dev`.** Ruleset 20466211 targets `bugfix` only, so the `merge_group` triggers this carries are inert here — the same state `bugfix` was in before its ruleset — and merging on `dev` works exactly as before. Extending the queue is a one-line ruleset change to make deliberately after more soak time on `bugfix`.

## Measured on bugfix, expected here

Light tier 23 jobs / ~16 min wall (verified on #15528's own run and every bugfix PR since); full tier 38–39 jobs / 18 min (verified by dispatch and by the queue's first landing, #15545). The grouped matrix also caught a real leftover-state bug on its first run (see #15524), which is the kind of coverage per-file isolation cannot provide.

## After merging

Dispatch the warm workflow once on the dev ref so the snapshot exists in dev's cache scope:

```bash
gh workflow run "CI: Warm Caches" --repo DefectDojo/django-DefectDojo --ref dev
```

Until then the first PRs pay one cold migrate-and-save — the designed fallback, ~1 min slower than baseline, self-healing.

## Verification

- Every ported file verified **blob-identical** to `bugfix` after checkout (`git diff --quiet origin/bugfix -- <files>`).
- YAML parses on all six workflows; `bash -n` on all three entrypoints; ruff clean on the four Python files; LF endings throughout.
- This PR's own run is the live validation: it should produce exactly the 23-job light tier with the `Unit Tests Complete` gate reporting — on dev's content.