### PR TITLE
Add a DISA STIG checklist parser (.ckl and .cklb)

### DIFF
--- a/docs/content/federal_compliance/compliance_profile.md
+++ b/docs/content/federal_compliance/compliance_profile.md
@@ -49,7 +49,10 @@ Two profile settings are not on the form and are set through the compliance API:
   *do* carry their own control references are mapped from those instead; see
   [Control Coverage](../control_coverage).
 * **Configuration test types** — the test types whose findings are treated as configuration items,
-  which is what drives CM-6 consolidation in the ledger.
+  which is what drives CM-6 consolidation in the ledger. `DISA STIG Checklist` is the usual
+  candidate: a benchmark assessment produces many configuration items at once, and consolidating
+  them keeps the ledger readable. Whether to consolidate is a per-system decision, so no test type
+  is listed here by default.
 
 ## Auditability
 

--- a/docs/content/federal_compliance/control_coverage.md
+++ b/docs/content/federal_compliance/control_coverage.md
@@ -49,8 +49,10 @@ was enabled, backfill them:
 manage.py extract_control_mappings --product <id>
 ```
 
-Use `--all` to scan every active finding instead of one product. The command reports how many
-mappings it created, and it leaves manual and suppressed mappings alone.
+Use `--all` to scan every active finding instead of one product. Both passes — scanner references
+and the CCI crosswalk — run by default, and each reports how many mappings it created. Add
+`--skip-crosswalk` or `--skip-scanner-refs` to run only one. Manual and suppressed mappings are left
+alone either way.
 
 ## Correcting a mapping
 

--- a/docs/content/federal_compliance/control_coverage.md
+++ b/docs/content/federal_compliance/control_coverage.md
@@ -18,9 +18,24 @@ automatically. Among others:
 * **Prowler** writes NIST 800-53 control lists into finding references.
 * **Tenable** plugins carry 800-53 cross-references.
 * **InSpec** and **MITRE SAF** profiles tag their checks with `nist` identifiers.
+* **DISA STIG checklists** cite CCIs, which DefectDojo crosswalks onto 800-53 — see below.
 
 Extraction is grounded in the imported catalog, so an identifier the catalog does not recognize
 never produces a mapping.
+
+### STIG checklists and CCIs
+
+A STIG rule does not name an 800-53 control directly. It cites one or more **Control Correlation
+Identifiers** (`CCI-000366`), DISA's own index into the control catalog. When you import a checklist
+with the [DISA STIG Checklist](/supported_tools/parsers/file/stig_checklist/) parser, DefectDojo
+reads those CCIs and maps each item onto the 800-53 Rev 5 controls that DISA's published CCI list
+associates with them.
+
+That mapping is what makes a STIG assessment show up as control coverage: the checklist tells you
+which rules failed, and the crosswalk tells you which controls those failures speak to.
+
+Crosswalked mappings rank above the ones extracted from finding text, because DISA's list is the
+authority for what a CCI means. Mappings you make by hand still win over both.
 
 Findings that carry no control references of their own are attributed to the default scan controls
 on the Compliance Profile — see [Compliance Profile](../compliance_profile).

--- a/docs/content/supported_tools/parsers/file/stig_checklist.md
+++ b/docs/content/supported_tools/parsers/file/stig_checklist.md
@@ -1,0 +1,83 @@
+---
+title: "DISA STIG Checklist"
+toc_hide: true
+---
+
+Import a DISA STIG checklist saved from STIG Viewer, so the items requiring remediation become
+findings that are tracked, aged against your SLAs and assigned like any other.
+
+### File Types
+
+Both checklist formats are accepted:
+
+- **`.ckl`** — XML, written by STIG Viewer 2.x.
+- **`.cklb`** — JSON, written by STIG Viewer 3.x.
+
+The format is detected from the file's content rather than its name, so a checklist that has been
+renamed (a `.ckl` saved as `.xml`, for example) imports correctly. Both formats produce identical
+findings for identical content. Checklists holding several `iSTIG` blocks — one host assessed
+against several STIGs — are supported, as are checklists exported by tools other than STIG Viewer.
+
+Note this parser reads *checklists*, not XCCDF benchmark results. To import the output of an
+OpenSCAP/SCAP compliance scan, use the Openscap parser instead.
+
+### Statuses
+
+Every checklist item is imported, so the finding list mirrors the checklist:
+
+| Checklist status | Finding state | Meaning |
+|------------------|---------------|---------|
+| Open | Active, Verified | Requires remediation. |
+| Not Reviewed | Active, not Verified | Still needs to be assessed. |
+| Not A Finding | Mitigated (inactive) | Assessed as compliant. |
+| Not Applicable | Out of Scope (inactive) | Does not apply to this asset. |
+
+Reimporting a newer checklist for the same asset moves findings between those states: an item that
+changes from Open to Not A Finding is closed, and one that regresses from Not A Finding to Open is
+reactivated.
+
+### Severity
+
+The rule's DISA category maps to severity — `high` to High, `medium` to Medium and `low` to Low —
+and the category itself (CAT I, CAT II, CAT III) is recorded in Impact. An item with no severity
+recorded is imported at Info rather than dropped, since it still has to be tracked.
+
+Where an assessor has overridden the severity, the override sets the finding's severity and the
+reason is recorded in the severity justification. Impact keeps the rule's own category, which an
+override does not change.
+
+### Fields
+
+`Check_Content` becomes the steps to reproduce, `Fix_Text` becomes the mitigation, and the
+discussion, finding details and assessor comments are collected into the description. Every CCI the
+rule cites is recorded on its own line in References. DefectDojo Pro's federal compliance pack reads
+those CCIs to map each item onto its NIST 800-53 controls, which populates control coverage.
+
+The V-number is used as the finding's identifier, because it is stable across STIG releases. The
+`Rule_ID` carries a revision suffix (`SV-257777r925318_rule`) that changes with every release, so it
+is recorded in the description for reference only.
+
+### Recommended Usage
+
+**Import each asset's checklist into its own Test, and reimport newer checklists of that asset into
+the same Test.** Closing on reimport is driven by an item being absent from the report, and that
+comparison is scoped to one Test — so if checklists from several assets share a Test, turn off
+"Close old findings" to avoid closing the other assets' items.
+
+A checklist with no host name, FQDN or IP recorded produces findings with no endpoint, identified by
+V-number alone. Two such un-keyed checklists in the same product cannot be told apart; key the asset
+in STIG Viewer to keep them distinct.
+
+### Sample Scan Data
+
+Sample DISA STIG Checklist scans can be found [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/unittests/scans/stig_checklist).
+
+### Default Deduplication Hashcode Fields
+
+By default, DefectDojo identifies duplicate findings using these [hashcode fields](https://docs.defectdojo.com/en/working_with_findings/finding_deduplication/about_deduplication/):
+
+- vuln_id_from_tool
+- endpoints
+
+Findings are matched on the unique id from the tool, which is the V-number qualified by the host it
+was assessed on — so the same rule failing on two hosts stays two findings.

--- a/docs/content/supported_tools/parsers/file/stig_checklist.md
+++ b/docs/content/supported_tools/parsers/file/stig_checklist.md
@@ -36,6 +36,9 @@ Reimporting a newer checklist for the same asset moves findings between those st
 changes from Open to Not A Finding is closed, and one that regresses from Not A Finding to Open is
 reactivated.
 
+Note that DefectDojo marks any out-of-scope finding as mitigated as well, so a Not Applicable item
+shows both flags. Out of Scope is the one that says why.
+
 ### Severity
 
 The rule's DISA category maps to severity — `high` to High, `medium` to Medium and `low` to Low —

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -259,7 +259,8 @@ env = environ.FileAwareEnv(
                                  ".sarif", ".xlsx", ".doc", ".html", ".js", ".nessus", ".zip", ".fpr"]),
     # List of acceptable file types that can be (re)imported
     DD_FILE_IMPORT_TYPES=(list, [".xml", ".csv", ".nessus", ".json", ".jsonl", ".html", ".js", ".zip",
-                                 ".xlsx", ".txt", ".sarif", ".fpr", ".md", ".log", ".fvdl"]),
+                                 ".xlsx", ".txt", ".sarif", ".fpr", ".md", ".log", ".fvdl", ".ckl",
+                                 ".cklb"]),
     # Max file size for scan added via API in MB
     DD_SCAN_FILE_MAX_SIZE=(int, 100),
     # When disabled, existing user tokens will not be removed but it will not be
@@ -1111,6 +1112,12 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # for backwards compatibility because someone decided to rename this scanner:
     "Symfony Security Check": ["title", "vulnerability_ids"],
     "DSOP Scan": ["vulnerability_ids"],
+    # A checklist item is identified by its V-number on the host it was assessed on. The
+    # revision-suffixed Rule_ID changes with every STIG release, severity is overridable by the
+    # assessor, and the description holds per-scan finding details, so none of them may take part.
+    # Matching uses unique_id_from_tool (the host-qualified V-number); this entry is what keeps the
+    # stored hash_code stable for everything else that reads it.
+    "DISA STIG Checklist": ["vuln_id_from_tool", "endpoints"],
     "Acunetix Scan": ["title", "description"],
     "Terrascan Scan": ["vuln_id_from_tool", "title", "severity", "file_path", "line", "component_name"],
     "Trivy Operator Scan": ["title", "severity", "vulnerability_ids", "description"],
@@ -1567,6 +1574,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     # for backwards compatibility because someone decided to rename this scanner:
     "Symfony Security Check": DEDUPE_ALGO_HASH_CODE,
     "DSOP Scan": DEDUPE_ALGO_HASH_CODE,
+    "DISA STIG Checklist": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     "Terrascan Scan": DEDUPE_ALGO_HASH_CODE,
     "Trivy Operator Scan": DEDUPE_ALGO_HASH_CODE,
     "Trivy Scan": DEDUPE_ALGO_HASH_CODE,

--- a/dojo/tools/stig_checklist/parser.py
+++ b/dojo/tools/stig_checklist/parser.py
@@ -1,0 +1,476 @@
+"""
+Parser for DISA STIG Viewer checklists.
+
+Two interchangeable formats are accepted, told apart by content rather than by file name so a
+renamed export still imports:
+
+- `.ckl`  - STIG Viewer 2.x, XML rooted at `<CHECKLIST>`.
+- `.cklb` - STIG Viewer 3.x, JSON.
+
+Both readers build the same intermediate `ChecklistItem` records, so the two formats produce
+identical findings for identical content (locked down by a parity unit test).
+
+Identity: the V-number (`Vuln_Num` / `group_id`) is the stable per-rule identifier. `Rule_ID`
+carries a revision suffix (`SV-257777r925318_rule`) that changes with every STIG release, so it is
+recorded for display only and never participates in identity.
+
+REFERENCES FORMAT IS A CROSS-REPO CONTRACT. Every CCI is written as a bare `CCI-NNNNNN` token on
+its own line. DefectDojo Pro's federal compliance pack reads those tokens back out of
+`Finding.references` to crosswalk each checklist item onto its NIST 800-53 controls. Reformatting
+these lines breaks that mapping.
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+
+from defusedxml.ElementTree import ParseError, fromstring
+from django.conf import settings
+
+from dojo.models import Endpoint, Finding
+from dojo.tools.locations import LocationData
+
+logger = logging.getLogger(__name__)
+
+SCAN_TYPE = "DISA STIG Checklist"
+
+# STIG severity is the rule's DISA category. Anything else (including an empty value, which real
+# checklists do contain) is imported as Info rather than dropped: the item still has to be tracked.
+SEVERITY_MAP = {
+    "high": "High",
+    "medium": "Medium",
+    "low": "Low",
+}
+DEFAULT_SEVERITY = "Info"
+# DISA category of the rule, kept in Impact so it survives an assessor severity override.
+CATEGORY_MAP = {
+    "high": "CAT I",
+    "medium": "CAT II",
+    "low": "CAT III",
+}
+
+# Checklist status -> finding flags. `.ckl` uses CamelCase ("NotAFinding"), `.cklb` uses snake_case
+# ("not_a_finding"), so statuses are normalised before lookup.
+#
+# NotAFinding and Not_Applicable deliberately carry is_mitigated/out_of_scope rather than only
+# active=False: on reimport an incoming finding that is merely inactive is a no-op, while
+# is_mitigated closes the existing finding and out_of_scope copies the flag across.
+STATUS_FLAGS = {
+    "open": {"active": True, "verified": True},
+    "notreviewed": {"active": True, "verified": False},
+    "notafinding": {"active": False, "verified": False, "is_mitigated": True},
+    "notapplicable": {"active": False, "verified": False, "out_of_scope": True},
+}
+DEFAULT_STATUS = "notreviewed"
+
+# CKL <STIG_INFO> keys this parser uses, out of the ~11 STIG Viewer writes.
+CKL_STIG_INFO_KEYS = {"title", "stigid", "version", "releaseinfo"}
+
+
+@dataclass
+class AssetInfo:
+
+    """The single host a checklist describes, from CKL <ASSET> or CKLB target_data."""
+
+    host_name: str = ""
+    fqdn: str = ""
+    ip: str = ""
+
+    @property
+    def host(self) -> str:
+        """The most specific identifier the checklist recorded. Blank when the asset is un-keyed."""
+        return self.fqdn or self.host_name or self.ip
+
+
+@dataclass
+class ChecklistItem:
+
+    """One assessed rule, normalised across the two checklist formats."""
+
+    group_id: str = ""
+    rule_id: str = ""
+    rule_version: str = ""
+    rule_title: str = ""
+    group_title: str = ""
+    severity: str = ""
+    severity_override: str = ""
+    severity_justification: str = ""
+    status: str = ""
+    discussion: str = ""
+    check_content: str = ""
+    fix_text: str = ""
+    finding_details: str = ""
+    comments: str = ""
+    ccis: list[str] = field(default_factory=list)
+    stig_title: str = ""
+    stig_id: str = ""
+    stig_version: str = ""
+    stig_release: str = ""
+
+    def add_cci(self, cci: str) -> None:
+        """CKL repeats a CCI_REF block per reference; keep first-seen order and drop repeats."""
+        cci = (cci or "").strip().upper()
+        if cci and cci not in self.ccis:
+            self.ccis.append(cci)
+
+
+class StigChecklistParser:
+
+    """Parses DISA STIG Viewer checklists in both the `.ckl` (XML) and `.cklb` (JSON) formats."""
+
+    def get_scan_types(self):
+        return [SCAN_TYPE]
+
+    def get_label_for_scan_types(self, scan_type):
+        return SCAN_TYPE
+
+    def get_description_for_scan_types(self, scan_type):
+        return (
+            "Import a DISA STIG Viewer checklist: .ckl (STIG Viewer 2.x, XML) or .cklb "
+            "(STIG Viewer 3.x, JSON). Open items are imported as active findings."
+        )
+
+    def get_fields(self) -> list[str]:
+        """
+        Return the list of fields used in the STIG Checklist Parser.
+
+        Fields:
+        - title: V-number and rule title.
+        - severity: the rule's DISA category, or the assessor's severity override where present.
+        - severity_justification: the assessor's reason for a severity override.
+        - impact: the rule's DISA category (CAT I/II/III), which an override does not change.
+        - description: group, rule version, rule id, checklist, discussion, finding details, comments.
+        - steps_to_reproduce: the rule's check content, i.e. how to assess the item.
+        - mitigation: the rule's fix text.
+        - references: the checklist the rule came from and every CCI it cites.
+        - component_name: the STIG the rule belongs to (for example RHEL_9_STIG).
+        - component_version: the STIG version and release.
+        - vuln_id_from_tool: the V-number, which is stable across STIG releases.
+        - unique_id_from_tool: host-qualified V-number, so one rule on two hosts stays two findings.
+        - active / verified / is_mitigated / out_of_scope: mapped from the checklist status.
+        - dynamic_finding: True - a checklist records an assessment of a running host.
+
+        NOTE: the host is reported through unsaved_locations (or unsaved_endpoints), and Rule_ID is
+        recorded in the description only, because its revision suffix changes every STIG release.
+        """
+        return [
+            "title",
+            "severity",
+            "severity_justification",
+            "impact",
+            "description",
+            "steps_to_reproduce",
+            "mitigation",
+            "references",
+            "component_name",
+            "component_version",
+            "vuln_id_from_tool",
+            "unique_id_from_tool",
+            "active",
+            "verified",
+            "is_mitigated",
+            "out_of_scope",
+            "dynamic_finding",
+        ]
+
+    def get_dedupe_fields(self) -> list[str]:
+        """
+        Return the list of fields used for deduplication in the STIG Checklist Parser.
+
+        Fields:
+        - vuln_id_from_tool: the V-number.
+        - endpoints: the assessed host.
+
+        NOTE: matching itself uses unique_id_from_tool, which already qualifies the V-number with
+        the host. Neither severity (assessors override it) nor the description (it holds per-scan
+        finding details) may take part, and Rule_ID is revision-suffixed.
+        """
+        return ["vuln_id_from_tool", "endpoints"]
+
+    def get_findings(self, file, test):
+        content = file.read()
+        raw = content.encode("utf-8") if isinstance(content, str) else content
+        asset, items = self.parse_checklist(raw)
+
+        findings = {}
+        for item in items:
+            if not item.group_id:
+                logger.warning("Skipping a STIG checklist item with no V-number; it has no identity.")
+                continue
+            finding = self.build_finding(item, asset, test)
+            # A well-formed checklist assesses each rule once. Collapse repeats rather than
+            # importing findings that would immediately deduplicate against each other.
+            if finding.unique_id_from_tool in findings:
+                logger.debug("STIG checklist repeats %s; keeping the first occurrence.", item.group_id)
+                continue
+            findings[finding.unique_id_from_tool] = finding
+        return list(findings.values())
+
+    def parse_checklist(self, raw: bytes) -> tuple[AssetInfo, list[ChecklistItem]]:
+        """Detect the checklist format from its content and dispatch to the matching reader."""
+        # Skip a UTF-8 BOM and any leading whitespace so the first meaningful byte decides.
+        head = raw.lstrip(b"\xef\xbb\xbf \t\r\n")
+        if head.startswith(b"{"):
+            return self.parse_cklb(self.load_json(raw))
+        if head.startswith(b"<"):
+            return self.parse_ckl(self.load_xml(raw))
+        msg = (
+            "This does not look like a DISA STIG Viewer checklist. Expected either a .ckl file "
+            "(XML with a CHECKLIST root element) or a .cklb file (JSON)."
+        )
+        raise ValueError(msg)
+
+    def load_json(self, raw: bytes) -> dict:
+        """
+        Only reached once the sniff has seen a leading `{`, which means the document either fails
+        to parse or parses as an object - so there is no non-object case left to reject here.
+        """
+        try:
+            # utf-8-sig tolerates the BOM some checklist writers emit.
+            return json.loads(raw.decode("utf-8-sig"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            msg = f"This .cklb checklist is not valid JSON: {exc}"
+            raise ValueError(msg) from exc
+
+    def load_xml(self, raw: bytes):
+        # Parsed from bytes on purpose: expat then honours the encoding the XML prolog declares,
+        # which for STIG Viewer exports is not always UTF-8.
+        try:
+            root = fromstring(raw)
+        except ParseError as exc:
+            msg = f"This .ckl checklist is not valid XML: {exc}"
+            raise ValueError(msg) from exc
+        if root.tag != "CHECKLIST":
+            msg = (
+                f"Expected a STIG Viewer checklist rooted at CHECKLIST, found '{root.tag}'. "
+                "XCCDF benchmark results are imported with the Openscap parser instead."
+            )
+            raise ValueError(msg)
+        return root
+
+    # --- .ckl (STIG Viewer 2.x, XML) ---------------------------------------------------------
+
+    def parse_ckl(self, root) -> tuple[AssetInfo, list[ChecklistItem]]:
+        asset = AssetInfo(
+            host_name=self.text(root.findtext("./ASSET/HOST_NAME")),
+            fqdn=self.text(root.findtext("./ASSET/HOST_FQDN")),
+            ip=self.text(root.findtext("./ASSET/HOST_IP")),
+        )
+        items = []
+        # A single checklist can hold several iSTIG blocks: one host assessed against several STIGs.
+        for istig in root.findall("./STIGS/iSTIG"):
+            stig_info = self.ckl_stig_info(istig)
+            items.extend(self.ckl_item(vuln, stig_info) for vuln in istig.findall("./VULN"))
+        return asset, items
+
+    def ckl_stig_info(self, istig) -> dict[str, str]:
+        """Read the <STIG_INFO> SID_NAME/SID_DATA pairs describing which STIG this block covers."""
+        info = {}
+        for si_data in istig.findall("./STIG_INFO/SI_DATA"):
+            name = self.text(si_data.findtext("./SID_NAME")).lower()
+            if name in CKL_STIG_INFO_KEYS and name not in info:
+                info[name] = self.text(si_data.findtext("./SID_DATA"))
+        return info
+
+    def ckl_item(self, vuln, stig_info: dict[str, str]) -> ChecklistItem:
+        item = ChecklistItem(
+            status=self.text(vuln.findtext("./STATUS")),
+            finding_details=self.text(vuln.findtext("./FINDING_DETAILS")),
+            comments=self.text(vuln.findtext("./COMMENTS")),
+            severity_override=self.text(vuln.findtext("./SEVERITY_OVERRIDE")),
+            severity_justification=self.text(vuln.findtext("./SEVERITY_JUSTIFICATION")),
+            stig_title=stig_info.get("title", ""),
+            stig_id=stig_info.get("stigid", ""),
+            stig_version=stig_info.get("version", ""),
+            stig_release=stig_info.get("releaseinfo", ""),
+        )
+        # Rule metadata arrives as a flat list of attribute/value pairs, with CCI_REF repeated once
+        # per reference.
+        attributes = {
+            "Vuln_Num": "group_id",
+            "Rule_ID": "rule_id",
+            "Rule_Ver": "rule_version",
+            "Rule_Title": "rule_title",
+            "Group_Title": "group_title",
+            "Severity": "severity",
+            "Vuln_Discuss": "discussion",
+            "Check_Content": "check_content",
+            "Fix_Text": "fix_text",
+        }
+        for stig_data in vuln.findall("./STIG_DATA"):
+            name = self.text(stig_data.findtext("./VULN_ATTRIBUTE"))
+            value = self.text(stig_data.findtext("./ATTRIBUTE_DATA"))
+            if name == "CCI_REF":
+                item.add_cci(value)
+            elif (attribute := attributes.get(name)) and value and not getattr(item, attribute):
+                setattr(item, attribute, value)
+        return item
+
+    # --- .cklb (STIG Viewer 3.x, JSON) -------------------------------------------------------
+
+    def parse_cklb(self, data: dict) -> tuple[AssetInfo, list[ChecklistItem]]:
+        target = data.get("target_data") or {}
+        asset = AssetInfo(
+            host_name=self.text(target.get("host_name")),
+            fqdn=self.text(target.get("fqdn")),
+            ip=self.text(target.get("ip_address")),
+        )
+        items = []
+        for stig in data.get("stigs") or []:
+            if not isinstance(stig, dict):
+                continue
+            items.extend(
+                self.cklb_item(rule, stig)
+                for rule in stig.get("rules") or []
+                if isinstance(rule, dict)
+            )
+        return asset, items
+
+    def cklb_item(self, rule: dict, stig: dict) -> ChecklistItem:
+        override = (rule.get("overrides") or {}).get("severity") or {}
+        item = ChecklistItem(
+            group_id=self.text(rule.get("group_id")),
+            rule_id=self.text(rule.get("rule_id")),
+            rule_version=self.text(rule.get("rule_version")),
+            rule_title=self.text(rule.get("rule_title")),
+            group_title=self.text(rule.get("group_title")),
+            severity=self.text(rule.get("severity")),
+            severity_override=self.text(override.get("severity")),
+            # STIG Viewer writes "reason"; some other checklist writers use "justification".
+            severity_justification=self.text(override.get("reason") or override.get("justification")),
+            status=self.text(rule.get("status")),
+            discussion=self.text(rule.get("discussion")),
+            check_content=self.text(rule.get("check_content")),
+            fix_text=self.text(rule.get("fix_text")),
+            finding_details=self.text(rule.get("finding_details")),
+            comments=self.text(rule.get("comments")),
+            stig_title=self.text(stig.get("display_name") or stig.get("stig_name")),
+            stig_id=self.text(stig.get("stig_id")),
+            stig_version=self.text(stig.get("version")),
+            stig_release=self.text(stig.get("release_info")),
+        )
+        for cci in rule.get("ccis") or []:
+            item.add_cci(cci if isinstance(cci, str) else "")
+        return item
+
+    # --- checklist item -> Finding ------------------------------------------------------------
+
+    def build_finding(self, item: ChecklistItem, asset: AssetInfo, test) -> Finding:
+        severity_key = (item.severity_override or item.severity).lower()
+        finding = Finding(
+            test=test,
+            title=f"{item.group_id} - {item.rule_title}".strip(" -")[:511],
+            severity=SEVERITY_MAP.get(severity_key, DEFAULT_SEVERITY),
+            severity_justification=self.build_severity_justification(item) or None,
+            # The DISA category belongs to the rule, so an assessor override does not move it.
+            impact=CATEGORY_MAP.get(item.severity.lower()) or None,
+            description=self.build_description(item),
+            steps_to_reproduce=item.check_content or None,
+            mitigation=item.fix_text or None,
+            references=self.build_references(item) or None,
+            component_name=(item.stig_id or item.stig_title)[:500] or None,
+            component_version=self.build_component_version(item)[:100] or None,
+            vuln_id_from_tool=item.group_id[:500],
+            unique_id_from_tool=self.build_unique_id(item, asset),
+            # A checklist records an assessment of a running host, not a code review.
+            dynamic_finding=True,
+            static_finding=False,
+            **self.status_flags(item),
+        )
+        finding.unsaved_tags = ["stig"]
+        self.attach_host(finding, asset)
+        return finding
+
+    def status_flags(self, item: ChecklistItem) -> dict[str, bool]:
+        key = item.status.lower().replace("_", "").replace(" ", "")
+        if key not in STATUS_FLAGS:
+            logger.warning(
+                "Unrecognised STIG checklist status '%s' on %s; treating it as Not_Reviewed.",
+                item.status, item.group_id,
+            )
+            key = DEFAULT_STATUS
+        return dict(STATUS_FLAGS[key])
+
+    def build_unique_id(self, item: ChecklistItem, asset: AssetInfo) -> str:
+        """
+        Qualify the V-number with the host.
+
+        One rule assessed on two hosts has to stay two findings, and reimport matches on this id
+        without ever comparing endpoints. A checklist with no host recorded falls back to the bare
+        V-number, so two un-keyed assets in one product would share an identity - key the asset in
+        STIG Viewer to avoid that.
+        """
+        host = asset.host.lower()
+        return (f"{host}/{item.group_id}" if host else item.group_id)[:500]
+
+    def build_severity_justification(self, item: ChecklistItem) -> str:
+        if not item.severity_override:
+            return item.severity_justification
+        original = item.severity or "unspecified"
+        note = f"Severity overridden from '{original}' to '{item.severity_override}' by the assessor."
+        return f"{note}\n{item.severity_justification}" if item.severity_justification else note
+
+    def build_description(self, item: ChecklistItem) -> str:
+        sections = [
+            ("Group", item.group_title),
+            ("Rule Version (STIG-ID)", item.rule_version),
+            # Display only: the revision suffix changes with every STIG release.
+            ("Rule ID", item.rule_id),
+            ("Checklist", item.stig_title),
+            ("Discussion", item.discussion),
+            ("Finding Details", item.finding_details),
+            ("Comments", item.comments),
+        ]
+        return "\n".join(f"**{label}:** {value}" for label, value in sections if value)
+
+    def build_references(self, item: ChecklistItem) -> str:
+        """
+        Record the source checklist and every CCI the rule cites.
+
+        The bare `CCI-NNNNNN` lines are the contract described in this module's docstring: Pro reads
+        them back to crosswalk the item onto its NIST 800-53 controls.
+        """
+        lines = []
+        if stig := self.build_stig_reference(item):
+            lines.append(f"**STIG:** {stig}")
+        if item.rule_id:
+            rule = f"{item.rule_id} ({item.rule_version})" if item.rule_version else item.rule_id
+            lines.append(f"**Rule:** {rule}")
+        lines.extend(item.ccis)
+        return "\n".join(lines)
+
+    def build_stig_reference(self, item: ChecklistItem) -> str:
+        """Name the source checklist the way DISA's own STIGRef attribute does."""
+        reference = item.stig_title
+        if item.stig_version:
+            reference = f"{reference} :: Version {item.stig_version}" if reference else f"Version {item.stig_version}"
+        if item.stig_release:
+            reference = f"{reference}, {item.stig_release}" if reference else item.stig_release
+        return reference
+
+    def build_component_version(self, item: ChecklistItem) -> str:
+        """Combine the STIG version with the release number STIG Viewer writes as free text."""
+        if not item.stig_version:
+            return ""
+        release = ""
+        for token in item.stig_release.replace(":", " ").split():
+            if release == "pending":
+                release = token
+                break
+            if token.lower() == "release":
+                release = "pending"
+        if release and release != "pending":
+            return f"V{item.stig_version}R{release}"
+        return item.stig_version
+
+    def attach_host(self, finding: Finding, asset: AssetInfo) -> None:
+        """A checklist describes one host; an un-keyed checklist has none to report."""
+        host = asset.host
+        if settings.V3_FEATURE_LOCATIONS:
+            finding.unsaved_locations = [LocationData.url(host=host)] if host else []
+        else:
+            # TODO: Delete this after the move to Locations
+            finding.unsaved_endpoints = [Endpoint(host=host)] if host else []
+
+    def text(self, value) -> str:
+        return (value or "").strip() if isinstance(value, str) or value is None else str(value).strip()

--- a/unittests/scans/stig_checklist/blank_host.ckl
+++ b/unittests/scans/stig_checklist/blank_host.ckl
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DISA STIG Viewer :: 2.18-->
+<CHECKLIST>
+  <ASSET>
+    <ROLE>None</ROLE>
+    <ASSET_TYPE>Computing</ASSET_TYPE>
+    <HOST_NAME/>
+    <HOST_IP/>
+    <HOST_MAC/>
+    <HOST_FQDN/>
+    <TARGET_KEY>0</TARGET_KEY>
+    <WEB_OR_DATABASE>false</WEB_OR_DATABASE>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>version</SID_NAME>
+          <SID_DATA>2</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>RHEL_9_STIG</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>title</SID_NAME>
+          <SID_DATA>Red Hat Enterprise Linux 9 Security Technical Implementation Guide</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>releaseinfo</SID_NAME>
+          <SID_DATA>Release: 3 Benchmark Date: 24 Jul 2024</SID_DATA>
+        </SI_DATA>
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-257777</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>high</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-257777r925318_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL-09-211010</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL 9 must be a vendor-supported release.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>An operating system release is considered supported if the vendor continues to provide security patches.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>$ cat /etc/redhat-release</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Upgrade to a supported version of RHEL 9.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS/>
+        <COMMENTS/>
+        <SEVERITY_OVERRIDE/>
+        <SEVERITY_JUSTIFICATION/>
+      </VULN>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>

--- a/unittests/scans/stig_checklist/bom.cklb
+++ b/unittests/scans/stig_checklist/bom.cklb
@@ -1,0 +1,31 @@
+﻿{
+  "title": "bomhost",
+  "cklb_version": "1.0",
+  "target_data": {
+    "host_name": "bomhost",
+    "fqdn": "bomhost.example.mil",
+    "ip_address": "10.0.0.31"
+  },
+  "stigs": [
+    {
+      "display_name": "Red Hat Enterprise Linux 9 Security Technical Implementation Guide",
+      "stig_id": "RHEL_9_STIG",
+      "release_info": "Release: 3 Benchmark Date: 24 Jul 2024",
+      "version": "2",
+      "rules": [
+        {
+          "group_id": "V-257777",
+          "rule_id": "SV-257777r925318_rule",
+          "rule_version": "RHEL-09-211010",
+          "rule_title": "RHEL 9 must be a vendor-supported release.",
+          "severity": "high",
+          "status": "open",
+          "discussion": "An operating system release is considered supported if the vendor continues to provide security patches.",
+          "check_content": "$ cat /etc/redhat-release",
+          "fix_text": "Upgrade to a supported version of RHEL 9.",
+          "ccis": ["CCI-000366"]
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/scans/stig_checklist/cklb_missing_keys.cklb
+++ b/unittests/scans/stig_checklist/cklb_missing_keys.cklb
@@ -1,0 +1,33 @@
+{
+  "title": "sparsehost",
+  "cklb_version": "1.0",
+  "target_data": {
+    "host_name": "sparsehost"
+  },
+  "stigs": [
+    {
+      "stig_name": "Red Hat Enterprise Linux 9 Security Technical Implementation Guide",
+      "stig_id": "RHEL_9_STIG",
+      "rules": [
+        {
+          "group_id": "V-257777",
+          "rule_id": "SV-257777r925318_rule",
+          "rule_title": "RHEL 9 must be a vendor-supported release.",
+          "status": "open",
+          "fix_text": "Upgrade to a supported version of RHEL 9.",
+          "check_content": "$ cat /etc/redhat-release",
+          "discussion": null,
+          "ccis": null,
+          "overrides": null,
+          "comments": null,
+          "finding_details": null
+        },
+        {
+          "group_id": "V-257778",
+          "rule_title": "RHEL 9 vendor packaged system security patches and updates must be installed and up to date.",
+          "status": "open"
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/scans/stig_checklist/multi_istig.ckl
+++ b/unittests/scans/stig_checklist/multi_istig.ckl
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DISA STIG Viewer :: 2.18-->
+<CHECKLIST>
+  <ASSET>
+    <ROLE>Member Server</ROLE>
+    <ASSET_TYPE>Computing</ASSET_TYPE>
+    <HOST_NAME>webhost</HOST_NAME>
+    <HOST_IP>10.0.0.9</HOST_IP>
+    <HOST_MAC/>
+    <HOST_FQDN>webhost.example.mil</HOST_FQDN>
+    <TARGET_KEY>4021</TARGET_KEY>
+    <WEB_OR_DATABASE>true</WEB_OR_DATABASE>
+    <WEB_DB_SITE>default</WEB_DB_SITE>
+    <WEB_DB_INSTANCE/>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>version</SID_NAME>
+          <SID_DATA>2</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>RHEL_9_STIG</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>title</SID_NAME>
+          <SID_DATA>Red Hat Enterprise Linux 9 Security Technical Implementation Guide</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>releaseinfo</SID_NAME>
+          <SID_DATA>Release: 3 Benchmark Date: 24 Jul 2024</SID_DATA>
+        </SI_DATA>
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-257777</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>high</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-257777r925318_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL-09-211010</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL 9 must be a vendor-supported release.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>An operating system release is considered supported if the vendor continues to provide security patches.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>$ cat /etc/redhat-release</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Upgrade to a supported version of RHEL 9.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS/>
+        <COMMENTS/>
+        <SEVERITY_OVERRIDE/>
+        <SEVERITY_JUSTIFICATION/>
+      </VULN>
+    </iSTIG>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>version</SID_NAME>
+          <SID_DATA>3</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>APACHE_2-4_UNIX_SERVER_STIG</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>title</SID_NAME>
+          <SID_DATA>Apache Server 2.4 UNIX Server Security Technical Implementation Guide</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>releaseinfo</SID_NAME>
+          <SID_DATA>Release: 1 Benchmark Date: 24 Jan 2024</SID_DATA>
+        </SI_DATA>
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-214244</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-214244r881448_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>AS24-U1-000030</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>The Apache web server must have system logging enabled.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Log records are useful in subsequent security investigations.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Review the httpd.conf file for the CustomLog directive.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Configure the CustomLog directive in httpd.conf and restart the web server.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000067</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS/>
+        <COMMENTS/>
+        <SEVERITY_OVERRIDE/>
+        <SEVERITY_JUSTIFICATION/>
+      </VULN>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>

--- a/unittests/scans/stig_checklist/no_vulns.ckl
+++ b/unittests/scans/stig_checklist/no_vulns.ckl
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DISA STIG Viewer :: 2.18-->
+<CHECKLIST>
+  <ASSET>
+    <ROLE>Member Server</ROLE>
+    <ASSET_TYPE>Computing</ASSET_TYPE>
+    <HOST_NAME>freshhost</HOST_NAME>
+    <HOST_IP>10.0.0.11</HOST_IP>
+    <HOST_MAC/>
+    <HOST_FQDN>freshhost.example.mil</HOST_FQDN>
+    <TARGET_KEY>5544</TARGET_KEY>
+    <WEB_OR_DATABASE>false</WEB_OR_DATABASE>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>version</SID_NAME>
+          <SID_DATA>2</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>RHEL_9_STIG</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>title</SID_NAME>
+          <SID_DATA>Red Hat Enterprise Linux 9 Security Technical Implementation Guide</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>releaseinfo</SID_NAME>
+          <SID_DATA>Release: 3 Benchmark Date: 24 Jul 2024</SID_DATA>
+        </SI_DATA>
+      </STIG_INFO>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>

--- a/unittests/scans/stig_checklist/rhel9_mixed_statuses.ckl
+++ b/unittests/scans/stig_checklist/rhel9_mixed_statuses.ckl
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--DISA STIG Viewer :: 2.18-->
+<CHECKLIST>
+  <ASSET>
+    <ROLE>Member Server</ROLE>
+    <ASSET_TYPE>Computing</ASSET_TYPE>
+    <HOST_NAME>rhel9host</HOST_NAME>
+    <HOST_IP>10.0.0.5</HOST_IP>
+    <HOST_MAC/>
+    <HOST_FQDN>rhel9.example.mil</HOST_FQDN>
+    <TARGET_COMMENT/>
+    <TECH_AREA/>
+    <TARGET_KEY>5544</TARGET_KEY>
+    <WEB_OR_DATABASE>false</WEB_OR_DATABASE>
+    <WEB_DB_SITE/>
+    <WEB_DB_INSTANCE/>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>version</SID_NAME>
+          <SID_DATA>2</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>classification</SID_NAME>
+          <SID_DATA>UNCLASSIFIED</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>RHEL_9_STIG</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>title</SID_NAME>
+          <SID_DATA>Red Hat Enterprise Linux 9 Security Technical Implementation Guide</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>releaseinfo</SID_NAME>
+          <SID_DATA>Release: 3 Benchmark Date: 24 Jul 2024</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>source</SID_NAME>
+          <SID_DATA>STIG.DOD.MIL</SID_DATA>
+        </SI_DATA>
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-257777</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>high</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000480-GPOS-00227</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-257777r925318_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL-09-211010</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL 9 must be a vendor-supported release.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>An operating system release is considered "supported" if the vendor continues to provide security patches for the product.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Verify the version of the operating system is vendor supported with the following command:
+
+$ cat /etc/redhat-release
+
+If the installed version of RHEL 9 is not supported, this is a finding.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Upgrade to a supported version of RHEL 9.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Weight</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>10.0</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Class</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Unclass</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>STIGRef</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Red Hat Enterprise Linux 9 Security Technical Implementation Guide :: Version 2, Release: 3 Benchmark Date: 24 Jul 2024</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-002617</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS>Installed release reached end of maintenance support on 2025-05-31.</FINDING_DETAILS>
+        <COMMENTS>Upgrade scheduled for the next maintenance window.</COMMENTS>
+        <SEVERITY_OVERRIDE/>
+        <SEVERITY_JUSTIFICATION/>
+      </VULN>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-257778</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000480-GPOS-00227</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-257778r925321_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL-09-211015</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL 9 vendor packaged system security patches and updates must be installed and up to date.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Timely patching is critical for maintaining the operational availability, confidentiality, and integrity of information technology systems.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Verify the operating system security patches are up to date with the following command:
+
+$ dnf history list | more</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Install the operating system patches or updated packages available from the vendor.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>STIGRef</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Red Hat Enterprise Linux 9 Security Technical Implementation Guide :: Version 2, Release: 3 Benchmark Date: 24 Jul 2024</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>NotAFinding</STATUS>
+        <FINDING_DETAILS>All available vendor updates applied on 2026-07-30.</FINDING_DETAILS>
+        <COMMENTS/>
+        <SEVERITY_OVERRIDE/>
+        <SEVERITY_JUSTIFICATION/>
+      </VULN>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-257779</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000023-GPOS-00006</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-257779r925324_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL-09-211020</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner before granting local or remote access to the system via a graphical user logon.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Display of the Standard Mandatory DOD Notice and Consent Banner before granting access to the operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Verify RHEL 9 displays the banner at the graphical logon. If the system does not have a graphical user interface installed, this requirement is Not Applicable.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Configure the graphical logon banner text in /etc/dconf/db/local.d/01-banner-message.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>STIGRef</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Red Hat Enterprise Linux 9 Security Technical Implementation Guide :: Version 2, Release: 3 Benchmark Date: 24 Jul 2024</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000048</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-001384</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Not_Applicable</STATUS>
+        <FINDING_DETAILS>No graphical user interface is installed on this server.</FINDING_DETAILS>
+        <COMMENTS/>
+        <SEVERITY_OVERRIDE/>
+        <SEVERITY_JUSTIFICATION/>
+      </VULN>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-257781</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>medium</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Group_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SRG-OS-000033-GPOS-00014</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-257781r925330_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL-09-211030</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL 9 must implement DOD-approved encryption to protect the confidentiality of remote access sessions.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Without confidentiality protection mechanisms, an unauthorized individual may be able to view and modify privileged information.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Verify the SSH daemon is configured to use only FIPS-validated key exchange algorithms.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Configure the SSH daemon to use only FIPS-validated key exchange algorithms and restart sshd.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>STIGRef</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Red Hat Enterprise Linux 9 Security Technical Implementation Guide :: Version 2, Release: 3 Benchmark Date: 24 Jul 2024</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000068</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Not_Reviewed</STATUS>
+        <FINDING_DETAILS/>
+        <COMMENTS>Awaiting the crypto policy review before this item can be assessed.</COMMENTS>
+        <SEVERITY_OVERRIDE>low</SEVERITY_OVERRIDE>
+        <SEVERITY_JUSTIFICATION>Host is reachable only from an isolated management enclave, so exposure is limited.</SEVERITY_JUSTIFICATION>
+      </VULN>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>

--- a/unittests/scans/stig_checklist/rhel9_mixed_statuses.cklb
+++ b/unittests/scans/stig_checklist/rhel9_mixed_statuses.cklb
@@ -1,0 +1,141 @@
+{
+  "title": "rhel9host",
+  "id": "8f1a4c02-5c1c-4e0b-9a3f-0b5d6d3f9a71",
+  "cklb_version": "1.0",
+  "active": false,
+  "mode": 1,
+  "has_path": true,
+  "target_data": {
+    "target_type": "Computing",
+    "host_name": "rhel9host",
+    "ip_address": "10.0.0.5",
+    "mac_address": "",
+    "fqdn": "rhel9.example.mil",
+    "comments": "",
+    "role": "Member Server",
+    "is_web_database": false,
+    "technology_area": "",
+    "web_db_site": "",
+    "web_db_instance": ""
+  },
+  "stigs": [
+    {
+      "stig_name": "Red Hat Enterprise Linux 9 Security Technical Implementation Guide",
+      "display_name": "Red Hat Enterprise Linux 9 Security Technical Implementation Guide",
+      "stig_id": "RHEL_9_STIG",
+      "release_info": "Release: 3 Benchmark Date: 24 Jul 2024",
+      "version": "2",
+      "uuid": "0b25b7f0-2f8a-4a3e-9b62-6c8a2b4e1d33",
+      "reference_identifier": "5544",
+      "size": 4,
+      "rules": [
+        {
+          "group_id_src": "V-257777",
+          "group_tree": [
+            {
+              "id": "V-257777",
+              "title": "SRG-OS-000480-GPOS-00227",
+              "description": "<GroupDescription></GroupDescription>"
+            }
+          ],
+          "group_id": "V-257777",
+          "severity": "high",
+          "group_title": "SRG-OS-000480-GPOS-00227",
+          "rule_id_src": "SV-257777r925318_rule",
+          "rule_id": "SV-257777r925318_rule",
+          "rule_version": "RHEL-09-211010",
+          "rule_title": "RHEL 9 must be a vendor-supported release.",
+          "fix_text": "Upgrade to a supported version of RHEL 9.",
+          "weight": "10.0",
+          "check_content": "Verify the version of the operating system is vendor supported with the following command:\n\n$ cat /etc/redhat-release\n\nIf the installed version of RHEL 9 is not supported, this is a finding.",
+          "discussion": "An operating system release is considered \"supported\" if the vendor continues to provide security patches for the product.",
+          "ccis": [
+            "CCI-000366",
+            "CCI-002617"
+          ],
+          "legacy_ids": [],
+          "references": "",
+          "status": "open",
+          "overrides": {},
+          "comments": "Upgrade scheduled for the next maintenance window.",
+          "finding_details": "Installed release reached end of maintenance support on 2025-05-31."
+        },
+        {
+          "group_id_src": "V-257778",
+          "group_id": "V-257778",
+          "severity": "medium",
+          "group_title": "SRG-OS-000480-GPOS-00227",
+          "rule_id_src": "SV-257778r925321_rule",
+          "rule_id": "SV-257778r925321_rule",
+          "rule_version": "RHEL-09-211015",
+          "rule_title": "RHEL 9 vendor packaged system security patches and updates must be installed and up to date.",
+          "fix_text": "Install the operating system patches or updated packages available from the vendor.",
+          "weight": "10.0",
+          "check_content": "Verify the operating system security patches are up to date with the following command:\n\n$ dnf history list | more",
+          "discussion": "Timely patching is critical for maintaining the operational availability, confidentiality, and integrity of information technology systems.",
+          "ccis": [
+            "CCI-000366"
+          ],
+          "legacy_ids": [],
+          "references": "",
+          "status": "not_a_finding",
+          "overrides": {},
+          "comments": "",
+          "finding_details": "All available vendor updates applied on 2026-07-30."
+        },
+        {
+          "group_id_src": "V-257779",
+          "group_id": "V-257779",
+          "severity": "medium",
+          "group_title": "SRG-OS-000023-GPOS-00006",
+          "rule_id_src": "SV-257779r925324_rule",
+          "rule_id": "SV-257779r925324_rule",
+          "rule_version": "RHEL-09-211020",
+          "rule_title": "RHEL 9 must display the Standard Mandatory DOD Notice and Consent Banner before granting local or remote access to the system via a graphical user logon.",
+          "fix_text": "Configure the graphical logon banner text in /etc/dconf/db/local.d/01-banner-message.",
+          "weight": "10.0",
+          "check_content": "Verify RHEL 9 displays the banner at the graphical logon. If the system does not have a graphical user interface installed, this requirement is Not Applicable.",
+          "discussion": "Display of the Standard Mandatory DOD Notice and Consent Banner before granting access to the operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws.",
+          "ccis": [
+            "CCI-000048",
+            "CCI-001384"
+          ],
+          "legacy_ids": [],
+          "references": "",
+          "status": "not_applicable",
+          "overrides": {},
+          "comments": "",
+          "finding_details": "No graphical user interface is installed on this server."
+        },
+        {
+          "group_id_src": "V-257781",
+          "group_id": "V-257781",
+          "severity": "medium",
+          "group_title": "SRG-OS-000033-GPOS-00014",
+          "rule_id_src": "SV-257781r925330_rule",
+          "rule_id": "SV-257781r925330_rule",
+          "rule_version": "RHEL-09-211030",
+          "rule_title": "RHEL 9 must implement DOD-approved encryption to protect the confidentiality of remote access sessions.",
+          "fix_text": "Configure the SSH daemon to use only FIPS-validated key exchange algorithms and restart sshd.",
+          "weight": "10.0",
+          "check_content": "Verify the SSH daemon is configured to use only FIPS-validated key exchange algorithms.",
+          "discussion": "Without confidentiality protection mechanisms, an unauthorized individual may be able to view and modify privileged information.",
+          "ccis": [
+            "CCI-000068"
+          ],
+          "legacy_ids": [],
+          "references": "",
+          "status": "not_reviewed",
+          "overrides": {
+            "severity": {
+              "severity": "low",
+              "reason": "Host is reachable only from an isolated management enclave, so exposure is limited."
+            }
+          },
+          "comments": "Awaiting the crypto policy review before this item can be assessed.",
+          "finding_details": ""
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/scans/stig_checklist/windows1252.ckl
+++ b/unittests/scans/stig_checklist/windows1252.ckl
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="windows-1252"?>
+<!--DISA STIG Viewer :: 2.18-->
+<CHECKLIST>
+  <ASSET>
+    <ROLE>Member Server</ROLE>
+    <ASSET_TYPE>Computing</ASSET_TYPE>
+    <HOST_NAME>legacyhost</HOST_NAME>
+    <HOST_IP>10.0.0.21</HOST_IP>
+    <HOST_MAC/>
+    <HOST_FQDN>legacyhost.example.mil</HOST_FQDN>
+    <TARGET_KEY>5544</TARGET_KEY>
+    <WEB_OR_DATABASE>false</WEB_OR_DATABASE>
+  </ASSET>
+  <STIGS>
+    <iSTIG>
+      <STIG_INFO>
+        <SI_DATA>
+          <SID_NAME>version</SID_NAME>
+          <SID_DATA>2</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>stigid</SID_NAME>
+          <SID_DATA>RHEL_9_STIG</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>title</SID_NAME>
+          <SID_DATA>Red Hat Enterprise Linux 9 Security Technical Implementation Guide</SID_DATA>
+        </SI_DATA>
+        <SI_DATA>
+          <SID_NAME>releaseinfo</SID_NAME>
+          <SID_DATA>Release: 3 Benchmark Date: 24 Jul 2024</SID_DATA>
+        </SI_DATA>
+      </STIG_INFO>
+      <VULN>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>V-257777</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Severity</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>high</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_ID</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>SV-257777r925318_rule</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Ver</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL-09-211010</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>RHEL 9 must be a vendor-supported release.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Vuln_Discuss</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>The vendor’s maintenance support window — published per release — determines whether patches are still issued.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Check_Content</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>$ cat /etc/redhat-release</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>Fix_Text</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>Upgrade to a supported version of RHEL 9.</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STIG_DATA>
+          <VULN_ATTRIBUTE>CCI_REF</VULN_ATTRIBUTE>
+          <ATTRIBUTE_DATA>CCI-000366</ATTRIBUTE_DATA>
+        </STIG_DATA>
+        <STATUS>Open</STATUS>
+        <FINDING_DETAILS/>
+        <COMMENTS/>
+        <SEVERITY_OVERRIDE/>
+        <SEVERITY_JUSTIFICATION/>
+      </VULN>
+    </iSTIG>
+  </STIGS>
+</CHECKLIST>

--- a/unittests/tools/test_stig_checklist_parser.py
+++ b/unittests/tools/test_stig_checklist_parser.py
@@ -1,0 +1,238 @@
+import io
+
+from dojo.models import Finding, Test
+from dojo.tools.stig_checklist.parser import StigChecklistParser
+from unittests.dojo_test_case import DojoTestCase, get_unit_tests_scans_path
+
+# One CKL VULN with a status STIG Viewer never writes, and one with no V-number at all.
+MALFORMED_CKL = """<?xml version="1.0" encoding="UTF-8"?>
+<CHECKLIST>
+  <ASSET><HOST_NAME>h1</HOST_NAME></ASSET>
+  <STIGS><iSTIG><STIG_INFO/>
+    <VULN>
+      <STIG_DATA><VULN_ATTRIBUTE>Vuln_Num</VULN_ATTRIBUTE><ATTRIBUTE_DATA>V-1</ATTRIBUTE_DATA></STIG_DATA>
+      <STIG_DATA><VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE><ATTRIBUTE_DATA>Rule one</ATTRIBUTE_DATA></STIG_DATA>
+      <STATUS>Something_Else</STATUS>
+    </VULN>
+    <VULN>
+      <STIG_DATA><VULN_ATTRIBUTE>Rule_Title</VULN_ATTRIBUTE><ATTRIBUTE_DATA>No V number</ATTRIBUTE_DATA></STIG_DATA>
+      <STATUS>Open</STATUS>
+    </VULN>
+  </iSTIG></STIGS>
+</CHECKLIST>"""
+
+
+class TestStigChecklistParser(DojoTestCase):
+    def parse(self, filename, mode="r"):
+        path = get_unit_tests_scans_path("stig_checklist") / filename
+        # Real uploads arrive as binary handles; the text mode here matches how the other parser
+        # tests open their samples. Both are exercised: windows1252.ckl is opened as bytes.
+        kwargs = {"encoding": "utf-8"} if mode == "r" else {}
+        with path.open(mode, **kwargs) as file:
+            findings = StigChecklistParser().get_findings(file, Test())
+        self.validate_locations(findings)
+        return findings
+
+    def status_flags(self, finding):
+        return (finding.active, finding.verified, finding.is_mitigated, finding.out_of_scope)
+
+    def hosts(self, finding):
+        return [location.host for location in self.get_unsaved_locations(finding)]
+
+    def by_vuln_num(self, findings):
+        return {finding.vuln_id_from_tool: finding for finding in findings}
+
+    def test_scan_type_metadata(self):
+        parser = StigChecklistParser()
+        self.assertEqual(["DISA STIG Checklist"], parser.get_scan_types())
+        self.assertEqual("DISA STIG Checklist", parser.get_label_for_scan_types("DISA STIG Checklist"))
+        self.assertIn(".cklb", parser.get_description_for_scan_types("DISA STIG Checklist"))
+
+    def test_ckl_mixed_statuses_flags(self):
+        """
+        Every checklist status maps to a distinct set of finding flags.
+
+        NotAFinding and Not_Applicable carry is_mitigated/out_of_scope rather than only
+        active=False, because on reimport a merely inactive incoming finding is a no-op.
+        """
+        findings = self.by_vuln_num(self.parse("rhel9_mixed_statuses.ckl"))
+        self.assertEqual(4, len(findings))
+        # Open
+        self.assertEqual((True, True, False, False), self.status_flags(findings["V-257777"]))
+        # NotAFinding
+        self.assertEqual((False, False, True, False), self.status_flags(findings["V-257778"]))
+        # Not_Applicable
+        self.assertEqual((False, False, False, True), self.status_flags(findings["V-257779"]))
+        # Not_Reviewed
+        self.assertEqual((True, False, False, False), self.status_flags(findings["V-257781"]))
+        for finding in findings.values():
+            self.assertFalse(finding.false_p)
+
+    def test_ckl_field_mapping(self):
+        """Full field mapping of an Open item, from a STIG Viewer 2.x export."""
+        finding = self.by_vuln_num(self.parse("rhel9_mixed_statuses.ckl"))["V-257777"]
+
+        self.assertEqual("V-257777 - RHEL 9 must be a vendor-supported release.", finding.title)
+        self.assertEqual("High", finding.severity)
+        self.assertIn(finding.severity, Finding.SEVERITIES)
+        self.assertEqual("CAT I", finding.impact)
+        self.assertEqual("V-257777", finding.vuln_id_from_tool)
+        self.assertEqual("rhel9.example.mil/V-257777", finding.unique_id_from_tool)
+        self.assertEqual("RHEL_9_STIG", finding.component_name)
+        self.assertEqual("V2R3", finding.component_version)
+        self.assertEqual(["stig"], finding.unsaved_tags)
+        self.assertTrue(finding.dynamic_finding)
+        self.assertFalse(finding.static_finding)
+        self.assertIsNone(finding.severity_justification)
+
+        self.assertEqual("Upgrade to a supported version of RHEL 9.", finding.mitigation)
+        self.assertIn("cat /etc/redhat-release", finding.steps_to_reproduce)
+
+        self.assertIn("**Rule Version (STIG-ID):** RHEL-09-211010", finding.description)
+        # The revision-suffixed Rule_ID is recorded for the reader but never used as identity.
+        self.assertIn("**Rule ID:** SV-257777r925318_rule", finding.description)
+        self.assertIn("continues to provide security patches", finding.description)
+        self.assertIn("**Finding Details:** Installed release reached end of maintenance", finding.description)
+        self.assertIn("**Comments:** Upgrade scheduled", finding.description)
+
+        # The FQDN wins over the host name and the IP the checklist also recorded.
+        self.assertEqual(["rhel9.example.mil"], self.hosts(finding))
+
+    def test_ckl_references_carry_every_cci_once(self):
+        """
+        The bare CCI lines are a contract: Pro reads them back to map items onto NIST controls.
+
+        A CKL repeats a CCI_REF block per reference, and this sample repeats CCI-000366, so the
+        order-preserving dedupe is what keeps one line per CCI.
+        """
+        finding = self.by_vuln_num(self.parse("rhel9_mixed_statuses.ckl"))["V-257777"]
+        lines = finding.references.splitlines()
+
+        self.assertIn("**STIG:** Red Hat Enterprise Linux 9 Security Technical Implementation Guide "
+                      ":: Version 2, Release: 3 Benchmark Date: 24 Jul 2024", lines)
+        self.assertIn("**Rule:** SV-257777r925318_rule (RHEL-09-211010)", lines)
+        self.assertEqual(["CCI-000366", "CCI-002617"], [line for line in lines if line.startswith("CCI-")])
+
+    def test_ckl_severity_override(self):
+        """An assessor severity override moves the severity but not the rule's DISA category."""
+        finding = self.by_vuln_num(self.parse("rhel9_mixed_statuses.ckl"))["V-257781"]
+        self.assertEqual("Low", finding.severity)
+        self.assertEqual("CAT II", finding.impact)
+        self.assertIn("overridden from 'medium' to 'low'", finding.severity_justification)
+        self.assertIn("isolated management enclave", finding.severity_justification)
+
+    def test_cklb_mixed_statuses_flags(self):
+        """The same four statuses, expressed in STIG Viewer 3.x's snake_case JSON."""
+        findings = self.by_vuln_num(self.parse("rhel9_mixed_statuses.cklb"))
+        self.assertEqual(4, len(findings))
+        self.assertEqual((True, True, False, False), self.status_flags(findings["V-257777"]))
+        self.assertEqual((False, False, True, False), self.status_flags(findings["V-257778"]))
+        self.assertEqual((False, False, False, True), self.status_flags(findings["V-257779"]))
+        self.assertEqual((True, False, False, False), self.status_flags(findings["V-257781"]))
+        self.assertEqual("Low", findings["V-257781"].severity)
+        self.assertIn("isolated management enclave", findings["V-257781"].severity_justification)
+
+    def test_ckl_and_cklb_agree(self):
+        """
+        The two formats describe the same assessment, so they must produce the same findings.
+
+        This is what stops the XML and JSON readers drifting apart: a change to one that is not
+        mirrored in the other fails here.
+        """
+        def identity(finding):
+            return (
+                finding.title, finding.severity, finding.impact,
+                finding.active, finding.verified, finding.is_mitigated, finding.out_of_scope,
+                finding.vuln_id_from_tool, finding.unique_id_from_tool,
+                finding.component_name, finding.component_version,
+                finding.references, finding.mitigation, finding.steps_to_reproduce,
+            )
+
+        ckl = self.parse("rhel9_mixed_statuses.ckl")
+        cklb = self.parse("rhel9_mixed_statuses.cklb")
+        self.assertEqual(sorted(map(identity, ckl)), sorted(map(identity, cklb)))
+
+    def test_multiple_istig_blocks(self):
+        """One host assessed against two STIGs: both benchmarks' items are imported."""
+        findings = self.by_vuln_num(self.parse("multi_istig.ckl"))
+        self.assertEqual(2, len(findings))
+        self.assertEqual("RHEL_9_STIG", findings["V-257777"].component_name)
+        self.assertEqual("V2R3", findings["V-257777"].component_version)
+        self.assertEqual("APACHE_2-4_UNIX_SERVER_STIG", findings["V-214244"].component_name)
+        self.assertEqual("V3R1", findings["V-214244"].component_version)
+        for vuln_num, finding in findings.items():
+            self.assertEqual(f"webhost.example.mil/{vuln_num}", finding.unique_id_from_tool)
+            self.assertEqual(["webhost.example.mil"], self.hosts(finding))
+
+    def test_blank_host(self):
+        """An un-keyed checklist has no host to report, so the V-number stands alone as the id."""
+        findings = self.parse("blank_host.ckl")
+        self.assertEqual(1, len(findings))
+        self.assertEqual("V-257777", findings[0].unique_id_from_tool)
+        self.assertEqual([], self.hosts(findings[0]))
+
+    def test_no_vulns(self):
+        """A checklist opened but never assessed carries STIG_INFO and no VULN elements."""
+        self.assertEqual(0, len(self.parse("no_vulns.ckl")))
+
+    def test_windows_1252_encoded_ckl(self):
+        """
+        STIG Viewer exports are not always UTF-8.
+
+        This sample declares windows-1252 in its prolog and contains bytes that are not valid
+        UTF-8, so it only parses because the XML is handed to the parser as bytes.
+        """
+        findings = self.parse("windows1252.ckl", mode="rb")
+        self.assertEqual(1, len(findings))
+        # Escaped rather than literal: these are the two cp1252 bytes (0x92, 0x97) the sample
+        # carries, and spelling them out keeps it obvious which characters are under test.
+        self.assertIn("vendor\u2019s maintenance support window", findings[0].description)
+        self.assertIn("\u2014 published per release \u2014", findings[0].description)
+
+    def test_cklb_with_utf8_bom(self):
+        """A BOM ahead of the JSON must not defeat format detection."""
+        findings = self.parse("bom.cklb")
+        self.assertEqual(1, len(findings))
+        self.assertEqual("bomhost.example.mil/V-257777", findings[0].unique_id_from_tool)
+
+    def test_cklb_missing_keys(self):
+        """Checklist writers other than STIG Viewer omit keys; none of them are required."""
+        findings = self.by_vuln_num(self.parse("cklb_missing_keys.cklb"))
+        self.assertEqual(2, len(findings))
+        # No severity recorded: imported as Info rather than dropped, with no DISA category.
+        self.assertEqual("Info", findings["V-257777"].severity)
+        self.assertIsNone(findings["V-257777"].impact)
+        self.assertIsNone(findings["V-257777"].component_version)
+        # host_name is the only identifier this checklist recorded.
+        self.assertEqual(["sparsehost"], self.hosts(findings["V-257777"]))
+        self.assertEqual("sparsehost/V-257778", findings["V-257778"].unique_id_from_tool)
+
+    def test_unknown_status_and_missing_vuln_num(self):
+        """An unrecognised status defaults to Not_Reviewed; an item with no V-number has no identity."""
+        findings = StigChecklistParser().get_findings(io.StringIO(MALFORMED_CKL), Test())
+        self.assertEqual(1, len(findings))
+        self.assertEqual("h1/V-1", findings[0].unique_id_from_tool)
+        self.assertEqual((True, False, False, False), self.status_flags(findings[0]))
+
+    def test_files_that_are_not_checklists_are_rejected(self):
+        """
+        Every rejection is a ValueError, which the importer turns into a clean validation error.
+
+        A defusedxml ParseError escaping the parser would surface as a server error instead.
+        """
+        cases = {
+            "plain text": io.StringIO("hello"),
+            "xccdf benchmark": io.StringIO('<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.2"/>'),
+            "truncated xml": io.StringIO("<CHECKLIST><ASSET>"),
+            "json array": io.StringIO("[1, 2]"),
+            "broken json": io.StringIO('{"stigs": ['),
+        }
+        for label, handle in cases.items():
+            with self.subTest(case=label), self.assertRaises(ValueError):
+                StigChecklistParser().get_findings(handle, Test())
+
+    def test_xccdf_rejection_names_the_right_parser(self):
+        """XCCDF benchmark results are a different tool; say so rather than failing opaquely."""
+        with self.assertRaises(ValueError) as context:
+            StigChecklistParser().get_findings(io.StringIO("<Benchmark/>"), Test())
+        self.assertIn("Openscap", str(context.exception))


### PR DESCRIPTION
## Description

Adds a parser for **DISA STIG Viewer checklists**, so the items in a checklist that require remediation become trackable findings rather than living in a file on someone's laptop.

Requested by a customer running STIG assessments who wants the open items aged against SLAs, assigned, and reported on alongside everything else.

### Formats

Both checklist formats are accepted through **one** scan type, `DISA STIG Checklist`:

- `.ckl` — XML, written by STIG Viewer 2.x
- `.cklb` — JSON, written by STIG Viewer 3.x

The format is detected from **file content, not the file name**, so a renamed export still imports. Both readers build the same intermediate records and feed one finding builder, so identical content in either format produces identical findings — held in place by a parity test that compares the two sample files field by field.

Checklists with several `iSTIG` blocks (one host assessed against several STIGs) are supported, as are exports from tools other than STIG Viewer, whose JSON omits keys STIG Viewer always writes.

This reads *checklists*. XCCDF benchmark results remain the Openscap parser's job, and a file rooted at `<Benchmark>` is rejected with a message that says so.

### Statuses

All four checklist statuses are imported, so the finding list mirrors the checklist:

| Checklist status | Finding state |
|---|---|
| Open | Active, Verified |
| Not Reviewed | Active, not Verified |
| Not A Finding | Mitigated (inactive) |
| Not Applicable | Out of Scope (inactive) |

Not A Finding and Not Applicable carry `is_mitigated` / `out_of_scope` rather than only `active=False`. That is deliberate and load-bearing: on reimport an incoming finding that is merely inactive is a no-op, so mapping them that way would leave a remediated item sitting open forever. With these flags, reimporting an updated checklist closes items that were fixed and reactivates ones that regressed.

### Identity

`unique_id_from_tool` is the **V-number qualified by the assessed host** (`rhel9.example.mil/V-257777`), with `DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL`.

- The V-number is the stable per-rule id. `Rule_ID` carries a revision suffix (`SV-257777r925318_rule`) that changes with **every STIG release**, so it is recorded in the description for the reader and never used as identity — a STIG version upgrade keeps finding continuity.
- Reimport and cross-test dedupe match on the unique id without ever comparing endpoints, so qualifying it with the host is what keeps one rule failing on two hosts as two findings.
- A `HASHCODE_FIELDS_PER_SCANNER` entry (`vuln_id_from_tool`, `endpoints`) is registered alongside so the *stored* `hash_code` is stable too, rather than falling through to the legacy title+description formula that false-positive history and similar-findings key on.

A checklist with no host name, FQDN or IP recorded falls back to the bare V-number; two such un-keyed checklists in one product cannot be told apart. Documented on the parser page.

### Other mapping notes

- Severity comes from the rule's DISA category (`high`/`medium`/`low`), and the category itself (CAT I/II/III) is kept in Impact, where an assessor's severity override does not move it. An override sets the severity and its reason becomes the severity justification.
- `Check_Content` becomes the steps to reproduce and `Fix_Text` the mitigation.
- Every CCI the rule cites is written on its own line in References. That format is a deliberate seam: DefectDojo Pro's compliance pack reads those CCIs back to map checklist items onto their NIST 800-53 controls.
- An unrecognised status is imported as Not Reviewed with a warning rather than dropped; an item with no V-number has no identity and is skipped.

### `.ckl` / `.cklb` added to the importable file types

Without this, `ImporterFileExtensionValidator` rejects a natively-named checklist before the parser is ever reached.

## Testing

- 16 new parser tests, run with `V3_FEATURE_LOCATIONS` **both on and off**.
- Full native suite, all three CI passes: **6486 / 45 / 7 tests**, no failures attributable to this change. (One pre-existing environment-only failure, `test_add_jira_instance_unknown_host`, which asserts the libc resolver's message text and fails on macOS at any commit.)
- `test_parsers`, `test_factory` and `test_dedupe_config_checks` all pass, so the docs page, sample directory, class naming and the dedupe-config system check are satisfied.
- `ruff check` clean against the repo config with the CI-pinned 0.16.0.
- Validated live against a running stack: imported the `.ckl`, confirmed the four status states and the CCI lines; reimported an edited checklist and confirmed a fixed item closes, a regressed item reactivates, and one dropped from the checklist is closed by absence; imported the `.cklb` twin and confirmed all four findings deduplicate against the `.ckl` originals; imported a second host's checklist and confirmed the same rule stays a separate finding.

### Sample data

Eight synthetic samples covering mixed statuses, a severity override with justification, repeated `CCI_REF` blocks, multiple `iSTIG` blocks, a blank host, an empty checklist, a `.cklb` missing optional keys, a windows-1252 encoded `.ckl`, and a `.cklb` with a UTF-8 BOM. Content is public STIG rule material only.
