### PR TITLE
ci: balance the UI groups by measured time, not by file count

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,12 +23,33 @@ jobs:
           # Do not reorder files across groups without that history in mind;
           # appending a NEW file to the last group (or its own group) is safe.
           # tests/zap.py stays disabled, as it was in the per-file matrix.
-          # group 01
-          "tests/finding_test.py tests/report_builder_test.py tests/notes_test.py tests/regulations_test.py tests/product_type_test.py tests/product_test.py",
+          # Group sizes are balanced against MEASURED per-file test time, not
+          # file count. Two files dominate the suite -- finding_test.py at 4.8
+          # minutes and dedupe_test.py at 4.5 -- against roughly 4.2 minutes of
+          # fixed per-job cost (image load, stack boot, initializer, teardown).
+          # Six files per group put both dominators in six-file groups that took
+          # 12.2 and 12.8 minutes while every other group finished in 5-6, and
+          # the slowest group is the whole phase's wall clock. So each of those
+          # two groups is split, isolating its dominator. Splitting preserves the
+          # contiguity invariant above: both halves remain contiguous slices.
+          #
+          # Measured per file (merge-queue run 31024574933, minutes):
+          #   finding 4.8 | product 1.6 | notes 0.7 | report_builder 0.6 | product_type 0.2 | regulations 0.1
+          #   dedupe 4.5 | close_old_findings_dedupe 1.6 | close_old_findings 1.1 | file 0.7 | announcement_banner 0.6 | search 0.1
+          #
+          # Rebalance again from data, not intuition: read per-file times out of
+          # a job log by diffing the "Running: <file>" and "Success: <file>"
+          # timestamps the entrypoint prints.
+          # group 01a -- finding_test alone; it is 60% of its old group
+          "tests/finding_test.py",
+          # group 01b
+          "tests/report_builder_test.py tests/notes_test.py tests/regulations_test.py tests/product_type_test.py tests/product_test.py",
           # group 02
           "tests/engagement_test.py tests/environment_test.py tests/test_test.py tests/user_test.py tests/product_member_test.py tests/product_type_member_test.py",
-          # group 03
-          "tests/search_test.py tests/file_test.py tests/dedupe_test.py tests/announcement_banner_test.py tests/close_old_findings_dedupe_test.py tests/close_old_findings_test.py",
+          # group 03a -- carries dedupe_test, the other dominator
+          "tests/search_test.py tests/file_test.py tests/dedupe_test.py",
+          # group 03b
+          "tests/announcement_banner_test.py tests/close_old_findings_dedupe_test.py tests/close_old_findings_test.py",
           # group 04
           "tests/false_positive_history_test.py tests/check_various_pages.py tests/notifications_test.py tests/note_type_test.py tests/sla_configuration_test.py tests/dashboard_test.py",
           # group 05


### PR DESCRIPTION
## The problem the grouping left behind

Grouping the Selenium matrix put six files in each group — which balances *file counts*, not minutes. Measured on the merge-queue run that landed #15545: ten of twelve groups finished in **5–6 minutes**, two took **12.2 and 12.8**. The groups run concurrently, so the slowest one *is* the phase's wall clock — roughly five minutes per run spent waiting on two jobs while ten sat idle.

## Per-file measurements

Read out of the job logs by diffing the entrypoint's `Running: <file>` / `Success: <file>` timestamps:

| group 01 | min | | group 03 | min |
|---|---|---|---|---|
| **finding** | **4.8** | | **dedupe** | **4.5** |
| product | 1.6 | | close_old_findings_dedupe | 1.6 |
| notes | 0.7 | | close_old_findings | 1.1 |
| report_builder | 0.6 | | file | 0.7 |
| product_type | 0.2 | | announcement_banner | 0.6 |
| regulations | 0.1 | | search | 0.1 |

**Each heavy group is dominated by one file.** Against ~4.2 min of fixed per-job cost (image load, stack boot, initializer, teardown), no group containing `finding_test` or `dedupe_test` finishes much under 9 minutes — so the useful move isn't shuffling, it's stopping those two files from carrying five others with them.

## The change

Split each of the two heavy groups in half, isolating its dominator. **This preserves the contiguity invariant the grouping rests on** — both halves remain contiguous slices of the entrypoint's legacy order, so every adjacency kept here is one that has always run back-to-back in one stack.

| | before | after |
|---|---|---|
| slowest group | 12.8 min | **~9.5 min** |
| full-tier wall | ~18 min | **~14 min** |
| light tier | 23 jobs | 25 |
| full tier | 39 jobs | 43 |

Cost is two extra stacks per flag value — about 8 and 17 runner-minutes. That trade is deliberate: wall clock is the scarcer resource, since the queue runs the full tier on **every landing** and the org's concurrent-job allowance is shared with every other PR in flight.

## Verification

- File set unchanged by the split: **57 before, 57 after, none missing, none added, none duplicated** (checked programmatically against `origin/bugfix`).
- `actionlint` clean; YAML parses; LF preserved.
- This PR's own run measures the result — the numbers above are predictions from per-file data, and the group durations in its run are the check on them.

The comment block in the diff records both the measurements and **how to redo them**, so the next rebalance is data-driven rather than intuition.