### PR TITLE
fix(engagement): re-home finding endpoints/locations when moving or copying to a new product

### DIFF
--- a/dojo/endpoint/models.py
+++ b/dojo/endpoint/models.py
@@ -73,6 +73,21 @@ class Endpoint_Status(models.Model):
         current_endpoint = self.endpoint
         if finding:
             copy.finding = finding
+            # Re-home the endpoint onto the copied finding's product. An Endpoint carries
+            # its own product FK, so reusing the source endpoint would leave a finding
+            # copied/moved into another product pointing at the source product's endpoint.
+            new_product = finding.test.engagement.product
+            if current_endpoint.product_id is not None and current_endpoint.product_id != new_product.id:
+                from dojo.endpoint.utils import endpoint_get_or_create  # noqa: PLC0415 -- avoid import cycle
+                current_endpoint, _ = endpoint_get_or_create(
+                    protocol=current_endpoint.protocol,
+                    host=current_endpoint.host,
+                    port=current_endpoint.port,
+                    path=current_endpoint.path,
+                    query=current_endpoint.query,
+                    fragment=current_endpoint.fragment,
+                    product=new_product,
+                )
         copy.endpoint = current_endpoint
         copy.save()
 

--- a/dojo/engagement/api/views.py
+++ b/dojo/engagement/api/views.py
@@ -13,6 +13,7 @@ from dojo.api_v2 import serializers as api_v2_serializers
 from dojo.api_v2.prefetch.prefetcher import _Prefetcher
 from dojo.api_v2.views import DojoModelViewSet, PrefetchDojoModelViewSet, report_generate_response, schema_with_prefetch
 from dojo.authorization import api_permissions as permissions
+from dojo.authorization.authorization import user_has_permission_or_403
 from dojo.celery_dispatch import dojo_dispatch_task
 from dojo.engagement.api.filters import ApiEngagementFilter
 from dojo.engagement.api.serializer import (
@@ -23,7 +24,7 @@ from dojo.engagement.api.serializer import (
     EngagementToNotesSerializer,
 )
 from dojo.engagement.queries import get_authorized_engagements
-from dojo.engagement.services import close_engagement, reopen_engagement
+from dojo.engagement.services import close_engagement, reassign_engagement_product_endpoints, reopen_engagement
 from dojo.jira import services as jira_services
 from dojo.models import (
     Check_List,
@@ -65,6 +66,22 @@ class EngagementViewSet(
     @property
     def risk_application_model_class(self):
         return Engagement
+
+    def perform_update(self, serializer):
+        # Moving an engagement to a different product must re-home its findings'
+        # endpoints/locations onto the new product, mirroring the Classic UI
+        # edit_engagement view. Covers PUT and PATCH (both route through here) and,
+        # via inheritance, the Pro Vue UI which moves engagements over this same path.
+        old_product = serializer.instance.product
+        # validated_data omits "product" on a PATCH that doesn't touch it -> no move.
+        new_product = serializer.validated_data.get("product", old_product)
+        if new_product != old_product:
+            # Destination-product edit check, mirroring the Classic edit_engagement view.
+            user_has_permission_or_403(self.request.user, new_product, "edit")
+        engagement = serializer.save()
+        if new_product != old_product:
+            # calculate_grade for both products is dispatched by the service itself.
+            reassign_engagement_product_endpoints(engagement, old_product, new_product)
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/dojo/engagement/services.py
+++ b/dojo/engagement/services.py
@@ -1,6 +1,7 @@
 # #  engagements
 import logging
 
+from django.conf import settings
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.urls import reverse
@@ -52,6 +53,68 @@ def copy_engagement(engagement, user):
         icon="exclamation-triangle",
     )
     return engagement_copy
+
+
+def reassign_engagement_product_endpoints(engagement, old_product, new_product):
+    """
+    Re-home the endpoints (legacy) or locations (V3) of an engagement's findings onto
+    new_product after the engagement has been moved there.
+
+    An endpoint/location carries its own product association, independent of the
+    finding -> test -> engagement -> product chain, so moving an engagement between
+    products would otherwise leave the findings' endpoints/locations pointing at the
+    source product. HTTP-free so both the UI view and the API can call it.
+    """
+    if old_product == new_product:
+        return
+
+    if settings.V3_FEATURE_LOCATIONS:
+        from dojo.location.models import Location, LocationFindingReference  # noqa: PLC0415 -- avoid import cycle
+        # Distinct locations referenced by this engagement's findings
+        location_ids = set(
+            LocationFindingReference.objects.filter(
+                finding__test__engagement=engagement,
+            ).values_list("location_id", flat=True),
+        )
+        for location in Location.objects.filter(id__in=location_ids):
+            location.associate_with_product(new_product)
+            # Drop the stale source-product association only if no finding remaining in
+            # the old product still references this (shared) location.
+            still_used = LocationFindingReference.objects.filter(
+                location=location,
+                finding__test__engagement__product=old_product,
+            ).exists()
+            if not still_used:
+                location.disassociate_from_product(old_product)
+    else:
+        # TODO: Delete this after the move to Locations
+        from dojo.endpoint.utils import endpoint_get_or_create  # noqa: PLC0415 -- avoid import cycle
+        from dojo.models import Endpoint_Status  # noqa: PLC0415 -- avoid import cycle
+        statuses = Endpoint_Status.objects.filter(
+            finding__test__engagement=engagement,
+        ).select_related("endpoint")
+        # Cache re-homed endpoints so an endpoint shared across many findings is only
+        # get_or_create'd once for the destination product.
+        rehomed = {}
+        for status in statuses:
+            endpoint = status.endpoint
+            if endpoint.product_id == new_product.id:
+                continue
+            key = (endpoint.protocol, endpoint.host, endpoint.port, endpoint.path, endpoint.query, endpoint.fragment)
+            new_endpoint = rehomed.get(key)
+            if new_endpoint is None:
+                new_endpoint, _ = endpoint_get_or_create(
+                    protocol=endpoint.protocol,
+                    host=endpoint.host,
+                    port=endpoint.port,
+                    path=endpoint.path,
+                    query=endpoint.query,
+                    fragment=endpoint.fragment,
+                    product=new_product,
+                )
+                rehomed[key] = new_endpoint
+            status.endpoint = new_endpoint
+            status.save()
 
 
 @receiver(pre_save, sender=Engagement)

--- a/dojo/engagement/services.py
+++ b/dojo/engagement/services.py
@@ -69,7 +69,11 @@ def reassign_engagement_product_endpoints(engagement, old_product, new_product):
         return
 
     if settings.V3_FEATURE_LOCATIONS:
-        from dojo.location.models import Location, LocationFindingReference  # noqa: PLC0415 -- avoid import cycle
+        from dojo.location.models import (  # noqa: PLC0415 -- avoid import cycle
+            Location,
+            LocationFindingReference,
+            LocationProductReference,
+        )
         # Distinct locations referenced by this engagement's findings
         location_ids = set(
             LocationFindingReference.objects.filter(
@@ -77,14 +81,27 @@ def reassign_engagement_product_endpoints(engagement, old_product, new_product):
             ).values_list("location_id", flat=True),
         )
         for location in Location.objects.filter(id__in=location_ids):
-            location.associate_with_product(new_product)
-            # Drop the stale source-product association only if no finding remaining in
-            # the old product still references this (shared) location.
+            # Associate with the destination product and (re)assess its status, since an
+            # already-existing reference is returned without recomputation.
+            new_ref = location.associate_with_product(new_product)
+            new_ref.status = location.status_from_product(new_product)
+            new_ref.save(update_fields=["status"])
+            # For the source product: drop the association if no finding remaining there
+            # references this (shared) location, otherwise reassess its status because the
+            # moved finding no longer counts toward the old product.
             still_used = LocationFindingReference.objects.filter(
                 location=location,
                 finding__test__engagement__product=old_product,
             ).exists()
-            if not still_used:
+            if still_used:
+                old_ref = LocationProductReference.objects.filter(
+                    location=location,
+                    product=old_product,
+                ).first()
+                if old_ref is not None:
+                    old_ref.status = location.status_from_product(old_product)
+                    old_ref.save(update_fields=["status"])
+            else:
                 location.disassociate_from_product(old_product)
     else:
         # TODO: Delete this after the move to Locations
@@ -115,6 +132,11 @@ def reassign_engagement_product_endpoints(engagement, old_product, new_product):
                 rehomed[key] = new_endpoint
             status.endpoint = new_endpoint
             status.save()
+
+    # Findings moved between products change the aggregate grade of both, so recompute
+    # the grade for the source and destination product.
+    dojo_dispatch_task(calculate_grade, old_product.id)
+    dojo_dispatch_task(calculate_grade, new_product.id)
 
 
 @receiver(pre_save, sender=Engagement)

--- a/dojo/engagement/ui/views.py
+++ b/dojo/engagement/ui/views.py
@@ -45,6 +45,7 @@ from dojo.endpoint.utils import save_endpoints_to_add
 from dojo.engagement.queries import get_authorized_engagements
 from dojo.engagement.services import (
     close_engagement,
+    reassign_engagement_product_endpoints,
     reopen_engagement,
 )
 from dojo.engagement.services import (
@@ -291,13 +292,16 @@ def edit_engagement(request, eid):
         if form.is_valid():
             # first save engagement details
             new_status = form.cleaned_data.get("status")
-            if form.cleaned_data.get("product") != engagement.product:
+            old_product = engagement.product
+            new_product = form.cleaned_data.get("product")
+            product_changed = new_product != old_product
+            if product_changed:
                 user_has_permission_or_403(
                     request.user,
-                    form.cleaned_data.get("product"),
+                    new_product,
                     "edit",
                 )
-            engagement.product = form.cleaned_data.get("product")
+            engagement.product = new_product
             engagement = form.save(commit=False)
             if (new_status in {"Cancelled", "Completed"}):
                 engagement.active = False
@@ -305,6 +309,10 @@ def edit_engagement(request, eid):
                 engagement.active = True
             engagement.save()
             form.save_m2m()
+            # When the engagement moves to a different product, re-home its findings'
+            # endpoints/locations onto the new product so they no longer reference the old one.
+            if product_changed:
+                reassign_engagement_product_endpoints(engagement, old_product, new_product)
 
             messages.add_message(
                 request,

--- a/dojo/location/models.py
+++ b/dojo/location/models.py
@@ -537,6 +537,10 @@ class LocationFindingReference(BaseModel, ReferenceDataMixin):
         copy.finding = finding
         copy.location = self.location
         copy.save()
+        # Re-home the shared location onto the copied finding's product. Without this a
+        # finding copied/moved into a different product keeps a location that is only
+        # associated with the source product. Mirrors associate_with_finding().
+        copy.location.associate_with_product(finding.test.engagement.product)
         return copy
 
     def set_status(self, status: FindingLocationStatus, auditor: Dojo_User, audit_time: datetime) -> None:

--- a/unittests/test_apiv2_engagement.py
+++ b/unittests/test_apiv2_engagement.py
@@ -1,0 +1,172 @@
+"""
+API-level regression tests for moving an engagement to a different product via the
+REST API (PATCH/PUT /api/v2/engagements/{id}/).
+
+Moving an engagement between products must re-home the endpoints (legacy) or locations
+(V3) of that engagement's findings onto the destination product, exactly as the Classic
+UI edit_engagement view does. The Pro Vue UI drives this same API path (its engagement
+viewsets inherit the OSS EngagementViewSet without overriding update/perform_update), so
+wiring the behaviour into the OSS viewset covers Pro too. The move also has to enforce an
+edit-permission check on the destination product.
+"""
+from unittest.mock import patch
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from dojo.location.models import LocationProductReference
+from dojo.models import (
+    Dojo_User,
+    Endpoint,
+    Endpoint_Status,
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+)
+from dojo.url.models import URL
+
+from .dojo_test_case import DojoTestCase, skip_unless_v2, skip_unless_v3
+
+PASSWORD = "testTEST1234!@#$"
+
+
+class TestMoveEngagementProductAPI(DojoTestCase):
+
+    """
+    Moving an engagement to a different product through the REST API must trigger the
+    same endpoint/location re-homing as the Classic UI, and must reject a move to a
+    destination product the user cannot edit.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.product_type = Product_Type.objects.create(name="eng_move_api_pt")
+        cls.product_a = Product.objects.create(
+            name="eng_move_api_a", description="a", prod_type=cls.product_type,
+        )
+        cls.product_b = Product.objects.create(
+            name="eng_move_api_b", description="b", prod_type=cls.product_type,
+        )
+
+        # Superuser drives the happy-path moves (tests 1, 2, 4).
+        cls.admin = Dojo_User.objects.create_user(
+            username="eng_move_api_admin", password=PASSWORD, is_active=True,
+            is_superuser=True, is_staff=True,
+        )
+        cls.admin_token = Token.objects.create(user=cls.admin)
+
+        # A user authorized on the source product only, used to prove a move to a
+        # destination product the user cannot access is rejected (test 3). Legacy OSS
+        # authorization keys off product.authorized_users (there is no per-role add/edit
+        # split); the same membership grants view+edit on product A but nothing on B.
+        cls.limited = Dojo_User.objects.create_user(
+            username="eng_move_api_limited", password=PASSWORD, is_active=True,
+        )
+        cls.product_a.authorized_users.add(cls.limited)
+        cls.limited_token = Token.objects.create(user=cls.limited)
+
+    def _engagement_with_finding(self):
+        now = timezone.now()
+        engagement = Engagement.objects.create(
+            name="eng_move_api_eng", product=self.product_a,
+            target_start=now, target_end=now,
+        )
+        test = Test.objects.create(
+            engagement=engagement, scan_type="NPM Audit Scan",
+            test_type=Test_Type.objects.get(name="NPM Audit Scan"),
+            target_start=now, target_end=now,
+        )
+        finding = Finding.objects.create(test=test, reporter=self.admin)
+        return engagement, finding
+
+    def _client(self, token):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+        return client
+
+    def _move_url(self, engagement):
+        return reverse("engagement-detail", args=[engagement.id])
+
+    # TODO: Delete this after the move to Locations
+    @skip_unless_v2
+    def test_api_move_engagement_rehomes_endpoints(self):
+        engagement, finding = self._engagement_with_finding()
+        endpoint = Endpoint.from_uri("host-a.example.com")
+        endpoint.product = self.product_a
+        endpoint.save()
+        endpoint_status = Endpoint_Status.objects.create(finding=finding, endpoint=endpoint)
+
+        client = self._client(self.admin_token)
+        response = client.patch(
+            self._move_url(engagement), {"product": self.product_b.id}, format="json",
+        )
+        self.assertEqual(200, response.status_code, response.content[:1000])
+
+        # The finding's endpoint status now points at an endpoint in the destination product.
+        endpoint_status.refresh_from_db()
+        self.assertEqual(self.product_b, endpoint_status.endpoint.product)
+        # The original source endpoint row is untouched (still in product A).
+        endpoint.refresh_from_db()
+        self.assertEqual(self.product_a, endpoint.product)
+
+    @skip_unless_v3
+    def test_api_move_engagement_rehomes_locations(self):
+        engagement, finding = self._engagement_with_finding()
+        url = URL(host="host-a.example.com")
+        url.save()
+        location = url.location
+        location.associate_with_finding(finding=finding)
+        self.assertTrue(
+            LocationProductReference.objects.filter(location=location, product=self.product_a).exists(),
+        )
+
+        client = self._client(self.admin_token)
+        response = client.patch(
+            self._move_url(engagement), {"product": self.product_b.id}, format="json",
+        )
+        self.assertEqual(200, response.status_code, response.content[:1000])
+
+        # The location is now associated with the destination product, and the stale
+        # source association is dropped since no finding there still references it.
+        self.assertTrue(
+            LocationProductReference.objects.filter(location=location, product=self.product_b).exists(),
+        )
+        self.assertFalse(
+            LocationProductReference.objects.filter(location=location, product=self.product_a).exists(),
+        )
+
+    def test_api_move_engagement_requires_destination_edit_permission(self):
+        engagement, _finding = self._engagement_with_finding()
+
+        client = self._client(self.limited_token)
+        response = client.patch(
+            self._move_url(engagement), {"product": self.product_b.id}, format="json",
+        )
+        # No edit permission on the destination product -> forbidden.
+        self.assertEqual(403, response.status_code, response.content[:1000])
+        # The engagement's product is unchanged.
+        engagement.refresh_from_db()
+        self.assertEqual(self.product_a, engagement.product)
+
+    def test_api_patch_without_product_change_does_no_rehoming(self):
+        # A PATCH that does not touch product must not run any endpoint/location
+        # re-homing (and must not blow up on the missing "product" in validated_data).
+        engagement, _finding = self._engagement_with_finding()
+
+        client = self._client(self.admin_token)
+        with patch(
+            "dojo.engagement.api.views.reassign_engagement_product_endpoints",
+        ) as mock_reassign:
+            response = client.patch(
+                self._move_url(engagement), {"name": "renamed-no-move"}, format="json",
+            )
+        self.assertEqual(200, response.status_code, response.content[:1000])
+        mock_reassign.assert_not_called()
+        engagement.refresh_from_db()
+        self.assertEqual(self.product_a, engagement.product)
+        self.assertEqual("renamed-no-move", engagement.name)

--- a/unittests/test_copy_model.py
+++ b/unittests/test_copy_model.py
@@ -3,9 +3,11 @@ from unittest.mock import patch
 
 from dojo.engagement.services import copy_engagement, reassign_engagement_product_endpoints
 from dojo.location.models import Location, LocationFindingReference, LocationProductReference
+from dojo.location.status import ProductLocationStatus
 from dojo.models import Endpoint, Endpoint_Status, Engagement, Finding, Product, Test, User
 from dojo.test.services import copy_test
 from dojo.url.models import URL
+from dojo.utils import calculate_grade
 
 from .dojo_test_case import DojoTestCase, skip_unless_v2, skip_unless_v3
 
@@ -526,3 +528,44 @@ class TestMoveEngagementProduct(DojoTestCase):
         # old-product association is removed since no finding there references it
         self.assertTrue(LocationProductReference.objects.filter(location=location, product=product_b).exists())
         self.assertFalse(LocationProductReference.objects.filter(location=location, product=product_a).exists())
+
+    @patch("dojo.engagement.services.dojo_dispatch_task")
+    def test_move_engagement_recomputes_grade_for_both_products(self, mock_dispatch):
+        # Moving findings between products changes both products' aggregate grade, so the
+        # move must recompute the grade for the source and destination product.
+        _user, product_a, product_b, engagement, _finding = self._setup()
+        self._move(engagement, product_a, product_b)
+        graded_product_ids = {
+            call.args[1]
+            for call in mock_dispatch.call_args_list
+            if call.args and call.args[0] is calculate_grade
+        }
+        self.assertIn(product_a.id, graded_product_ids)
+        self.assertIn(product_b.id, graded_product_ids)
+
+    @skip_unless_v3
+    def test_move_engagement_reassesses_shared_old_product_location_status(self):
+        # A location shared with another finding that stays in the old product must keep
+        # its old-product association, but its status must be reassessed: moving the only
+        # active finding out flips the old product's location status to Mitigated.
+        user, product_a, product_b, engagement, active_finding = self._setup()
+        # A second, mitigated finding in the old product (different engagement) sharing the location
+        other_engagement = self.create_engagement("mv_eng_other", product_a)
+        other_test = self.create_test(engagement=other_engagement, scan_type="NPM Audit Scan", title="mv_test2")
+        mitigated_finding = Finding.objects.create(test=other_test, reporter=user, active=False, is_mitigated=True)
+        url = URL(host="host-a.example.com")
+        url.save()
+        location = url.location
+        location.associate_with_finding(finding=active_finding)
+        location.associate_with_finding(finding=mitigated_finding)
+        # Before the move the old product's location status is Active (the active finding)
+        old_ref = LocationProductReference.objects.get(location=location, product=product_a)
+        self.assertEqual(ProductLocationStatus.Active, old_ref.status)
+        # Move the engagement holding the active finding to product B
+        self._move(engagement, product_a, product_b)
+        # Old product keeps the association (mitigated finding still references it) but is reassessed
+        old_ref.refresh_from_db()
+        self.assertEqual(ProductLocationStatus.Mitigated, old_ref.status)
+        # New product now carries the active status
+        new_ref = LocationProductReference.objects.get(location=location, product=product_b)
+        self.assertEqual(ProductLocationStatus.Active, new_ref.status)

--- a/unittests/test_copy_model.py
+++ b/unittests/test_copy_model.py
@@ -1,8 +1,8 @@
 
 from unittest.mock import patch
 
-from dojo.engagement.services import copy_engagement
-from dojo.location.models import Location, LocationFindingReference
+from dojo.engagement.services import copy_engagement, reassign_engagement_product_endpoints
+from dojo.location.models import Location, LocationFindingReference, LocationProductReference
 from dojo.models import Endpoint, Endpoint_Status, Engagement, Finding, Product, Test, User
 from dojo.test.services import copy_test
 from dojo.url.models import URL
@@ -419,3 +419,110 @@ class TestCopyEngagementService(DojoTestCase):
         mock_dispatch.assert_called_once()
         mock_notification.assert_called_once()
         self.assertEqual(mock_notification.call_args.kwargs["event"], "engagement_copied")
+
+
+class TestCopyFindingCrossProduct(DojoTestCase):
+
+    """
+    Copying a finding into a test in a different product must re-home the finding's
+    endpoints/locations onto the destination product, not leave them pointing at the
+    source product.
+    """
+
+    def _two_products(self):
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type("xprod_type")
+        product_a = self.create_product("xprod_a", prod_type=product_type)
+        product_b = self.create_product("xprod_b", prod_type=product_type)
+        engagement_a = self.create_engagement("xeng_a", product_a)
+        engagement_b = self.create_engagement("xeng_b", product_b)
+        test_a = self.create_test(engagement=engagement_a, scan_type="NPM Audit Scan", title="test_a")
+        test_b = self.create_test(engagement=engagement_b, scan_type="NPM Audit Scan", title="test_b")
+        return user, product_a, product_b, test_a, test_b
+
+    # TODO: Delete this after the move to Locations
+    @skip_unless_v2
+    def test_copy_finding_to_other_product_rehomes_endpoint(self):
+        user, product_a, product_b, test_a, test_b = self._two_products()
+        endpoint = Endpoint.from_uri("host-a.example.com")
+        endpoint.product = product_a
+        endpoint.save()
+        finding = Finding.objects.create(test=test_a, reporter=user)
+        Endpoint_Status.objects.create(finding=finding, endpoint=endpoint)
+        # Copy the finding into product B's test
+        finding_copy = finding.copy(test=test_b)
+        # The copied finding's endpoint must belong to the destination product
+        copied_status = finding_copy.status_finding.all().first()
+        self.assertIsNotNone(copied_status)
+        self.assertEqual(product_b, copied_status.endpoint.product)
+        # The original endpoint (and finding) is untouched
+        endpoint.refresh_from_db()
+        self.assertEqual(product_a, endpoint.product)
+
+    @skip_unless_v3
+    def test_copy_finding_to_other_product_rehomes_location(self):
+        user, product_a, product_b, test_a, test_b = self._two_products()
+        finding = Finding.objects.create(test=test_a, reporter=user)
+        url = URL(host="host-a.example.com")
+        url.save()
+        location = url.location
+        location.associate_with_finding(finding=finding)
+        # Sanity: the location is associated with product A only
+        self.assertTrue(LocationProductReference.objects.filter(location=location, product=product_a).exists())
+        self.assertFalse(LocationProductReference.objects.filter(location=location, product=product_b).exists())
+        # Copy the finding into product B's test
+        finding.copy(test=test_b)
+        # The shared location is now also associated with the destination product
+        self.assertTrue(LocationProductReference.objects.filter(location=location, product=product_b).exists())
+
+
+class TestMoveEngagementProduct(DojoTestCase):
+
+    """
+    Moving an engagement to a different product must re-home the endpoints/locations of
+    that engagement's findings onto the new product.
+    """
+
+    def _setup(self):
+        user, _ = User.objects.get_or_create(username="admin")
+        product_type = self.create_product_type("mv_prod_type")
+        product_a = self.create_product("mv_prod_a", prod_type=product_type)
+        product_b = self.create_product("mv_prod_b", prod_type=product_type)
+        engagement = self.create_engagement("mv_eng", product_a)
+        test = self.create_test(engagement=engagement, scan_type="NPM Audit Scan", title="mv_test")
+        finding = Finding.objects.create(test=test, reporter=user)
+        return user, product_a, product_b, engagement, finding
+
+    def _move(self, engagement, old_product, new_product):
+        engagement.product = new_product
+        engagement.save()
+        reassign_engagement_product_endpoints(engagement, old_product, new_product)
+
+    # TODO: Delete this after the move to Locations
+    @skip_unless_v2
+    def test_move_engagement_rehomes_endpoints(self):
+        _user, product_a, product_b, engagement, finding = self._setup()
+        endpoint = Endpoint.from_uri("host-a.example.com")
+        endpoint.product = product_a
+        endpoint.save()
+        endpoint_status = Endpoint_Status.objects.create(finding=finding, endpoint=endpoint)
+        # Move the engagement to product B
+        self._move(engagement, product_a, product_b)
+        # The finding's endpoint status now points at an endpoint in the new product
+        endpoint_status.refresh_from_db()
+        self.assertEqual(product_b, endpoint_status.endpoint.product)
+
+    @skip_unless_v3
+    def test_move_engagement_rehomes_locations(self):
+        _user, product_a, product_b, engagement, finding = self._setup()
+        url = URL(host="host-a.example.com")
+        url.save()
+        location = url.location
+        location.associate_with_finding(finding=finding)
+        self.assertTrue(LocationProductReference.objects.filter(location=location, product=product_a).exists())
+        # Move the engagement to product B
+        self._move(engagement, product_a, product_b)
+        # The location is now associated with the new product, and the stale
+        # old-product association is removed since no finding there references it
+        self.assertTrue(LocationProductReference.objects.filter(location=location, product=product_b).exists())
+        self.assertFalse(LocationProductReference.objects.filter(location=location, product=product_a).exists())


### PR DESCRIPTION
[sc-14342]

## Problem

Multiple user reports describe that after **moving or cloning an engagement to a different product**, the endpoints on that engagement's findings still point at the **original** product. The finding appears under the new product, but its endpoint (and, under the V3 Locations feature, its location) remains associated with the old one.

### Root cause

An `Endpoint` (legacy) and a `Location` (V3) each carry their **own** product association, independent of the `Finding → Test → Engagement → Product` chain, and none of the copy/move code paths updated it:

- `Endpoint_Status.copy()` re-linked the copy to the **same** `Endpoint` row (old product's endpoint).
- `LocationFindingReference.copy()` re-linked to the **same** `Location`, never creating a `LocationProductReference` for the destination product.
- `edit_engagement` changed only `engagement.product`; it never walked the findings to re-home their endpoints/locations.
- The REST API move path (`PUT`/`PATCH /api/v2/engagements/{id}/` with a new product) never re-homed anything either — the fix had only been wired into the Classic UI view.

## Fix

Covers **both paths** (legacy Endpoint and V3 Locations) across **move**, **clone-engagement**, and **copy-test / copy-finding**:

- **Locations copy** — `LocationFindingReference.copy()` now associates the shared location with the copied finding's product via the existing `Location.associate_with_product()`, mirroring `associate_with_finding()`.
- **Legacy copy** — `Endpoint_Status.copy()` `endpoint_get_or_create`s an equivalent endpoint in the destination product, but **only when the copy actually crosses products** (the common same-product clone path is unchanged, so no extra queries there).
- **Move (Classic UI)** — a new HTTP-free `reassign_engagement_product_endpoints()` service in `dojo/engagement/services.py`, called from `edit_engagement` when the product changes. It dedupes by distinct location / caches re-homed endpoints to avoid redundant lookups, and drops the stale source-product location association when no finding there still references it.
- **Move (REST API)** — `EngagementViewSet.perform_update()` now runs the same `reassign_engagement_product_endpoints()` on a product change, so `PUT` **and** `PATCH` trigger the re-homing, and enforces an edit-permission check on the destination product mirroring the Classic view. The **Pro Vue UI** moves engagements over this same API path and its engagement viewsets inherit the OSS `EngagementViewSet` without overriding `update`/`perform_update`, so this fixes the Pro UI with **no Pro-side change**.

`Endpoint.product` is never mutated directly, preserving the existing guard that blocks changing an endpoint's product via the API (`test_endpoint_change_product`).

## Testing

- New cross-product **copy** and **move** tests for both the legacy (`skip_unless_v2`) and Locations (`skip_unless_v3`) paths in `unittests/test_copy_model.py`. Confirmed red before the fix (missing destination-product association), green after.
- New **API-level** move tests in `unittests/test_apiv2_engagement.py`, driven through `APIClient`: a `PATCH` product move re-homes the finding's endpoint (v2) / location (v3) onto the destination product while leaving the source row/association correct; a user without edit permission on the destination product gets `403` and the engagement's product is unchanged; and a `PATCH` that doesn't touch product does no endpoint/location work. Confirmed red before the fix, green after, in **both** v2 and v3 modes.
- `unittests.test_copy_model` passes in **both** v2 and v3 modes.
- Regression: `test_apiv2_endpoint` (incl. `test_endpoint_change_product`), `test_endpoint_model`, endpoint/location authz suites, `test_finding_model`, `test_bulk_locations`, edit-finding-endpoint suites all pass. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8Y2cCrkjhV3QxY4o6j1sr
