### PR TITLE
docs(connectors): document the Tenable Web App Scanning connector

### DIFF
--- a/docs/content/import_data/pro/connectors/connectors_tool_reference.md
+++ b/docs/content/import_data/pro/connectors/connectors_tool_reference.md
@@ -1410,6 +1410,28 @@ On\-premise Tenable Connectors are not available at this time.
 
 See [Tenable's API Documentation](https://docs.tenable.com/vulnerability-management/Content/Settings/my-account/GenerateAPIKey.htm) for more info.
 
+## **Tenable Web App Scanning**
+
+The Tenable Web App Scanning connector imports **web application (DAST) findings** from Tenable Web App Scanning. It is a separate connector from Tenable (Vulnerability Management): the two products cover different assets and are configured independently, so you can use either or both.
+
+DefectDojo creates a Record for each **scanned web application**. Applications are discovered from your Web App Scanning scan configurations; a configuration that has never run does not produce a Record until its first scan completes. When more than one configuration scans the same application, they share a single Record.
+
+#### Prerequisites
+
+Tenable **API keys** (an access key and a secret key) for a user with Web App Scanning permissions. In Tenable, go to **My Account \> API Keys** to generate them, and confirm the user can view the scans you want to import — keys limited to Vulnerability Management cannot read Web App Scanning data.
+
+On\-premise Tenable connectors are not available at this time.
+
+#### Connector Mappings
+
+1. Enter <https://cloud.tenable.com> in the **Location** field.
+2. Enter your **Access Key** and **Secret Key**.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Findings are imported with the severity Tenable reports for your account, including any severity your team has recast. Each finding carries the affected URL as an endpoint, the request parameter and payload that triggered it, and Tenable's proof and output as steps to reproduce, along with CWE, CVE, CVSS and EPSS values where the detecting plugin supplies them.
+
+Only findings that are currently open or reopened are imported. A finding Tenable has marked fixed is closed in DefectDojo on the next sync.
+
 ## **Veracode**
 
 The Veracode connector imports application findings from the Veracode platform, split by scan type into **SAST**, **DAST**, **SCA**, and **Manual** finding types. DefectDojo creates a Record for each Veracode **application**.


### PR DESCRIPTION
Adds a tool-reference section for the Tenable Web App Scanning connector, alongside the existing Tenable (Vulnerability Management) entry.

Tenable ships Vulnerability Management and Web App Scanning as separate products, and they are separate connectors: they cover different assets and are configured independently, so a reader needs to know which one they are setting up and that they can use either or both.

The section covers what the connector imports, the fact that a Record is a scanned **web application** rather than a scan configuration (and what follows from that — a configuration that has never run produces no Record, and two configurations scanning one application share a Record), the Web App Scanning permission the API keys need, which finding fields are populated, and that only open and reopened findings are imported.

Documentation only — no code changes.