### PR TITLE
docs(notifications): note where notification settings live in the Pro UI

### DIFF
--- a/docs/content/admin/notifications/configure_personal_notifs.md
+++ b/docs/content/admin/notifications/configure_personal_notifs.md
@@ -5,14 +5,7 @@ aliases:
   - /en/customize_dojo/notifications/configure_personal_notifs
 ---
 
-{{% alert title="DefectDojo Pro" color="info" %}}
-In DefectDojo Pro, notification settings live in the Pro UI as three separate pages
-rather than one page with a Scope drop-down: **Settings \> Notifications \> Personal
-Notifications**, **System Notifications** and **Notification Template**. System
-Notifications and the Notification Template are visible to superusers only. Notification
-Webhooks moved alongside them, under **Settings \> Notifications \> Notification
-Webhooks**.
-{{% /alert %}}
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: In DefectDojo Pro, notification settings live in the Pro UI as three separate pages rather than one page with a Scope drop-down: **Settings \> Notifications \> Personal Notifications**, **System Notifications** and **Notification Template**. System Notifications and the Notification Template are visible to superusers only. Notification Webhooks moved alongside them, under **Settings \> Notifications \> Notification Webhooks**.</span>
 ## Configure Personal notifications
 
 Personal Notifications are sent in addition to System\-Wide Notifications, and will apply to any Product, Product Type or other data type that you have access to. Personal Notification preferences only apply to a single user, and can only be set on the account which is configuring them.

--- a/docs/content/admin/notifications/configure_personal_notifs.md
+++ b/docs/content/admin/notifications/configure_personal_notifs.md
@@ -4,6 +4,15 @@ description: "Configure notifications for a personal account"
 aliases:
   - /en/customize_dojo/notifications/configure_personal_notifs
 ---
+
+{{% alert title="DefectDojo Pro" color="info" %}}
+In DefectDojo Pro, notification settings live in the Pro UI as three separate pages
+rather than one page with a Scope drop-down: **Settings \> Notifications \> Personal
+Notifications**, **System Notifications** and **Notification Template**. System
+Notifications and the Notification Template are visible to superusers only. Notification
+Webhooks moved alongside them, under **Settings \> Notifications \> Notification
+Webhooks**.
+{{% /alert %}}
 ## Configure Personal notifications
 
 Personal Notifications are sent in addition to System\-Wide Notifications, and will apply to any Product, Product Type or other data type that you have access to. Personal Notification preferences only apply to a single user, and can only be set on the account which is configuring them.

--- a/docs/content/admin/notifications/configure_system_notifs.md
+++ b/docs/content/admin/notifications/configure_system_notifs.md
@@ -4,6 +4,15 @@ description: "How to configure Personal & System notifications"
 aliases:
   - /en/customize_dojo/notifications/configure_system_notifs
 ---
+
+{{% alert title="DefectDojo Pro" color="info" %}}
+In DefectDojo Pro, notification settings live in the Pro UI as three separate pages
+rather than one page with a Scope drop-down: **Settings \> Notifications \> Personal
+Notifications**, **System Notifications** and **Notification Template**. System
+Notifications and the Notification Template are visible to superusers only. Notification
+Webhooks moved alongside them, under **Settings \> Notifications \> Notification
+Webhooks**.
+{{% /alert %}}
 DefectDojo has two different kinds of notifications: **Personal** (sent to a single account) and **System** (which are sent to all users).
 
 Both an account’s Personal Notifications and the global System Notifications can be configured from the same page: **⚙️Configuration \> Notifications** in the sidebar.

--- a/docs/content/admin/notifications/configure_system_notifs.md
+++ b/docs/content/admin/notifications/configure_system_notifs.md
@@ -5,14 +5,7 @@ aliases:
   - /en/customize_dojo/notifications/configure_system_notifs
 ---
 
-{{% alert title="DefectDojo Pro" color="info" %}}
-In DefectDojo Pro, notification settings live in the Pro UI as three separate pages
-rather than one page with a Scope drop-down: **Settings \> Notifications \> Personal
-Notifications**, **System Notifications** and **Notification Template**. System
-Notifications and the Notification Template are visible to superusers only. Notification
-Webhooks moved alongside them, under **Settings \> Notifications \> Notification
-Webhooks**.
-{{% /alert %}}
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: In DefectDojo Pro, notification settings live in the Pro UI as three separate pages rather than one page with a Scope drop-down: **Settings \> Notifications \> Personal Notifications**, **System Notifications** and **Notification Template**. System Notifications and the Notification Template are visible to superusers only. Notification Webhooks moved alongside them, under **Settings \> Notifications \> Notification Webhooks**.</span>
 DefectDojo has two different kinds of notifications: **Personal** (sent to a single account) and **System** (which are sent to all users).
 
 Both an account’s Personal Notifications and the global System Notifications can be configured from the same page: **⚙️Configuration \> Notifications** in the sidebar.


### PR DESCRIPTION
**Description**

Notes where notification settings live in DefectDojo Pro's UI, which now serves them as three separate pages — Personal Notifications, System Notifications and Notification Template — instead of a single page with a Scope drop-down. The notification webhook page moved alongside them.

Added as a Pro callout on the two configuration pages rather than a rewrite of the instructions: the Scope drop-down is still exactly how it works in open source, so the existing steps stay correct for that audience.

**Test results**

Documentation only; no code changes and no tests affected.

**Documentation**

This PR is the documentation change.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (no code changes).
- [x] Your code is python 3.13 compliant (no code changes).
- [x] Documentation included in this PR.
