### PR TITLE
fix(dedupe): skip findings deleted between the loop scan and the repair

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -1152,7 +1152,17 @@ def removeLoop(finding_id, counter):
     # in bulk, but loops are rare (only from past bugs or high parallel load) so the
     # current implementation is acceptable.
     # get latest status
-    finding = Finding.objects.get(id=finding_id)
+    #
+    # Every id reaching this function was read earlier -- fix_loop_duplicates streams candidate
+    # ids through a cursor, and the recursion below walks ids off a queryset -- so the row can
+    # already be deleted by the time it is fetched. Callers run alongside deletes (the delete
+    # path itself calls in through prepare_duplicates_for_delete), so get() turned that ordinary
+    # race into a Finding.DoesNotExist that aborted the caller. A row that is gone has no loop
+    # left to repair, so skip it and let the run continue with the remaining candidates.
+    finding = Finding.objects.filter(id=finding_id).first()
+    if finding is None:
+        deduplicationLogger.debug("removeLoop: finding %s no longer exists, skipping", finding_id)
+        return
     real_original = finding.duplicate_finding
 
     if not real_original or real_original is None:
@@ -1172,8 +1182,15 @@ def removeLoop(finding_id, counter):
         # If not, swap them around
         tmp = finding_id
         finding_id = real_original.id
-        real_original = Finding.objects.get(id=tmp)
-        finding = Finding.objects.get(id=finding_id)
+        # Same race as the fetch above: both rows were read moments ago, but nothing holds
+        # them, so re-read defensively rather than letting one vanish take out the caller.
+        real_original = Finding.objects.filter(id=tmp).first()
+        finding = Finding.objects.filter(id=finding_id).first()
+        if real_original is None or finding is None:
+            deduplicationLogger.debug(
+                "removeLoop: finding %s or %s no longer exists, skipping", tmp, finding_id,
+            )
+            return
 
     if real_original in finding.original_finding.all():
         # remove the original from the duplicate list if it is there

--- a/unittests/test_duplication_loops.py
+++ b/unittests/test_duplication_loops.py
@@ -1,10 +1,13 @@
 import logging
+from unittest.mock import patch
 
 from crum import impersonate
 from django.db import connection
 from django.test.utils import override_settings
 
+from dojo.finding import helper as finding_helper
 from dojo.finding.deduplication import set_duplicate
+from dojo.finding.helper import removeLoop
 from dojo.management.commands.fix_loop_duplicates import fix_loop_duplicates
 from dojo.models import Engagement, Finding, Product, System_Settings, User, copy_model_util
 from dojo.tasks import _async_dupe_delete_impl  # noqa: PLC2701
@@ -504,6 +507,61 @@ class TestDuplicationLoops(DojoTestCase):
         )
         self.finding_a.refresh_from_db()
         self.assertEqual(self.finding_a.duplicate_finding_set().count(), 1)
+
+    def test_remove_loop_skips_a_finding_that_no_longer_exists(self):
+        """
+        Every call to removeLoop passes an id read earlier, so the row can be gone by the time
+        it runs: fix_loop_duplicates streams candidate ids through a cursor, and its callers run
+        while other workers delete findings. Fetching that id with get() turned the race into a
+        Finding.DoesNotExist that killed the whole caller -- observed aborting an async delete
+        task before it had prepared any duplicate cluster. A vanished row has no loop left to
+        repair, so removeLoop must skip it and return.
+        """
+        stale_id = self.finding_b.id
+        self.finding_b.delete()
+        self.assertIsNone(self.finding_b.id)
+
+        # Must not raise; there is nothing to repair and nothing to report.
+        self.assertIsNone(removeLoop(stale_id, 50))
+
+    def test_fix_loop_duplicates_survives_a_finding_deleted_mid_run(self):
+        """
+        The reported path end to end: a candidate id is deleted after fix_loop_duplicates has
+        streamed it but before removeLoop reaches it. The run must carry on and still repair the
+        loops whose findings are still there, instead of dying on the first stale id.
+        """
+        # Two independent self-loops. Candidates are streamed newest id first, so finding_c is
+        # repaired first and finding_b -- deleted while that happens -- is reached second.
+        for finding in (self.finding_b, self.finding_c):
+            finding.duplicate = True
+            finding.duplicate_finding = finding
+            super(Finding, finding).save(skip_validation=True)
+        self.assertLess(self.finding_b.id, self.finding_c.id)
+
+        doomed_id = self.finding_b.id
+        real_remove_loop = finding_helper.removeLoop
+        calls = []
+
+        def remove_loop_with_concurrent_delete(finding_id, counter):
+            if not calls:
+                # Stands in for the concurrent worker: the row goes away between the id being
+                # streamed and removeLoop being called with it.
+                Finding.objects.filter(id=doomed_id).delete()
+            calls.append(finding_id)
+            return real_remove_loop(finding_id, counter)
+
+        with patch.object(finding_helper, "removeLoop", side_effect=remove_loop_with_concurrent_delete):
+            loop_count = fix_loop_duplicates()
+        # Deleted by queryset above, so the instance still carries its old pk; clear it so
+        # tearDown does not try to delete the row a second time.
+        self.finding_b.id = None
+
+        self.assertIn(doomed_id, calls, "the deleted finding's id is still reached by the run")
+        self.assertEqual(loop_count, 0)
+
+        self.finding_c.refresh_from_db()
+        self.assertIsNone(self.finding_c.duplicate_finding, "the surviving self-loop is still repaired")
+        self.assertFalse(self.finding_c.duplicate)
 
     def test_delete_all_engagements(self):
         # make sure there is no exception when deleting all engagements


### PR DESCRIPTION
**Description**

A production backend task died with `Finding.DoesNotExist` inside the duplicate-loop repair, aborting an async delete before it had prepared a single duplicate cluster:

```
  File "dojo/utils.py", in async_delete_task
    prepare_duplicates_for_delete(obj)
  File "dojo/finding/helper.py", in prepare_duplicates_for_delete
    fix_loop_duplicates(scope_qs=Finding.objects.filter(**{scope_field: obj}))
  File "dojo/finding/helper.py", in fix_loop_duplicates
    removeLoop(find_id, 50)
  File "dojo/finding/helper.py", in removeLoop
    finding = Finding.objects.get(id=finding_id)
dojo.finding.models.Finding.DoesNotExist: Finding matching query does not exist.
```

Every id `removeLoop` receives was read at some earlier moment, never held:

- `fix_loop_duplicates` streams its candidate ids with `.order_by("-id").values_list("id", flat=True).iterator(chunk_size=1000)`, so the ids are a snapshot and the rows behind them are repaired one at a time afterwards;
- the recursion at the bottom of `removeLoop` walks `finding.original_finding.all()` and calls itself with each `f.id`, re-fetching a row it already read.

Both callers run while findings are being deleted — the delete path is itself one of them, reaching `fix_loop_duplicates` through `prepare_duplicates_for_delete`, and `fix_loop_duplicates_task` runs unscoped over the whole instance. So a candidate row disappearing before its turn is ordinary, not pathological, and `get()` turned it into an unhandled exception that took the entire caller down. For the delete path that means the delete never got past its first preparation step; for the periodic task it means every remaining loop in that run goes unrepaired.

The fix fetches defensively and skips an id whose row is gone. A finding that no longer exists has no loop left to repair, so there is nothing to do for it and the remaining candidates still get their turn. The two re-fetches in the swap branch get the same treatment — same `Finding.objects.get(id=...)` pattern, same race, a few lines below the reported one.

Nothing changes when the row is there, including cost: `filter(id=...).first()` is the same single indexed `SELECT ... LIMIT 1` as `get()`, so no performance counts move. The skip is logged at debug on the deduplication logger.

This is deliberately narrow. It does not touch the FK dereferences in the same function (`finding.duplicate_finding`), which are a different pattern and not what fired here, and it does not attempt to make loop repair transactional.

**Test results**

Failing tests first; both fail on `bugfix` with exactly the traceback above and pass with the fix. They live in `unittests/test_duplication_loops.py`, next to the existing loop-repair coverage.

- `TestDuplicationLoops::test_remove_loop_skips_a_finding_that_no_longer_exists` — the unit-level guard: `removeLoop` called with the id of a deleted finding must return quietly. Pre-fix: `Finding.DoesNotExist` at the entry fetch.
- `TestDuplicationLoops::test_fix_loop_duplicates_survives_a_finding_deleted_mid_run` — the reported path end to end. Two independent self-loops; candidates stream newest id first, and the lower-id one is deleted while the first is being repaired, standing in for the concurrent worker. The run must complete, return 0, and still have repaired the surviving loop. Pre-fix: `Finding.DoesNotExist` reached through `fix_loop_duplicates`.

Local runs (Python 3.13, PostgreSQL 16):

| Suite | Result |
|---|---|
| `unittests.test_duplication_loops` | 22 tests, OK |
| `+ test_utils_deduplication_reopen` + `test_deduplication_logic` + `test_dedupe_flush_missing_original` | 113 tests, OK (2 skipped) |

`ruff check dojo/ unittests/` clean (0.16.0, the pinned version).

No expected-query-count updates: the success path issues the same one query per fetch as before, and the skip path issues fewer.

**Pro impact**

Checked, because the pro plugin overrides parts of this area. It does not override any of the three functions involved — `removeLoop`, `fix_loop_duplicates` and `prepare_duplicates_for_delete` have no pro counterpart, and pro's only touchpoints are `prepare_duplicates_for_delete(obj, preview_only=True)` (which returns before reaching the loop repair) and the separate `BULK_DELETE_FINDINGS_METHOD` hook, which this does not go near. No signature change, no behavior change on the existing-row path, and no query-count movement, so no companion pro change and no pro performance-count update is needed.

**Documentation**

None. Internal robustness fix with no user-visible surface: the task either completed or died, and no documented behavior changes.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] Add applicable tests to the unit tests.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DQ4ypdQcCXrvL1vb7tCemE)_