### PR TITLE
docs: add DefectDojo Cloud architecture page with deployment and tier diagrams

### DIFF
--- a/docs/assets/images/cloud_architecture_kubernetes.svg
+++ b/docs/assets/images/cloud_architecture_kubernetes.svg
@@ -1,0 +1,159 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 1032" role="img" aria-labelledby="ttl desc" font-family="'Segoe UI', system-ui, -apple-system, Helvetica, Arial, sans-serif">
+  <title id="ttl">DefectDojo Cloud Kubernetes architecture with Sensei on Vertex AI</title>
+  <desc id="desc">Multi-tenant SaaS on Google Kubernetes Engine. Customers reach the platform via Google Cloud Load Balancing with managed TLS; scan results are uploaded inbound through the API. Each customer runs in its own Kubernetes namespace containing web/API, async processing, orchestration, integrations, an MCP server, Sensei AI remediation, and an in-namespace cache. The dedicated per-customer data plane holds a PostgreSQL database, a Cloud Storage bucket, and Vertex AI, through which Sensei runs in the customer's dedicated GCP project with per-customer credentials. Shared platform services include the container registry, secret manager, observability, and a shared cache of public EPSS/KEV enrichment data. Outbound connections cover email, ticketing, audit-log forwarding, and an optional customer-chosen AI provider.</desc>
+
+  <defs>
+    <marker id="ah" markerWidth="9" markerHeight="9" refX="7.5" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#94A3B8"/></marker>
+  </defs>
+
+  <rect x="0" y="0" width="1240" height="1032" fill="#F8FAFC"/>
+
+  <text x="40" y="46" font-size="26" font-weight="700" fill="#0F172A">DefectDojo Cloud — Kubernetes Architecture</text>
+  <text x="40" y="72" font-size="15" fill="#475569">Multi-tenant SaaS on Google Kubernetes Engine (GKE)</text>
+
+  <!-- Legend -->
+  <rect x="812" y="30" width="16" height="16" rx="3" fill="#EFF6FF" stroke="#60A5FA"/>
+  <text x="836" y="43" font-size="13" fill="#334155">Shared platform service</text>
+  <rect x="812" y="54" width="16" height="16" rx="3" fill="#F0FDFA" stroke="#14B8A6"/>
+  <text x="836" y="67" font-size="13" fill="#334155">Tenant workload (in-cluster)</text>
+  <rect x="812" y="78" width="16" height="16" rx="3" fill="#FFFBEB" stroke="#F59E0B"/>
+  <text x="836" y="91" font-size="13" fill="#334155">Dedicated per customer</text>
+
+  <!-- Inbound client -->
+  <rect x="40" y="104" width="210" height="54" rx="10" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="145" y="128" text-anchor="middle" font-size="15" font-weight="600" fill="#0F172A">Customers</text>
+  <text x="145" y="146" text-anchor="middle" font-size="11.5" fill="#64748B">Browser · API · CI · scan uploads</text>
+
+  <rect x="298" y="104" width="268" height="54" rx="10" fill="#EEF2FF" stroke="#818CF8"/>
+  <text x="432" y="128" text-anchor="middle" font-size="15" font-weight="600" fill="#3730A3">Cloud Load Balancing</text>
+  <text x="432" y="146" text-anchor="middle" font-size="12" fill="#4F46E5">HTTPS · Google-managed TLS</text>
+
+  <line x1="250" y1="131" x2="296" y2="131" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+
+  <!-- ingress into web tier -->
+  <path d="M432,158 V200 H76 V440 H104" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+
+  <!-- GCP platform boundary -->
+  <rect x="40" y="204" width="1160" height="600" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-dasharray="6 5"/>
+  <text x="60" y="230" font-size="15" font-weight="700" fill="#334155">Google Cloud Platform · DefectDojo Cloud</text>
+
+  <!-- Regional cluster -->
+  <rect x="64" y="252" width="752" height="528" rx="12" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="84" y="280" font-size="15" font-weight="700" fill="#0F172A">Regional GKE cluster</text>
+  <text x="84" y="299" font-size="12" fill="#64748B">one of several — US · EU · APAC</text>
+  <rect x="470" y="262" width="326" height="30" rx="15" fill="#F1F5F9" stroke="#E2E8F0"/>
+  <text x="633" y="281" text-anchor="middle" font-size="12" fill="#475569">Autoscaling node pools · standard + high-mem</text>
+
+  <!-- namespace multiplicity -->
+  <rect x="112" y="356" width="680" height="396" rx="10" fill="#CCFBF1" opacity="0.35"/>
+  <rect x="100" y="344" width="680" height="396" rx="10" fill="#CCFBF1" opacity="0.55"/>
+
+  <!-- main namespace -->
+  <rect x="88" y="332" width="680" height="396" rx="10" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+  <text x="108" y="362" font-size="15" font-weight="700" fill="#0F766E">Customer namespace</text>
+  <rect x="290" y="348" width="146" height="20" rx="10" fill="#14B8A6"/>
+  <text x="363" y="362" text-anchor="middle" font-size="11" font-weight="600" fill="#FFFFFF">one per customer</text>
+  <text x="108" y="384" font-size="12" fill="#0F766E" opacity="0.85">Isolated Kubernetes namespace</text>
+
+  <!-- row 1 -->
+  <rect x="108" y="398" width="192" height="84" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
+  <text x="124" y="426" font-size="13.5" font-weight="600" fill="#0F172A">Web &amp; API</text>
+  <text x="124" y="445" font-size="12" fill="#64748B">django</text>
+  <text x="124" y="462" font-size="12" fill="#64748B">nginx + uWSGI</text>
+
+  <rect x="324" y="398" width="192" height="84" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
+  <text x="340" y="426" font-size="13.5" font-weight="600" fill="#0F172A">Async processing</text>
+  <text x="340" y="445" font-size="12" fill="#64748B">Celery workers</text>
+  <text x="340" y="462" font-size="12" fill="#64748B">+ beat scheduler</text>
+
+  <rect x="540" y="398" width="192" height="84" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
+  <text x="556" y="426" font-size="13.5" font-weight="600" fill="#0F172A">Orchestration</text>
+  <text x="556" y="445" font-size="12" fill="#64748B">Workflow engine</text>
+  <text x="556" y="462" font-size="12" fill="#64748B">+ workers</text>
+
+  <!-- row 2 -->
+  <rect x="108" y="496" width="192" height="84" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
+  <text x="124" y="524" font-size="13.5" font-weight="600" fill="#0F172A">Integrations</text>
+  <text x="124" y="543" font-size="12" fill="#64748B">Connectors</text>
+  <text x="124" y="560" font-size="12" fill="#64748B">+ ticketing</text>
+
+  <rect x="324" y="496" width="192" height="84" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
+  <text x="340" y="524" font-size="13.5" font-weight="600" fill="#0F172A">MCP server</text>
+  <text x="340" y="543" font-size="12" fill="#64748B">AI interface</text>
+
+  <rect x="540" y="496" width="192" height="84" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
+  <text x="556" y="524" font-size="13.5" font-weight="600" fill="#0F172A">Sensei</text>
+  <text x="556" y="543" font-size="12" fill="#64748B">AI remediation through</text>
+  <text x="556" y="560" font-size="12" fill="#64748B">Google's Vertex Platform</text>
+
+  <!-- row 3 -->
+  <rect x="108" y="594" width="192" height="84" rx="8" fill="#FFFFFF" stroke="#99F6E4"/>
+  <text x="124" y="622" font-size="13.5" font-weight="600" fill="#0F172A">In-namespace cache</text>
+  <text x="124" y="641" font-size="12" fill="#64748B">Redis / Valkey</text>
+
+  <text x="330" y="632" font-size="12" fill="#64748B">Setup: initializer Job runs</text>
+  <text x="330" y="650" font-size="12" fill="#64748B">database migrations on each deploy</text>
+
+  <!-- egress from namespace -->
+  <path d="M428,728 V820" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+
+  <!-- Dedicated per customer -->
+  <rect x="840" y="252" width="336" height="262" rx="12" fill="#FFFBEB" stroke="#F59E0B"/>
+  <text x="860" y="280" font-size="14" font-weight="700" fill="#B45309">Dedicated per customer</text>
+  <text x="860" y="298" font-size="12" fill="#92400E" opacity="0.85">isolated data plane</text>
+  <rect x="860" y="312" width="296" height="58" rx="8" fill="#FFFFFF" stroke="#FCD34D"/>
+  <text x="876" y="336" font-size="13" font-weight="600" fill="#78350F">Cloud SQL — PostgreSQL</text>
+  <text x="876" y="356" font-size="12" fill="#92400E">one database per customer</text>
+  <rect x="860" y="378" width="296" height="58" rx="8" fill="#FFFFFF" stroke="#FCD34D"/>
+  <text x="876" y="402" font-size="13" font-weight="600" fill="#78350F">Cloud Storage bucket</text>
+  <text x="876" y="422" font-size="12" fill="#92400E">media &amp; scans · gcsfuse CSI</text>
+  <rect x="860" y="444" width="296" height="62" rx="8" fill="#FFFFFF" stroke="#FCD34D"/>
+  <text x="876" y="468" font-size="13" font-weight="600" fill="#78350F">Vertex AI</text>
+  <text x="876" y="486" font-size="12" fill="#92400E">runs Sensei AI</text>
+  <text x="876" y="502" font-size="12" fill="#92400E">customer's own project &amp; credentials</text>
+
+  <path d="M768,420 H800 V341 H858" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+  <path d="M768,452 H820 V407 H858" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+
+  <!-- Shared platform services -->
+  <rect x="840" y="530" width="336" height="270" rx="12" fill="#EFF6FF" stroke="#60A5FA"/>
+  <text x="860" y="558" font-size="14" font-weight="700" fill="#1D4ED8">Shared platform services</text>
+  <rect x="860" y="570" width="296" height="48" rx="8" fill="#FFFFFF" stroke="#BFDBFE"/>
+  <text x="876" y="590" font-size="13" font-weight="600" fill="#1E3A8A">Artifact Registry</text>
+  <text x="876" y="608" font-size="12" fill="#3B82F6">container images</text>
+  <rect x="860" y="626" width="296" height="48" rx="8" fill="#FFFFFF" stroke="#BFDBFE"/>
+  <text x="876" y="646" font-size="13" font-weight="600" fill="#1E3A8A">Secret Manager</text>
+  <text x="876" y="664" font-size="12" fill="#3B82F6">secrets &amp; keys</text>
+  <rect x="860" y="682" width="296" height="48" rx="8" fill="#FFFFFF" stroke="#BFDBFE"/>
+  <text x="876" y="702" font-size="13" font-weight="600" fill="#1E3A8A">Cloud Monitoring &amp; Logging</text>
+  <text x="876" y="720" font-size="12" fill="#3B82F6">metrics · logs · alerts</text>
+  <rect x="860" y="738" width="296" height="48" rx="8" fill="#FFFFFF" stroke="#BFDBFE"/>
+  <text x="876" y="758" font-size="13" font-weight="600" fill="#1E3A8A">Shared enrichment cache</text>
+  <text x="876" y="776" font-size="12" fill="#3B82F6">EPSS · KEV · public data</text>
+
+  <!-- Sensei to Vertex AI -->
+  <path d="M768,538 H812 V475 H858" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+  <path d="M768,610 H812 V650 H856" fill="none" stroke="#94A3B8" stroke-width="1.4" stroke-dasharray="4 4" marker-end="url(#ah)"/>
+
+  <!-- Outbound connections -->
+  <rect x="64" y="820" width="1112" height="120" rx="12" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="84" y="848" font-size="14" font-weight="700" fill="#334155">Outbound connections</text>
+  <text x="84" y="866" font-size="12" fill="#64748B">customer-configured · initiated by DefectDojo</text>
+  <rect x="84" y="876" width="250" height="48" rx="8" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="100" y="898" font-size="13" font-weight="600" fill="#0F172A">Email (SMTP)</text>
+  <text x="100" y="915" font-size="12" fill="#64748B">notifications</text>
+  <rect x="358" y="876" width="250" height="48" rx="8" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="374" y="898" font-size="13" font-weight="600" fill="#0F172A">Ticketing</text>
+  <text x="374" y="915" font-size="12" fill="#64748B">Jira · ServiceNow · …</text>
+  <rect x="632" y="876" width="250" height="48" rx="8" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="648" y="898" font-size="13" font-weight="600" fill="#0F172A">Audit log</text>
+  <text x="648" y="915" font-size="12" fill="#64748B">forward to SIEM / log sink</text>
+  <rect x="906" y="876" width="250" height="48" rx="8" fill="#FFFFFF" stroke="#CBD5E1"/>
+  <text x="922" y="898" font-size="13" font-weight="600" fill="#0F172A">Customer AI</text>
+  <text x="922" y="915" font-size="12" fill="#64748B">MCP · Anthropic · OpenAI · …</text>
+
+  <!-- Footer -->
+  <text x="40" y="966" font-size="12.5" fill="#475569">Isolation: each customer runs in its own namespace with a dedicated database, storage bucket, and cache — no customer data is shared between customers.</text>
+  <text x="40" y="988" font-size="12.5" fill="#475569">The only cross-customer shared data is public vulnerability enrichment (EPSS · KEV). Dedicated single-tenant clusters are available (not shown).</text>
+  <text x="40" y="1010" font-size="12.5" fill="#475569">Sensei runs through Google's Vertex Platform in each customer's dedicated GCP project with per-customer credentials — an external AI provider is used only if the customer configures one.</text>
+</svg>

--- a/docs/assets/images/cloud_architecture_tiers.svg
+++ b/docs/assets/images/cloud_architecture_tiers.svg
@@ -1,0 +1,121 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1240 1020" role="img" aria-labelledby="ttl desc" font-family="'Segoe UI', system-ui, -apple-system, Helvetica, Arial, sans-serif">
+  <title id="ttl">DefectDojo Cloud tenant isolation by tier</title>
+  <desc id="desc">Isolation model for each DefectDojo Cloud tier. Standard and Pay-as-you-go tenants (Pay-as-you-go coming soon) each run in an isolated namespace on a shared GKE cluster and share a PostgreSQL instance with a per-tenant logical database and credentials. Premium tenants run in an isolated namespace on a shared GKE cluster with a dedicated PostgreSQL database per customer. The Dedicated tier runs the full stack in its own GKE cluster, VPC, and GCP project. Sensei runs through Google's Vertex Platform, dedicated per customer in every tier: the customer's own GCP project with per-customer credentials. Shared platform services — Artifact Registry, Secret Manager, and Cloud Monitoring and Logging — support every tier without carrying customer data between tenants.</desc>
+
+  <defs>
+    <marker id="ah" markerWidth="9" markerHeight="9" refX="7.5" refY="4.5" orient="auto"><path d="M0,0 L9,4.5 L0,9 Z" fill="#94A3B8"/></marker>
+  </defs>
+
+  <rect x="0" y="0" width="1240" height="1020" fill="#F8FAFC"/>
+
+  <text x="40" y="46" font-size="26" font-weight="700" fill="#0F172A">DefectDojo Cloud — Tenant Isolation by Tier</text>
+  <text x="40" y="72" font-size="15" fill="#475569">What is shared and what is dedicated in each tier</text>
+
+  <!-- Legend -->
+  <rect x="812" y="30" width="16" height="16" rx="3" fill="#EFF6FF" stroke="#60A5FA"/>
+  <text x="836" y="43" font-size="13" fill="#334155">Shared platform service</text>
+  <rect x="812" y="54" width="16" height="16" rx="3" fill="#F0FDFA" stroke="#14B8A6"/>
+  <text x="836" y="67" font-size="13" fill="#334155">Tenant workload (in-cluster)</text>
+  <rect x="812" y="78" width="16" height="16" rx="3" fill="#FFFBEB" stroke="#F59E0B"/>
+  <text x="836" y="91" font-size="13" fill="#334155">Dedicated per customer</text>
+
+  <!-- GCP platform boundary -->
+  <rect x="40" y="110" width="1160" height="830" rx="14" fill="#FFFFFF" stroke="#CBD5E1" stroke-dasharray="6 5"/>
+  <text x="60" y="136" font-size="15" font-weight="700" fill="#334155">Google Cloud Platform · DefectDojo Cloud</text>
+
+  <!-- Band 1: Standard + Pay-as-you-go -->
+  <rect x="64" y="158" width="752" height="310" rx="12" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="84" y="186" font-size="15" font-weight="700" fill="#0F172A">Shared GKE cluster — Standard &amp; Pay-as-you-go tiers</text>
+  <text x="84" y="205" font-size="12" fill="#64748B">one isolated namespace per tenant</text>
+
+  <rect x="104" y="246" width="300" height="100" rx="10" fill="#CCFBF1" opacity="0.35"/>
+  <rect x="94" y="236" width="300" height="100" rx="10" fill="#CCFBF1" opacity="0.55"/>
+  <rect x="84" y="226" width="300" height="100" rx="10" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+  <text x="100" y="254" font-size="14" font-weight="700" fill="#0F766E">Standard tenant</text>
+  <rect x="240" y="236" width="128" height="18" rx="9" fill="#14B8A6"/>
+  <text x="304" y="249" text-anchor="middle" font-size="10.5" font-weight="600" fill="#FFFFFF">one per tenant</text>
+  <text x="100" y="276" font-size="12" fill="#0F766E" opacity="0.85">namespace + workloads</text>
+
+  <rect x="84" y="360" width="300" height="100" rx="10" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="100" y="388" font-size="14" font-weight="700" fill="#0F766E">Pay-as-you-go tenant</text>
+  <rect x="244" y="370" width="124" height="18" rx="9" fill="#F59E0B"/>
+  <text x="306" y="383" text-anchor="middle" font-size="10.5" font-weight="600" fill="#FFFFFF">coming soon</text>
+  <text x="100" y="410" font-size="12" fill="#0F766E" opacity="0.85">namespace + workloads</text>
+
+  <rect x="470" y="282" width="330" height="116" rx="8" fill="#EFF6FF" stroke="#60A5FA"/>
+  <text x="486" y="310" font-size="13.5" font-weight="600" fill="#1E3A8A">Cloud SQL — PostgreSQL</text>
+  <text x="486" y="330" font-size="12" fill="#3B82F6">shared instance for these tiers</text>
+  <text x="486" y="348" font-size="12" fill="#3B82F6">per-tenant logical database</text>
+  <text x="486" y="366" font-size="12" fill="#3B82F6">per-tenant credentials</text>
+
+  <path d="M386,276 H428 V320 H468" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+  <path d="M386,410 H428 V364 H468" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+
+  <!-- Band 2: Premium -->
+  <rect x="64" y="492" width="752" height="190" rx="12" fill="#F8FAFC" stroke="#CBD5E1"/>
+  <text x="84" y="520" font-size="15" font-weight="700" fill="#0F172A">Shared GKE cluster — Premium tier</text>
+  <text x="84" y="539" font-size="12" fill="#64748B">one isolated namespace per tenant</text>
+
+  <rect x="104" y="576" width="300" height="100" rx="10" fill="#CCFBF1" opacity="0.35"/>
+  <rect x="94" y="566" width="300" height="100" rx="10" fill="#CCFBF1" opacity="0.55"/>
+  <rect x="84" y="556" width="300" height="100" rx="10" fill="#F0FDFA" stroke="#14B8A6" stroke-width="1.5"/>
+  <text x="100" y="584" font-size="14" font-weight="700" fill="#0F766E">Premium tenant</text>
+  <rect x="240" y="566" width="128" height="18" rx="9" fill="#14B8A6"/>
+  <text x="304" y="579" text-anchor="middle" font-size="10.5" font-weight="600" fill="#FFFFFF">one per tenant</text>
+  <text x="100" y="606" font-size="12" fill="#0F766E" opacity="0.85">namespace + workloads</text>
+
+  <rect x="470" y="570" width="330" height="72" rx="8" fill="#FFFBEB" stroke="#F59E0B"/>
+  <text x="486" y="598" font-size="13.5" font-weight="600" fill="#78350F">Cloud SQL — PostgreSQL</text>
+  <text x="486" y="618" font-size="12" fill="#92400E">dedicated database per Premium customer</text>
+
+  <path d="M386,606 H468" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+
+  <!-- Band 3: Dedicated -->
+  <rect x="64" y="716" width="752" height="200" rx="12" fill="#FFFBEB" stroke="#F59E0B"/>
+  <text x="84" y="744" font-size="15" font-weight="700" fill="#B45309">Dedicated tier — own cluster per customer</text>
+  <rect x="420" y="730" width="140" height="20" rx="10" fill="#F59E0B"/>
+  <text x="490" y="744" text-anchor="middle" font-size="11" font-weight="600" fill="#FFFFFF">one per customer</text>
+  <text x="84" y="763" font-size="12" fill="#92400E" opacity="0.85">single-tenant: own GCP project · own VPC · own GKE cluster</text>
+
+  <rect x="84" y="782" width="212" height="84" rx="8" fill="#FFFFFF" stroke="#FCD34D"/>
+  <text x="100" y="810" font-size="13.5" font-weight="600" fill="#78350F">Ingress</text>
+  <text x="100" y="830" font-size="12" fill="#92400E">80/443 only</text>
+  <text x="100" y="848" font-size="12" fill="#92400E">customer IP allowlist</text>
+
+  <rect x="330" y="782" width="212" height="84" rx="8" fill="#FFFFFF" stroke="#FCD34D"/>
+  <text x="346" y="810" font-size="13.5" font-weight="600" fill="#78350F">Dedicated GKE cluster</text>
+  <text x="346" y="830" font-size="12" fill="#92400E">all workloads</text>
+  <text x="346" y="848" font-size="12" fill="#92400E">single-tenant</text>
+
+  <rect x="576" y="782" width="224" height="84" rx="8" fill="#FFFFFF" stroke="#FCD34D"/>
+  <text x="592" y="810" font-size="13.5" font-weight="600" fill="#78350F">Cloud SQL — PostgreSQL</text>
+  <text x="592" y="830" font-size="12" fill="#92400E">inside the customer VPC</text>
+
+  <path d="M298,824 H328" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+  <path d="M544,824 H574" fill="none" stroke="#94A3B8" stroke-width="1.6" marker-end="url(#ah)"/>
+
+  <!-- Sensei / Vertex AI: dedicated per customer, every tier -->
+  <rect x="840" y="158" width="336" height="140" rx="12" fill="#FFFBEB" stroke="#F59E0B"/>
+  <text x="860" y="186" font-size="14" font-weight="700" fill="#B45309">Dedicated per customer</text>
+  <rect x="860" y="200" width="296" height="82" rx="8" fill="#FFFFFF" stroke="#FCD34D"/>
+  <text x="876" y="224" font-size="13" font-weight="600" fill="#78350F">Vertex AI</text>
+  <text x="876" y="244" font-size="12" fill="#92400E">runs Sensei AI — every tier</text>
+  <text x="876" y="262" font-size="12" fill="#92400E">customer's own project &amp; credentials</text>
+
+  <!-- Shared platform services -->
+  <rect x="840" y="322" width="336" height="228" rx="12" fill="#EFF6FF" stroke="#60A5FA"/>
+  <text x="860" y="350" font-size="14" font-weight="700" fill="#1D4ED8">Shared platform services</text>
+  <rect x="860" y="364" width="296" height="48" rx="8" fill="#FFFFFF" stroke="#BFDBFE"/>
+  <text x="876" y="384" font-size="13" font-weight="600" fill="#1E3A8A">Artifact Registry</text>
+  <text x="876" y="402" font-size="12" fill="#3B82F6">container images</text>
+  <rect x="860" y="420" width="296" height="48" rx="8" fill="#FFFFFF" stroke="#BFDBFE"/>
+  <text x="876" y="440" font-size="13" font-weight="600" fill="#1E3A8A">Secret Manager</text>
+  <text x="876" y="458" font-size="12" fill="#3B82F6">secrets &amp; keys</text>
+  <rect x="860" y="476" width="296" height="48" rx="8" fill="#FFFFFF" stroke="#BFDBFE"/>
+  <text x="876" y="496" font-size="13" font-weight="600" fill="#1E3A8A">Cloud Monitoring &amp; Logging</text>
+  <text x="876" y="514" font-size="12" fill="#3B82F6">metrics · logs · alerts</text>
+
+  <!-- Footer -->
+  <text x="40" y="976" font-size="12.5" fill="#475569">Standard &amp; Pay-as-you-go tenants share a PostgreSQL instance with a per-tenant logical database and credentials — Premium tenants get a dedicated database.</text>
+  <text x="40" y="998" font-size="12.5" fill="#475569">The Dedicated tier runs everything in its own GKE cluster, VPC, and GCP project. Sensei is included in every tier and runs through Google's Vertex Platform in each customer's own project.</text>
+</svg>

--- a/docs/content/get_started/pro/cloud/cloud-architecture.md
+++ b/docs/content/get_started/pro/cloud/cloud-architecture.md
@@ -1,0 +1,117 @@
+---
+title: "Cloud Architecture"
+description: "How DefectDojo Cloud is deployed and isolated on Google Kubernetes Engine."
+weight: 4
+audience: pro
+---
+
+DefectDojo Cloud is a multi-tenant SaaS platform running on **Google Kubernetes
+Engine (GKE)** in Google Cloud. This page describes how the platform is
+structured and how customer environments are kept separate.
+
+![DefectDojo Cloud Kubernetes architecture: customer traffic enters through Google Cloud Load Balancing with Google-managed TLS into regional GKE clusters; each customer runs in its own Kubernetes namespace with a dedicated PostgreSQL database, Cloud Storage bucket, and Vertex AI project.](images/cloud_architecture_kubernetes.svg)
+
+## How a request flows
+
+1. Customer traffic (browser, API, or CI) arrives over **HTTPS** at **Google
+   Cloud Load Balancing**, which terminates TLS using Google-managed
+   certificates.
+2. The load balancer routes the request into the customer's environment inside a
+   **regional GKE cluster**, where the web/API tier (django, served by nginx and
+   uWSGI) handles it.
+3. The web tier reads and writes the customer's **dedicated PostgreSQL database**
+   and **dedicated Cloud Storage bucket**, and uses an **in-namespace cache**
+   (Redis/Valkey) for sessions and as the task broker.
+4. Longer-running work, such as scan imports, deduplication, and notifications,
+   is handed to **asynchronous workers** (Celery) so requests stay responsive.
+
+## Tenant isolation
+
+Every customer runs in its **own Kubernetes namespace**, and the data each
+customer stores never shares a store with another customer:
+
+- **Dedicated database**: a separate PostgreSQL database per customer (Cloud SQL).
+- **Dedicated object storage**: a separate Cloud Storage bucket per customer for
+  uploaded scans and media, mounted into the workloads via the GCS FUSE CSI driver.
+- **Dedicated cache**: each namespace runs its own Redis/Valkey instance.
+- **Per-customer credentials**: each environment has its own secrets and its own
+  TLS certificate and hostname.
+
+There is **no shared application data plane** between customers. Data is encrypted
+in transit (TLS) and at rest (Google Cloud default encryption).
+
+## Regions and data residency
+
+The platform runs **regional GKE clusters across multiple geographies** (for
+example North America, Europe, and Asia-Pacific). A customer environment, along
+with its database and storage bucket, lives in the region selected for that
+customer, which supports data-residency requirements.
+
+## Workloads in a customer environment
+
+Each namespace contains the components needed to run DefectDojo Pro end to end:
+
+| Group | Purpose |
+|---|---|
+| **Web & API** | Serves the UI and REST API (django · nginx + uWSGI). |
+| **Async processing** | Background jobs and scheduling (Celery workers + beat). |
+| **Orchestration** | Coordinates multi-step workflows across the platform. |
+| **Integrations** | Connectors and ticketing integrations. |
+| **MCP server** | AI interface for connecting your own AI tooling. |
+| **Sensei** | AI remediation through Google's Vertex Platform. |
+| **In-namespace cache** | Redis/Valkey for sessions and task brokering. |
+
+On each deploy, a short-lived **initializer job** runs database migrations before
+the new version serves traffic.
+
+## Sensei and AI isolation
+
+Sensei, DefectDojo's AI remediation capability, runs through **Google's Vertex
+Platform** with the same per-customer isolation as the rest of the data plane:
+
+- Each customer's Sensei requests run in **that customer's dedicated GCP
+  project**, authenticated with **per-customer credentials**.
+- There is no shared AI tenancy: one customer's prompts, findings, and results
+  never pass through another customer's environment.
+- An **external AI provider is used only if the customer configures one** (for
+  example through the MCP server or a customer-supplied AI integration).
+
+## Platform services and operations
+
+Shared, Google-managed services support every environment without carrying
+customer data between tenants:
+
+- **Artifact Registry**: signed container images.
+- **Secret Manager**: secret and key material.
+- **Cloud Monitoring & Logging**: metrics, logs, and alerting used by our
+  on-call team. Node pools **autoscale** to absorb load.
+
+The only cross-customer shared data is public vulnerability enrichment
+(EPSS and KEV).
+
+## Integrations are outbound-only
+
+Connections to external systems, such as email (SMTP), ticketing (Jira,
+ServiceNow, and others), security scanners, and error monitoring, are
+**configured by the customer and initiated outbound** from the customer's
+environment.
+
+## Isolation by tier
+
+DefectDojo Cloud is offered in tiers that differ in how much of the stack is
+dedicated to a single customer:
+
+![DefectDojo Cloud tenant isolation by tier: Standard and Pay-as-you-go tenants run in isolated namespaces on a shared GKE cluster and share a PostgreSQL instance with per-tenant logical databases; Premium tenants get a dedicated PostgreSQL database; the Dedicated tier runs in its own GKE cluster, VPC, and GCP project.](images/cloud_architecture_tiers.svg)
+
+| Tier | Compute | Database | Network boundary | Sensei |
+|---|---|---|---|---|
+| **Standard** | Isolated namespace on a shared cluster | Own logical database and credentials on a shared PostgreSQL instance | Shared VPC, per-tenant hostname + TLS, optional IP allowlist | Included |
+| **Pay-as-you-go** *(coming soon)* | Isolated namespace on a shared cluster | Own logical database and credentials on a shared PostgreSQL instance | Shared VPC, per-tenant hostname + TLS, optional IP allowlist | Included |
+| **Premium** | Isolated namespace on a shared cluster | **Dedicated PostgreSQL database** per customer | Shared VPC, per-tenant hostname + TLS, optional IP allowlist | Included |
+| **Dedicated** | **Own GKE cluster** | **Dedicated PostgreSQL database** in the customer's own VPC | **Own GCP project and VPC**, ingress restricted to the customer's IP range | Included |
+
+Sensei is included in every tier, and in every tier it runs through Google's
+Vertex Platform in the customer's own GCP project with per-customer credentials.
+
+*Have a question this page doesn't answer? Contact your DefectDojo
+representative.*


### PR DESCRIPTION
## Summary

Adds a **Cloud Architecture** page to the DefectDojo Pro (Cloud) docs section (`get_started/pro/cloud/`, weight 4), with two SVG diagrams shipped as docs assets.

The page covers:

- The GKE deployment model and how a request flows (Cloud Load Balancing with Google-managed TLS into regional clusters).
- Tenant isolation: one Kubernetes namespace per customer, with a dedicated PostgreSQL database, dedicated Cloud Storage bucket, in-namespace cache, and per-customer credentials.
- Regions and data residency.
- The workloads that run in each customer environment.
- Sensei AI isolation: Sensei runs through Google's Vertex Platform in each customer's dedicated GCP project with per-customer credentials; an external AI provider is used only if the customer configures one.
- Shared platform services (Artifact Registry, Secret Manager, Cloud Monitoring & Logging) and the outbound-only integration model.
- An isolation-by-tier matrix (Standard, Pay-as-you-go, Premium, Dedicated) with a matching diagram.

## Details

- New page: `docs/content/get_started/pro/cloud/cloud-architecture.md`.
- New assets: `docs/assets/images/cloud_architecture_kubernetes.svg` and `docs/assets/images/cloud_architecture_tiers.svg`, referenced via the standard `images/...` convention (the image render hook serves SVGs directly).
- Verified locally with the same Hugo version and production config that `validate_docs_build.yml` uses: the site builds clean, the page renders, and both image references resolve in `docs/public`.

## Test plan

- Docs CI (`Docs: Dry Run Production Deployment`) builds the site and runs the lychee link check over the rendered HTML.
