### PR TITLE
docs(reports): document the classic report engine removal and the migration

### DIFF
--- a/docs/content/metrics_reports/reports/PRO__report_builder.md
+++ b/docs/content/metrics_reports/reports/PRO__report_builder.md
@@ -162,6 +162,54 @@ Generated reports are collected in the Generated Reports list, which shows each 
 
 You can re-run a Template at any time to produce a fresh report. Keep in mind that each Generated Report is frozen in time — it reflects your data as of when it was generated and will not change as DefectDojo data changes, so re-run the Template whenever you need an up-to-date snapshot.
 
+## Moving off the classic report engine
+
+The classic report engine — the **Report Builder**, **Report Templates** and **Generated
+Reports** pages listed under *Classic Report Engine* in the sidebar — is removed in
+**3.3.0 (September 8, 2026)**. Until then those pages carry a banner reminding you of the
+date, and both they and this Report Builder offer a one-click migration.
+
+### Migrating your saved templates
+
+Use **Migrate to the new engine** on any classic page, or **Import from Classic Engine**
+on *All Report Templates* here. Both run the same conversion, so it does not matter which
+you start from, and both are safe to run more than once: a classic template whose name
+already exists here is reported as *already migrated* rather than duplicated.
+
+Each classic widget becomes a Block:
+
+| Classic widget | Becomes |
+|----------------|---------|
+| Cover Page | Cover Page stock Block |
+| Table Of Contents | Table of Contents stock Block |
+| Page Break | Page Break stock Block |
+| Custom Content / WYSIWYG | Text Block |
+| Findings | Tabular Block over Findings, keeping the widget's filters |
+| Vulnerable Endpoints | Tabular Block over URLs |
+| Severities | Active Findings by Severity chart Block |
+
+Two do not carry across, and the migration says so per template rather than converting
+them into something approximate:
+
+- **Executive Summary** — the classic engine derived this from whichever Findings widgets
+  sat in the same report. There is no equivalent aggregate Block; rebuild it as a Text
+  Block if you need it.
+- **Report Options** — not a Block. Its *Report name* becomes the new Template's name.
+  Finding notes, finding images and per-widget page breaks are Theme-level settings in
+  the new engine.
+
+### What happens to reports you have already run
+
+Nothing. Generated Reports produced by the classic engine are finished files, so there is
+nothing to convert. They stay listed and downloadable until the engine is removed — save
+anything you want to keep beyond 3.3.0.
+
+### If the Report Builder is switched off
+
+Migration still works with the **Reporting** feature flag disabled. The converted
+Templates simply do not appear until the flag is switched back on, so you can move your
+templates across on your own schedule.
+
 ## Next steps
 
 - **[Report Builder API](../report-builder-api/)** — script the whole workflow (Themes, Blocks, Templates, and Generated Reports) for repeatable, automated reporting.


### PR DESCRIPTION
**Description**

Documents that the classic report engine is removed in 3.3.0 (September 8, 2026), and how to carry saved report templates across to the Report Builder before then.

Adds a "Moving off the classic report engine" section to the Pro Report Builder page covering:

- the removal date and where the migration can be started from
- the full widget-to-Block mapping table
- what does not carry across, and why, rather than leaving users to discover it: Executive Summary has no equivalent aggregate Block, and Report Options is not a Block at all (its report name becomes the Template name; notes, images and page breaks are Theme-level settings now)
- that already-generated reports are finished files which stay downloadable until removal
- that migration works with the Reporting feature flag disabled, so customers can move on their own schedule

**Test results**

Documentation only; no code changes and no tests affected.

**Documentation**

This PR is the documentation change.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `bugfix`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (no code changes).
- [x] Your code is python 3.13 compliant (no code changes).
- [x] Documentation included in this PR.
