### PR TITLE
docs(triage): document the Root Cause API endpoints

### DIFF
--- a/docs/content/triage_findings/finding_correlation/PRO__root_cause_correlation.md
+++ b/docs/content/triage_findings/finding_correlation/PRO__root_cause_correlation.md
@@ -247,6 +247,36 @@ python manage.py recompute_correlations
 python manage.py recompute_correlations --product-id 42
 ```
 
+## What the API exposes
+
+Root Causes are readable over the standard API, so you can pull them into a report, open tickets
+from them, or track them as a metric without going through the UI.
+
+- `GET /api/v2/root_causes/` lists them, ranked the same way the page is.
+- `GET /api/v2/root_causes/{id}/` returns one Root Cause plus its member Findings, each with the
+  evidence that links it and whether the match was exact or heuristic.
+
+Both are read-only. Confirming, rejecting and muting are done from the UI for now; those are
+deliberately not published while the feature is in Beta, so that adding them later cannot break
+anything you have already built against.
+
+Filters on the list: `cause_type` (`exact` or `in`), `muted`, `identity_key` (`exact` or
+`icontains`) and `display_name__icontains`.
+
+Two behaviors worth knowing before you script against it:
+
+- **Counts are scoped to the token's access**, exactly as they are in the UI. Two tokens with
+  different Product access will report different `active_member_count`, `product_count` and
+  `risk_score` for the same Root Cause. This is intended -- the numbers describe what *that*
+  caller can see -- so do not treat them as portfolio-wide totals.
+- **Covered CVE causes are left out of the list** but are always retrievable by id. Pass
+  `?include_subsumed=true` to include them; a Root Cause id you stored earlier keeps working
+  through `GET /api/v2/root_causes/{id}/` even after it becomes covered. Each covered cause
+  carries `subsumed_by_id` and `subsumed_by_name` so you can see which fix clears it.
+
+If the feature flag is off, both endpoints return **403**, not 404 -- the endpoint exists, it is
+simply not enabled.
+
 ## Interaction with Global Component Deduplication
 
 [Global Component Deduplication](/triage_findings/finding_deduplication/pro__global_component_deduplication/)


### PR DESCRIPTION
## What

Documents the Root Cause REST endpoints added in DefectDojo Pro, on the existing Root Cause
Correlation page under **What the API exposes** — the same shape the Risk Acceptance page uses.

## Why

Root Causes became readable over `/api/v2/` but the page still described the feature as
UI-only, so there was no way to discover that pulling them into a report, a ticket-creation
pipeline or a metrics job is possible.

## Covers

- `GET /api/v2/root_causes/` and `GET /api/v2/root_causes/{id}/`, and the available filters.
- That the surface is **read-only** while the feature is in Beta — publishing the feedback
  actions later cannot then break anything built against it.
- **Counts are scoped to the calling token's access.** Two tokens with different Product access
  legitimately report different numbers for the same Root Cause, so they must not be read as
  portfolio-wide totals. This is the same contract the UI has, but it is far more surprising to a
  script.
- **Covered CVE causes are omitted from the list but always retrievable by id**, so an id stored
  earlier keeps working after that cause becomes covered. `include_subsumed=true` brings them
  back, each naming the cause that covers it.
- A disabled feature flag answers **403, not 404**, so a caller can tell "not enabled" from
  "wrong URL".

## Notes

- Documentation only — no code changes.
- In-page anchors re-validated.
