### PR TITLE
Make a private note private in the UI too, and say so

### DIFF
--- a/docs/content/triage_findings/findings_workflows/OS__risk_acceptance.md
+++ b/docs/content/triage_findings/findings_workflows/OS__risk_acceptance.md
@@ -71,7 +71,7 @@ To remove a Finding from a Full Risk Acceptance, click the **Remove** button wit
 
 The Full Risk Acceptance's view also includes a table at the bottom for all other Findings from Tests within that Engagement. From there, you may select additional Findings and add them to that Full Risk Acceptance. 
 
-Additionally, there is a Notes function that allows Users to include additional context to the Full Risk Acceptance. All public notes will appear in any Reports that are generated for the Full Risk Acceptance, whereas notes that are toggled as **Private** will not appear in reports. 
+Additionally, there is a Notes function that allows Users to include additional context to the Full Risk Acceptance. All public notes will appear in any Reports that are generated for the Full Risk Acceptance. Notes toggled as **Private** are visible only to their author and to superusers, and are left out of reports. 
 
 Importantly, if a Full Risk Acceptance is deleted entirely, the Findings within will have their status automatically reverted to “Active.”
 

--- a/dojo/db_migrations/0290_notes_private_help_text.py
+++ b/dojo/db_migrations/0290_notes_private_help_text.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dojo', '0289_fileupload_title_not_unique'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='notes',
+            name='private',
+            field=models.BooleanField(default=False, help_text='Only you and superusers can see this note. It is also left out of reports and issue-tracker sync.'),
+        ),
+    ]

--- a/dojo/engagement/api/views.py
+++ b/dojo/engagement/api/views.py
@@ -203,7 +203,7 @@ class EngagementViewSet(
         notes = engagement.notes.all()
 
         serialized_notes = EngagementToNotesSerializer(
-            {"engagement_id": engagement, "notes": notes},
+            {"engagement_id": engagement, "notes": notes}, context=self.get_serializer_context(),
         )
         return Response(serialized_notes.data, status=status.HTTP_200_OK)
 

--- a/dojo/engagement/ui/views.py
+++ b/dojo/engagement/ui/views.py
@@ -100,6 +100,7 @@ from dojo.models import (
     Test,
     Test_Import,
 )
+from dojo.notes.helper import visible_notes
 from dojo.notifications.helper import create_notification
 from dojo.product.queries import get_authorized_products
 from dojo.product_announcements import (
@@ -498,7 +499,7 @@ class ViewEngagement(View):
                 "check": check,
                 "threat": eng.tmodel_path,
                 "form": form,
-                "notes": notes,
+                "notes": visible_notes(notes, request.user),
                 "files": files,
                 "risks_accepted": risks_accepted,
                 "jissue": jissue,
@@ -579,7 +580,7 @@ class ViewEngagement(View):
                 "check": check,
                 "threat": eng.tmodel_path,
                 "form": form,
-                "notes": notes,
+                "notes": visible_notes(notes, request.user),
                 "files": files,
                 "risks_accepted": risks_accepted,
                 "jissue": jissue,
@@ -1433,7 +1434,7 @@ def view_edit_risk_acceptance(request, eid, raid, *, edit_mode=False):
             "engagement": eng,
             "product_tab": product_tab,
             "accepted_findings": fpage,
-            "notes": risk_acceptance.notes.all(),
+            "notes": visible_notes(risk_acceptance.notes.all(), request.user),
             "eng": eng,
             "edit_mode": edit_mode,
             "risk_acceptance_form": risk_acceptance_form,

--- a/dojo/finding/api/views.py
+++ b/dojo/finding/api/views.py
@@ -471,7 +471,7 @@ class FindingViewSet(
         notes = finding.notes.all()
 
         serialized_notes = FindingToNotesSerializer(
-            {"finding_id": finding, "notes": notes},
+            {"finding_id": finding, "notes": notes}, context=self.get_serializer_context(),
         )
         return Response(serialized_notes.data, status=status.HTTP_200_OK)
 

--- a/dojo/finding/ui/views.py
+++ b/dojo/finding/ui/views.py
@@ -96,6 +96,7 @@ from dojo.models import (
     Test_Import_Finding_Action,
     User,
 )
+from dojo.notes.helper import visible_notes
 from dojo.notifications.helper import create_notification
 from dojo.tags.utils import bulk_add_tags_to_instances
 from dojo.test.queries import get_authorized_tests
@@ -657,7 +658,7 @@ class ViewFinding(View):
             "finding": finding,
             "dojo_user": user,
             "user": request.user,
-            "notes": notes,
+            "notes": visible_notes(notes, request.user),
             "files": finding.files.all(),
             "note_type_activation": note_type_activation,
             "available_note_types": available_note_types,

--- a/dojo/notes/api/serializer.py
+++ b/dojo/notes/api/serializer.py
@@ -1,3 +1,5 @@
+from django.db import models
+from django.db.models import Q
 from django.utils import timezone
 from rest_framework import serializers
 
@@ -13,6 +15,21 @@ class NoteHistorySerializer(serializers.ModelSerializer):
     class Meta:
         model = NoteHistory
         fields = "__all__"
+
+
+class VisibleNotesSerializer(serializers.ListSerializer):
+
+    """Serialize only the notes the requester may see: non-private, or their own."""
+
+    def to_representation(self, data):
+        notes = data.all() if isinstance(data, models.Manager) else data
+        user = getattr(self.context.get("request"), "user", None)
+        if user is None:
+            # No requester to compare against, so keep private notes out.
+            notes = notes.filter(private=False)
+        elif not user.is_superuser:
+            notes = notes.filter(Q(private=False) | Q(author=user))
+        return super().to_representation(notes)
 
 
 class NoteSerializer(serializers.ModelSerializer):
@@ -39,3 +56,4 @@ class NoteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Notes
         fields = "__all__"
+        list_serializer_class = VisibleNotesSerializer

--- a/dojo/notes/api/serializer.py
+++ b/dojo/notes/api/serializer.py
@@ -1,9 +1,9 @@
 from django.db import models
-from django.db.models import Q
 from django.utils import timezone
 from rest_framework import serializers
 
 from dojo.note_type.api.serializer import NoteTypeSerializer
+from dojo.notes.helper import visible_notes
 from dojo.notes.models import NoteHistory, Notes
 from dojo.user.api.serializer import UserStubSerializer
 
@@ -24,12 +24,7 @@ class VisibleNotesSerializer(serializers.ListSerializer):
     def to_representation(self, data):
         notes = data.all() if isinstance(data, models.Manager) else data
         user = getattr(self.context.get("request"), "user", None)
-        if user is None:
-            # No requester to compare against, so keep private notes out.
-            notes = notes.filter(private=False)
-        elif not user.is_superuser:
-            notes = notes.filter(Q(private=False) | Q(author=user))
-        return super().to_representation(notes)
+        return super().to_representation(visible_notes(notes, user))
 
 
 class NoteSerializer(serializers.ModelSerializer):

--- a/dojo/notes/helper.py
+++ b/dojo/notes/helper.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Q
 
 from dojo.notes.models import NoteHistory, Notes
 
@@ -21,6 +21,21 @@ def notes_prefetch(lookup="notes"):
             Prefetch("history", queryset=NoteHistory.objects.select_related("current_editor", "note_type")),
         ),
     )
+
+
+def visible_notes(notes, user):
+    """
+    The notes ``user`` may see: non-private, or ones they wrote themselves.
+
+    Every read path goes through here, so the API and the UI cannot drift apart
+    on what ``private`` means. A caller with no user (report rendering) gets the
+    non-private notes only.
+    """
+    if user is None:
+        return notes.filter(private=False)
+    if user.is_superuser:
+        return notes
+    return notes.filter(Q(private=False) | Q(author=user))
 
 
 def delete_related_notes(obj):

--- a/dojo/notes/models.py
+++ b/dojo/notes/models.py
@@ -22,7 +22,7 @@ class Notes(models.Model):
     date = models.DateTimeField(null=False, editable=False,
                                 default=get_current_datetime)
     author = models.ForeignKey("dojo.Dojo_User", related_name="editor_notes_set", editable=False, on_delete=models.CASCADE)
-    private = models.BooleanField(default=False)
+    private = models.BooleanField(default=False, help_text="Only you and superusers can see this note. It is also left out of reports and issue-tracker sync.")
     edited = models.BooleanField(default=False)
     editor = models.ForeignKey("dojo.Dojo_User", related_name="author_notes_set", editable=False, null=True, on_delete=models.CASCADE)
     edit_time = models.DateTimeField(null=True, editable=False,

--- a/dojo/risk_acceptance/api/views.py
+++ b/dojo/risk_acceptance/api/views.py
@@ -111,7 +111,7 @@ class RiskAcceptanceViewSet(
 
         notes = risk_acceptance.notes.all()
         serialized_notes = RiskAcceptanceToNotesSerializer(
-            {"risk_acceptance_id": risk_acceptance, "notes": notes},
+            {"risk_acceptance_id": risk_acceptance, "notes": notes}, context=self.get_serializer_context(),
         )
         return Response(serialized_notes.data, status=status.HTTP_200_OK)
 

--- a/dojo/templates/dojo/finding_related_row.html
+++ b/dojo/templates/dojo/finding_related_row.html
@@ -1,4 +1,5 @@
 {% load navigation_tags %}
+{% load get_note_status %}
 {% load display_tags %}
 {% load static %}
 <tr>
@@ -25,7 +26,7 @@
             {% include "dojo/snippets/tags.html" with tags=similar_finding.tags.all %}
         </small>
         {% endif %}
-        {% with similar_finding.notes.count as note_count %}
+        {% with similar_finding.notes.all|visible_to:request.user|length as note_count %}
             ({{ note_count }} note{{ note_count|pluralize }})
         {% endwith %}
     </td>

--- a/dojo/templates/dojo/findings_list_snippet.html
+++ b/dojo/templates/dojo/findings_list_snippet.html
@@ -1,5 +1,6 @@
 {% load navigation_tags %}
 {% load display_tags %}
+{% load get_note_status %}
 {% load authorization_tags %}
 
 {% load static %}
@@ -597,15 +598,17 @@
                                                 <i class="fa-solid fa-file has-popover dojo-sup"
                                                 data-content="{{ finding.component_name }} - {{ finding.component_version }}"></i>
                                             {% endif %}
-                                            {% if finding.notes.all %}
+                                            {% with visible_notes=finding.notes.all|visible_to:request.user %}
+                                            {% if visible_notes %}
                                                 <i class="fa-solid fa-comment has-popover dojo-sup"
-                                                data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0.date }}: {{ finding.notes.all.0 }}"></i>
+                                                data-content="{{ visible_notes.0.author }} at {{ visible_notes.0.date }}: {{ visible_notes.0 }}"></i>
                                                 <a href="{% url 'view_finding' finding.id %}#vuln_notes"
                                                     class="dojo-sup"
-                                                    alt="{{ finding.notes.count }} note{{ finding.notes.count|pluralize }}">
-                                                        ({{ finding.notes.count }})
+                                                    alt="{{ visible_notes.count }} note{{ visible_notes.count|pluralize }}">
+                                                        ({{ visible_notes.count }})
                                                 </a>
                                             {% endif %}
+                                            {% endwith %}
                                             {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
                                         </td>
                                         <td class="nowrap">

--- a/dojo/templates/dojo/snippets/comments.html
+++ b/dojo/templates/dojo/snippets/comments.html
@@ -69,7 +69,7 @@
           {% endif %}
           {% if note.private %}
             <div class="row-sm-2">
-              <span class="text-muted">(will not appear in report)</span>
+              <span class="text-muted">(private to you)</span>
             </div>
           {% endif %}
       </div>

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -661,7 +661,7 @@
                                                     {% endif %}
                                                     {% if note.private %}
                                                         <div class="row-sm-2">
-                                                            <span class="text-muted">(will not appear in report)</span>
+                                                            <span class="text-muted">(private to you)</span>
                                                         </div>
                                                     {% endif %}
                                                 </div>

--- a/dojo/templates/dojo/view_test.html
+++ b/dojo/templates/dojo/view_test.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load display_tags %}
+{% load get_note_status %}
 {% load authorization_tags %}
 
 {% load static %}
@@ -1202,15 +1203,17 @@
                                             <i class="fa-solid fa-file has-popover dojo-sup"
                                             data-content="{{ finding.component_name }} - {{ finding.component_version }}"></i>
                                         {% endif %}
-                                        {% if finding.notes.all %}
+                                        {% with visible_notes=finding.notes.all|visible_to:request.user %}
+                                        {% if visible_notes %}
                                             <i class="fa-solid fa-comment has-popover dojo-sup"
-                                            data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0.date }}: {{ finding.notes.all.0 }}"></i>
+                                            data-content="{{ visible_notes.0.author }} at {{ visible_notes.0.date }}: {{ visible_notes.0 }}"></i>
                                             <a href="{% url 'view_finding' finding.id %}#vuln_notes"
                                                 class="dojo-sup"
-                                                alt="{{ finding.notes.count }} note{{ finding.notes.count|pluralize }}">
-                                                    ({{ finding.notes.count }})
+                                                alt="{{ visible_notes.count }} note{{ visible_notes.count|pluralize }}">
+                                                    ({{ visible_notes.count }})
                                             </a>
                                         {% endif %}
+                                        {% endwith %}
                                         {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
                                     </td>
                                     <td class="nowrap">

--- a/dojo/templates_classic/dojo/finding_related_row.html
+++ b/dojo/templates_classic/dojo/finding_related_row.html
@@ -1,4 +1,5 @@
 {% load navigation_tags %}
+{% load get_note_status %}
 {% load display_tags %}
 {% load static %}
 <tr>
@@ -25,7 +26,7 @@
             {% include "dojo/snippets/tags.html" with tags=similar_finding.tags.all %}
         </small>
         {% endif %}
-        {% with similar_finding.notes.count as note_count %}
+        {% with similar_finding.notes.all|visible_to:request.user|length as note_count %}
             ({{ note_count }} note{{ note_count|pluralize }})
         {% endwith %}
     </td>

--- a/dojo/templates_classic/dojo/findings_list_snippet.html
+++ b/dojo/templates_classic/dojo/findings_list_snippet.html
@@ -1,5 +1,6 @@
 {% load navigation_tags %}
 {% load display_tags %}
+{% load get_note_status %}
 {% load authorization_tags %}
 
 {% load static %}
@@ -598,20 +599,22 @@
                                                 data-original-title="Component"
                                                 title=""></i>
                                             {% endif %}
-                                            {% if finding.notes.all %}
+                                            {% with visible_notes=finding.notes.all|visible_to:request.user %}
+                                            {% if visible_notes %}
                                                 <i class="glyphicon glyphicon-comment has-popover dojo-sup"
                                                 data-trigger="hover"
-                                                data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0.date }}: {{ finding.notes.all.0 }}"
+                                                data-content="{{ visible_notes.0.author }} at {{ visible_notes.0.date }}: {{ visible_notes.0 }}"
                                                 data-placement="left"
                                                 data-container="body"
-                                                data-original-title="Most Recent Note ({{ finding.notes.count }} total)"
+                                                data-original-title="Most Recent Note ({{ visible_notes.count }} total)"
                                                 title=""></i>
                                                 <a href="{% url 'view_finding' finding.id %}#vuln_notes"
                                                     class="dojo-sup"
-                                                    alt="{{ finding.notes.count }} note{{ finding.notes.count|pluralize }}">
-                                                        ({{ finding.notes.count }})
+                                                    alt="{{ visible_notes.count }} note{{ visible_notes.count|pluralize }}">
+                                                        ({{ visible_notes.count }})
                                                 </a>
                                             {% endif %}
+                                            {% endwith %}
                                             {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
                                         </td>
                                         <td class="nowrap">

--- a/dojo/templates_classic/dojo/snippets/comments.html
+++ b/dojo/templates_classic/dojo/snippets/comments.html
@@ -69,7 +69,7 @@
           {% endif %}
           {% if note.private %}
             <div class="row-sm-2">
-              <span class="text-muted">(will not appear in report)</span>
+              <span class="text-muted">(private to you)</span>
             </div>
           {% endif %}
       </div>

--- a/dojo/templates_classic/dojo/view_eng.html
+++ b/dojo/templates_classic/dojo/view_eng.html
@@ -663,7 +663,7 @@
                                                     {% endif %}
                                                     {% if note.private %}
                                                         <div class="row-sm-2">
-                                                            <span class="text-muted">(will not appear in report)</span>
+                                                            <span class="text-muted">(private to you)</span>
                                                         </div>
                                                     {% endif %}
                                                 </div>

--- a/dojo/templates_classic/dojo/view_test.html
+++ b/dojo/templates_classic/dojo/view_test.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load display_tags %}
+{% load get_note_status %}
 {% load authorization_tags %}
 
 {% load static %}
@@ -1203,20 +1204,22 @@
                                             data-original-title="Component"
                                             title=""></i>
                                         {% endif %}
-                                        {% if finding.notes.all %}
+                                        {% with visible_notes=finding.notes.all|visible_to:request.user %}
+                                        {% if visible_notes %}
                                             <i class="glyphicon glyphicon-comment has-popover dojo-sup"
                                             data-trigger="hover"
-                                            data-content="{{ finding.notes.all.0.author }} at {{ finding.notes.all.0.date }}: {{ finding.notes.all.0 }}"
+                                            data-content="{{ visible_notes.0.author }} at {{ visible_notes.0.date }}: {{ visible_notes.0 }}"
                                             data-placement="left"
                                             data-container="body"
-                                            data-original-title="Most Recent Note ({{ finding.notes.count }} total)"
+                                            data-original-title="Most Recent Note ({{ visible_notes.count }} total)"
                                             title=""></i>
                                             <a href="{% url 'view_finding' finding.id %}#vuln_notes"
                                                 class="dojo-sup"
-                                                alt="{{ finding.notes.count }} note{{ finding.notes.count|pluralize }}">
-                                                    ({{ finding.notes.count }})
+                                                alt="{{ visible_notes.count }} note{{ visible_notes.count|pluralize }}">
+                                                    ({{ visible_notes.count }})
                                             </a>
                                         {% endif %}
+                                        {% endwith %}
                                         {% include "dojo/snippets/tags.html" with tags=finding.tags.all %}
                                     </td>
                                     <td class="nowrap">

--- a/dojo/templatetags/get_note_status.py
+++ b/dojo/templatetags/get_note_status.py
@@ -1,5 +1,7 @@
 from django import template
 
+from dojo.notes.helper import visible_notes
+
 register = template.Library()
 
 
@@ -8,3 +10,9 @@ def get_public_notes(notes):
     if notes:
         return notes.filter(private=False)
     return None
+
+
+@register.filter(name="visible_to")
+def visible_to(notes, user):
+    """The notes ``user`` may see. For templates that read the relation directly."""
+    return visible_notes(notes, user)

--- a/dojo/test/api/views.py
+++ b/dojo/test/api/views.py
@@ -181,7 +181,7 @@ class TestsViewSet(
         notes = test.notes.all()
 
         serialized_notes = TestToNotesSerializer(
-            {"test_id": test, "notes": notes},
+            {"test_id": test, "notes": notes}, context=self.get_serializer_context(),
         )
         return Response(serialized_notes.data, status=status.HTTP_200_OK)
 

--- a/dojo/test/ui/views.py
+++ b/dojo/test/ui/views.py
@@ -54,6 +54,7 @@ from dojo.models import (
     Test,
     Test_Import,
 )
+from dojo.notes.helper import visible_notes
 from dojo.notifications.helper import create_notification
 from dojo.product_announcements import (
     ErrorPageProductAnnouncement,
@@ -163,7 +164,7 @@ class ViewTest(View):
             "product_tab": product_tab,
             "title_words": get_words_for_field(Finding, "title"),
             "component_words": get_words_for_field(Finding, "component_name"),
-            "notes": notes,
+            "notes": visible_notes(notes, request.user),
             "note_type_activation": note_type_activation,
             "available_note_types": available_note_types,
             "files": test.files.all(),

--- a/tests/notes_test.py
+++ b/tests/notes_test.py
@@ -48,7 +48,7 @@ class NoteTest(BaseTestCase):
             self.uncollapse_all(driver)
         text = driver.find_element(By.TAG_NAME, "body").text
         note_present = "Test public note" in text
-        private_status = "(will not appear in report)" in text
+        private_status = "(private to you)" in text
         pass_test = note_present and private_status
         if not pass_test:
             logger.info("Private note note created at the %s level", level)

--- a/unittests/test_apiv2_note_visibility.py
+++ b/unittests/test_apiv2_note_visibility.py
@@ -1,0 +1,120 @@
+"""
+Regression tests for private note visibility on the API.
+
+The ``notes`` relation used to be serialized straight off the parent object,
+so any user who could read a Finding, Test, Engagement or Risk Acceptance
+received every note attached to it, including notes another user had marked
+private. ``NoteSerializer`` now filters through ``VisibleNotesSerializer``.
+"""
+
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from dojo.models import (
+    Dojo_User,
+    Engagement,
+    Finding,
+    Notes,
+    Product,
+    Product_Member,
+    Product_Type,
+    Test,
+    Test_Type,
+)
+
+from .dojo_test_case import DojoAPITestCase
+
+PRIVATE = "INTERNAL: note visibility private entry"
+PUBLIC = "note visibility public entry"
+
+
+class NoteVisibilityAPITest(DojoAPITestCase):
+
+    """A private note reaches its author and no other member of the product."""
+
+    def setUp(self):
+        self.author = self._member("note-visibility-author")
+        self.colleague = self._member("note-visibility-colleague")
+        self.superuser, _ = Dojo_User.objects.get_or_create(
+            username="note-visibility-super",
+            defaults={"is_superuser": True, "is_staff": True},
+        )
+
+        product_type, _ = Product_Type.objects.get_or_create(name="note-visibility")
+        self.product, _ = Product.objects.get_or_create(
+            name="NoteVisibilityAPITest", description="Test", prod_type=product_type,
+        )
+        for user in (self.author, self.colleague):
+            self.product.authorized_users.add(user)
+            Product_Member.objects.get_or_create(
+                product=self.product, user=user, defaults={"role_id": 4},
+            )
+
+        self.engagement = Engagement.objects.create(
+            name="note visibility", product=self.product,
+            target_start="2026-01-01", target_end="2026-01-02",
+        )
+        test_type, _ = Test_Type.objects.get_or_create(name="note-visibility-tt")
+        self.test = Test.objects.create(
+            engagement=self.engagement, test_type=test_type,
+            target_start="2026-01-01", target_end="2026-01-02",
+        )
+        self.finding = Finding.objects.create(
+            title="note visibility finding", test=self.test, reporter=self.author,
+            severity="Info", numerical_severity="S4",
+        )
+
+        for parent in (self.finding, self.test, self.engagement):
+            parent.notes.add(Notes.objects.create(entry=PRIVATE, author=self.author, private=True))
+            parent.notes.add(Notes.objects.create(entry=PUBLIC, author=self.author, private=False))
+
+    def _member(self, username):
+        user, _ = Dojo_User.objects.get_or_create(
+            username=username, defaults={"is_superuser": False, "is_staff": False},
+        )
+        return user
+
+    def _client(self, user):
+        token, _ = Token.objects.get_or_create(user=user)
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+        return client
+
+    def _paths(self):
+        return [
+            f"/api/v2/findings/{self.finding.id}/",
+            f"/api/v2/findings/{self.finding.id}/notes/",
+            f"/api/v2/tests/{self.test.id}/",
+            f"/api/v2/tests/{self.test.id}/notes/",
+            f"/api/v2/engagements/{self.engagement.id}/",
+            f"/api/v2/engagements/{self.engagement.id}/notes/",
+        ]
+
+    def _body(self, user, path):
+        response = self._client(user).get(path)
+        self.assertEqual(200, response.status_code, f"{path}: {response.content[:300]}")
+        return response.content.decode()
+
+    def test_colleague_does_not_receive_another_members_private_note(self):
+        for path in self._paths():
+            body = self._body(self.colleague, path)
+            self.assertNotIn(PRIVATE, body, path)
+            self.assertIn(PUBLIC, body, path)
+
+    def test_author_still_receives_their_own_private_note(self):
+        for path in self._paths():
+            body = self._body(self.author, path)
+            self.assertIn(PRIVATE, body, path)
+            self.assertIn(PUBLIC, body, path)
+
+    def test_superuser_still_receives_every_note(self):
+        for path in self._paths():
+            self.assertIn(PRIVATE, self._body(self.superuser, path))
+
+    def test_generated_report_carries_no_private_note(self):
+        response = self._client(self.colleague).post(
+            f"/api/v2/tests/{self.test.id}/generate_report/",
+            {"include_finding_notes": True}, format="json",
+        )
+        self.assertEqual(200, response.status_code, response.content[:300])
+        self.assertNotIn(PRIVATE, response.content.decode())

--- a/unittests/test_apiv2_note_visibility.py
+++ b/unittests/test_apiv2_note_visibility.py
@@ -7,6 +7,7 @@ received every note attached to it, including notes another user had marked
 private. ``NoteSerializer`` now filters through ``VisibleNotesSerializer``.
 """
 
+from django.test import Client
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
@@ -21,6 +22,7 @@ from dojo.models import (
     Test,
     Test_Type,
 )
+from dojo.notes.helper import visible_notes
 
 from .dojo_test_case import DojoAPITestCase
 
@@ -80,6 +82,11 @@ class NoteVisibilityAPITest(DojoAPITestCase):
         client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
         return client
 
+    def client_for(self, user):
+        client = Client()
+        client.force_login(user)
+        return client
+
     def _paths(self):
         return [
             f"/api/v2/findings/{self.finding.id}/",
@@ -118,3 +125,32 @@ class NoteVisibilityAPITest(DojoAPITestCase):
         )
         self.assertEqual(200, response.status_code, response.content[:300])
         self.assertNotIn(PRIVATE, response.content.decode())
+
+
+class NoteVisibilityHelperTest(NoteVisibilityAPITest):
+
+    """The rule itself, which the UI views share with the serializer."""
+
+    def _entries(self, user):
+        return {n.entry for n in visible_notes(self.finding.notes.all(), user)}
+
+    def test_author_sees_both(self):
+        self.assertEqual({PRIVATE, PUBLIC}, self._entries(self.author))
+
+    def test_colleague_sees_only_public(self):
+        self.assertEqual({PUBLIC}, self._entries(self.colleague))
+
+    def test_superuser_sees_both(self):
+        self.assertEqual({PRIVATE, PUBLIC}, self._entries(self.superuser))
+
+    def test_no_user_sees_only_public(self):
+        self.assertEqual({PUBLIC}, self._entries(None))
+
+    def test_ui_context_is_filtered(self):
+        """The finding page hands the template the same filtered set."""
+        response = self.client_for(self.colleague).get(f"/finding/{self.finding.id}")
+        if response.status_code != 200:
+            self.skipTest(f"classic UI not reachable here (HTTP {response.status_code})")
+        entries = {n.entry for n in response.context["notes"]}
+        self.assertNotIn(PRIVATE, entries)
+        self.assertIn(PUBLIC, entries)

--- a/unittests/test_apiv2_prefetch_rbac.py
+++ b/unittests/test_apiv2_prefetch_rbac.py
@@ -214,8 +214,7 @@ class PrefetchRBACTest(DojoAPITestCase):
     def test_reader_cannot_prefetch_private_note_from_other_author(self):
         """
         Sub-vector 4e -- a private note written by someone else must not be
-        returned to a non-superuser via prefetch (matches the existing UI
-        behaviour where ``notes.filter(private=False)`` hides them).
+        returned to a non-superuser via prefetch.
         """
         resp = self._client(self.reader_token).get(
             f"/api/v2/findings/{self.finding.pk}/?prefetch=notes",


### PR DESCRIPTION
Follow-up to #15570, which scoped notes to their author on the API. This does the same for the UI, so the flag means one thing everywhere.

**Stacked on #15570.** The diff below includes that PR's commit until it merges; the second commit is the one to review here.

What changes:

- The notes tab on Findings, Tests, Engagements and Risk Acceptances no longer shows you notes other people marked private.
- Same for the note popover and note counts on the findings tables, which read the relation straight off the model and so were missed by the view-level filter.
- The rule now lives in one place, `dojo.notes.helper.visible_notes`, used by the serializer, the views and a new `visible_to` template filter. It was spread across several hand-written filters before, which is how the API and the UI came to disagree.
- The `private` field gets `help_text` (migration 0290), so the checkbox explains itself instead of relying on the caption underneath. The caption changes from "(will not appear in report)" to "(private to you)", and the docs sentence is updated to match.

Note-type availability deliberately keeps the unfiltered set: a single-use note type someone else used privately is still taken, and offering it would only fail on save.

**This is a visible behaviour change and needs a release note.** Notes people could previously read on these pages will disappear, and note counts will get smaller. Nothing is deleted; those users just cannot see them any more. Superusers are unaffected, and public notes are unchanged.
