### PR TITLE
Escape popover attribute values through one shared helper

### DIFF
--- a/dojo/templates_classic/base.html
+++ b/dojo/templates_classic/base.html
@@ -30,6 +30,12 @@
         <script src="{% static "jquery-ui/dist/jquery-ui.min.js" %}"></script>
         <!-- Bootstrap Core JavaScript -->
         <script src="{% static "bootstrap/dist/js/bootstrap.min.js" %}"></script>
+        <script>
+            // No tooltip or popover here renders a link or an image, so keep both
+            // out of the markup Bootstrap accepts in one.
+            delete $.fn.popover.Constructor.DEFAULTS.whiteList.a;
+            delete $.fn.popover.Constructor.DEFAULTS.whiteList.img;
+        </script>
         <!-- Bootstrap Select -->
         <script src="{% static "bootstrap-select/dist/js/bootstrap-select.min.js" %}"></script>
 

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -21,7 +21,7 @@ from django.db.models import Case, IntegerField, Sum, Value, When
 from django.template.defaultfilters import stringfilter
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.html import conditional_escape, escape
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
@@ -1022,10 +1022,16 @@ def class_name(value):
     return value.__class__.__name__
 
 
+def escape_popover_value(value):
+    """Escape a value for a popover attribute, which the popover parses as HTML again."""
+    # escape() and not conditional_escape(): the latter is a no-op on its own output.
+    return escape(escape(value))
+
+
 @register.filter(needs_autoescape=True)
 def jira_project_tag(product_or_engagement, *, autoescape=True):
     if autoescape:
-        esc = conditional_escape
+        esc = escape_popover_value
     else:
         def esc(x):
             return x
@@ -1083,7 +1089,7 @@ def import_settings_tag(test_import, *, autoescape=True):
         return ""
 
     if autoescape:
-        esc = conditional_escape
+        esc = escape_popover_value
     else:
         def esc(x):
             return x

--- a/unittests/test_display_tags_popover.py
+++ b/unittests/test_display_tags_popover.py
@@ -1,0 +1,55 @@
+from html.parser import HTMLParser
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from dojo.templatetags.display_tags import import_settings_tag, jira_project_tag
+
+PAYLOAD = '<a href="https://evil.example/sso">re-authenticate</a><img src="https://evil.example/b.png">'
+
+
+class _Collector(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.tags = []
+        self.popover_values = []
+
+    def handle_starttag(self, tag, attrs):
+        self.tags.append(tag)
+        attrs = dict(attrs)
+        if "has-popover" in (attrs.get("class") or ""):
+            self.popover_values += [v for k, v in attrs.items() if k in {"data-content", "title"} and v]
+
+
+def _tags_after_second_parse(rendered):
+    """Tags a browser materialises from the popover attributes."""
+    # Parsing the page decodes the character references in the attribute values;
+    # the popover then assigns those values as HTML, which parses them again.
+    page = _Collector()
+    page.feed(str(rendered))
+    second = _Collector()
+    for value in page.popover_values:
+        second.feed(value)
+    return second.tags
+
+
+class TestPopoverContentEscaping(SimpleTestCase):
+
+    def test_import_settings_tag_keeps_injected_markup_inert(self):
+        test_import = mock.Mock(id=1, import_settings={"service": PAYLOAD})
+        tags = _tags_after_second_parse(import_settings_tag(test_import))
+        self.assertNotIn("a", tags)
+        self.assertNotIn("img", tags)
+
+    def test_import_settings_tag_still_renders_a_plain_service(self):
+        test_import = mock.Mock(id=1, import_settings={"service": "nightly-scan"})
+        self.assertIn("<b>Service:</b> nightly-scan", str(import_settings_tag(test_import)))
+
+    def test_jira_project_tag_keeps_injected_markup_inert(self):
+        jira_project = mock.Mock(project_key=PAYLOAD, component="", push_all_issues=False,
+                                 enable_engagement_epic_mapping=False, push_notes=False)
+        with mock.patch("dojo.templatetags.display_tags.jira_services.get_project",
+                        return_value=jira_project):
+            tags = _tags_after_second_parse(jira_project_tag(mock.Mock()))
+        self.assertNotIn("a", tags)
+        self.assertNotIn("img", tags)


### PR DESCRIPTION
`import_settings_tag` and `jira_project_tag` assemble their markup by hand and escaped interpolated values a single time. Those values are parsed again after the page itself is parsed, so one pass does not survive to the point where the content is rendered. Both now go through one shared helper.

Also drops links and images from the markup Bootstrap will accept in a tooltip or popover, since nothing in the classic UI renders either of them. That is one change rather than one per call site, so it covers the other places built the same way.

Adds regression tests. No functional change for existing well-formed values.

An input validator on `service` was considered and dropped: `service` is in `HASH_CODE_FIELDS_ALWAYS`, so a rejected import leads the user to change the service name in their pipeline, after which new findings no longer dedupe against the existing ones in that test, and the only reconciliation path is updating service on every finding and regenerating hash codes. Discussed in #bug-reporting.
