### PR TITLE
fix(notes): apply the private-note rule to an already-evaluated list

### DIFF
--- a/dojo/notes/helper.py
+++ b/dojo/notes/helper.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db.models import Prefetch, Q
+from django.db.models import Manager, Prefetch, Q, QuerySet
 
 from dojo.notes.models import NoteHistory, Notes
 
@@ -30,11 +30,20 @@ def visible_notes(notes, user):
     Every read path goes through here, so the API and the UI cannot drift apart
     on what ``private`` means. A caller with no user (report rendering) gets the
     non-private notes only.
+
+    ``notes`` does not always still carry a query. A DRF list serializer is
+    handed the paginated page, which is a plain list, and a ``to_attr``
+    prefetch yields one too. Those are filtered in Python; a queryset is still
+    narrowed in the database, so callers that go on to count or slice the
+    result keep doing that in one query.
     """
+    if user is not None and user.is_superuser:
+        return notes
+    if not isinstance(notes, (Manager, QuerySet)):
+        author_id = getattr(user, "pk", None)
+        return [note for note in notes if not note.private or note.author_id == author_id]
     if user is None:
         return notes.filter(private=False)
-    if user.is_superuser:
-        return notes
     return notes.filter(Q(private=False) | Q(author=user))
 
 

--- a/unittests/test_apiv2_note_visibility.py
+++ b/unittests/test_apiv2_note_visibility.py
@@ -12,8 +12,9 @@ import datetime
 from django.test import Client
 from django.urls import reverse
 from django.utils import timezone
+from parameterized import parameterized
 from rest_framework.authtoken.models import Token
-from rest_framework.test import APIClient
+from rest_framework.test import APIClient, APIRequestFactory
 
 from dojo.models import (
     Dojo_User,
@@ -26,7 +27,8 @@ from dojo.models import (
     Test,
     Test_Type,
 )
-from dojo.notes.helper import visible_notes
+from dojo.notes.api.serializer import NoteSerializer
+from dojo.notes.helper import notes_prefetch, visible_notes
 
 from .dojo_test_case import DojoAPITestCase
 
@@ -159,3 +161,133 @@ class NoteVisibilityTest(DojoAPITestCase):
         entries = {n.entry for n in response.context["notes"]}
         self.assertNotIn(PRIVATE, entries)
         self.assertIn(PUBLIC, entries)
+
+
+# Regression: visible_notes assumed a queryset and called .filter() on it, so a
+# caller that had already evaluated the notes raised AttributeError instead of
+# filtering. A DRF list serializer is exactly that caller -- it is handed the
+# paginated page, which is a list -- so every notes list request answered 500
+# for a non-superuser, and only for a non-superuser, since a superuser returns
+# early before the .filter().
+class MaterialisedNotesTest(DojoAPITestCase):
+
+    """
+    The rule holds whether the notes still carry a query or not.
+
+    Both shapes reach ``visible_notes`` in production: a queryset from the UI
+    views and the un-prefetched relation, a list from the paginated page a list
+    serializer receives. The parameterisation runs every case through both, so a
+    fix that only narrows a queryset cannot pass.
+    """
+
+    SHAPES = [("queryset",), ("list",)]
+    LOADED = [("prefetched",), ("not prefetched",)]
+
+    def setUp(self):
+        self.author, _ = Dojo_User.objects.get_or_create(
+            username="materialised-notes-author",
+            defaults={"is_superuser": False, "is_staff": False},
+        )
+        self.colleague, _ = Dojo_User.objects.get_or_create(
+            username="materialised-notes-colleague",
+            defaults={"is_superuser": False, "is_staff": False},
+        )
+        self.superuser, _ = Dojo_User.objects.get_or_create(
+            username="materialised-notes-super",
+            defaults={"is_superuser": True, "is_staff": True},
+        )
+
+        product_type, _ = Product_Type.objects.get_or_create(name="materialised-notes")
+        product, _ = Product.objects.get_or_create(
+            name="MaterialisedNotesTest", description="Test", prod_type=product_type,
+        )
+        for user in (self.author, self.colleague):
+            product.authorized_users.add(user)
+            Product_Member.objects.get_or_create(
+                product=product, user=user, defaults={"role_id": 4},
+            )
+
+        engagement = Engagement.objects.create(
+            name="materialised notes", product=product,
+            target_start=START, target_end=END,
+        )
+        test_type, _ = Test_Type.objects.get_or_create(name="materialised-notes-tt")
+        test = Test.objects.create(
+            engagement=engagement, test_type=test_type,
+            target_start=timezone.make_aware(datetime.datetime.combine(START, datetime.time())),
+            target_end=timezone.make_aware(datetime.datetime.combine(END, datetime.time())),
+        )
+        self.finding = Finding.objects.create(
+            title="materialised notes finding", test=test, reporter=self.author,
+            severity="Info", numerical_severity="S4",
+        )
+        self.finding.notes.add(Notes.objects.create(entry=PRIVATE, author=self.author, private=True))
+        self.finding.notes.add(Notes.objects.create(entry=PUBLIC, author=self.author, private=False))
+
+    def _shaped(self, shape):
+        """The notes relation as the two kinds of caller hand it over."""
+        queryset = self.finding.notes.all()
+        return list(queryset) if shape == "list" else queryset
+
+    def _relation(self, loading):
+        """The notes relation off a finding fetched with and without the prefetch."""
+        findings = Finding.objects.filter(pk=self.finding.pk)
+        if loading == "prefetched":
+            findings = findings.prefetch_related(notes_prefetch())
+        return findings.get().notes.all()
+
+    def _serialized(self, notes, user):
+        request = APIRequestFactory().get("/api/v2/notes/")
+        request.user = user
+        return {n["entry"] for n in NoteSerializer(notes, many=True, context={"request": request}).data}
+
+    # ---- the helper --------------------------------------------------------
+
+    @parameterized.expand(SHAPES)
+    def test_helper_gives_the_author_both(self, shape):
+        entries = {n.entry for n in visible_notes(self._shaped(shape), self.author)}
+        self.assertEqual({PRIVATE, PUBLIC}, entries, msg=f"{shape} input gave {entries}")
+
+    @parameterized.expand(SHAPES)
+    def test_helper_gives_a_colleague_only_the_public_one(self, shape):
+        entries = {n.entry for n in visible_notes(self._shaped(shape), self.colleague)}
+        self.assertEqual({PUBLIC}, entries, msg=f"{shape} input gave {entries}")
+
+    @parameterized.expand(SHAPES)
+    def test_helper_gives_a_superuser_both(self, shape):
+        entries = {n.entry for n in visible_notes(self._shaped(shape), self.superuser)}
+        self.assertEqual({PRIVATE, PUBLIC}, entries, msg=f"{shape} input gave {entries}")
+
+    @parameterized.expand(SHAPES)
+    def test_helper_without_a_user_gives_only_the_public_one(self, shape):
+        entries = {n.entry for n in visible_notes(self._shaped(shape), None)}
+        self.assertEqual({PUBLIC}, entries, msg=f"{shape} input gave {entries}")
+
+    # ---- the list serializer, which is what actually 500'd -----------------
+
+    @parameterized.expand(SHAPES)
+    def test_serializing_gives_the_author_both(self, shape):
+        entries = self._serialized(self._shaped(shape), self.author)
+        self.assertEqual({PRIVATE, PUBLIC}, entries, msg=f"{shape} input gave {entries}")
+
+    @parameterized.expand(SHAPES)
+    def test_serializing_gives_a_colleague_only_the_public_one(self, shape):
+        entries = self._serialized(self._shaped(shape), self.colleague)
+        self.assertEqual({PUBLIC}, entries, msg=f"{shape} input gave {entries}")
+
+    @parameterized.expand(SHAPES)
+    def test_serializing_gives_a_superuser_both(self, shape):
+        entries = self._serialized(self._shaped(shape), self.superuser)
+        self.assertEqual({PRIVATE, PUBLIC}, entries, msg=f"{shape} input gave {entries}")
+
+    # ---- the prefetched relation, which the API reads on every parent ------
+
+    @parameterized.expand(LOADED)
+    def test_the_prefetch_does_not_change_what_a_colleague_receives(self, loading):
+        entries = self._serialized(self._relation(loading), self.colleague)
+        self.assertEqual({PUBLIC}, entries, msg=f"{loading} relation gave {entries}")
+
+    @parameterized.expand(LOADED)
+    def test_the_prefetch_does_not_change_what_the_author_receives(self, loading):
+        entries = self._serialized(self._relation(loading), self.author)
+        self.assertEqual({PRIVATE, PUBLIC}, entries, msg=f"{loading} relation gave {entries}")


### PR DESCRIPTION
**Description**

`visible_notes()` (`dojo/notes/helper.py`, added in #15570) calls `.filter()` on whatever it is handed, so a caller that has already evaluated the notes gets

```
AttributeError: 'list' object has no attribute 'filter'
```

instead of having them filtered. A DRF list serializer is exactly that caller: `ListSerializer.to_representation` receives the paginated page, which is a plain `list`, not the queryset behind it. `NoteSerializer` binds `VisibleNotesSerializer` as its `list_serializer_class`, so a paginated notes response raises there and answers 500.

It only breaks for a non-superuser: `visible_notes` returns `notes` untouched before reaching the `.filter()` when `user.is_superuser`. That asymmetry is why the tests that shipped with the rule did not catch it — they exercise the queryset paths, and the one list-shaped path they could have covered runs as a superuser.

Upstream's own `/api/v2/notes/` is gated on `permissions.IsSuperUser`, so a non-superuser is refused before the serializer runs and the crash does not surface on this repo's endpoints today. What is broken is the helper's contract — its docstring says every read path goes through it, and one shape of "every read path" raises — so any deployment that pairs the same serializer with a paginated list a non-superuser may read gets a 500 where the rule was supposed to apply. Fixing it in the helper keeps the rule in one place rather than pushing a shape check into each caller.

**Fix**

Filter in Python when there is no query left to narrow, and keep the database filter for a queryset or a manager. Those callers go on to count and slice the result — `findings_list_snippet.html` and `view_test.html` read `visible_notes.count` — so returning a list for them would trade one bug for another.

The rule itself is unchanged: a private note still reaches its author and superusers and nobody else.

**Test results**

`unittests/test_apiv2_note_visibility.py` gains `MaterialisedNotesTest`, which runs the rule through both input shapes and through the notes relation loaded with and without `notes_prefetch()`, so a fix that only narrows a queryset cannot pass:

- the helper — author / colleague / superuser / no user, each against a queryset and a list
- the list serializer — author / colleague / superuser, each against a queryset and a list
- the serialized relation — colleague / author, prefetched and not prefetched

18 new cases. Against the current `bugfix` tree 5 of them fail, all of them the `list` variants and all with the `AttributeError` above; the queryset controls and both superuser cases pass, which pins the asymmetry. With the fix all 18 pass.

Run locally against PostgreSQL, with the pre-existing suites in the area, all green:

| Suite | Result |
|---|---|
| `unittests.test_apiv2_note_visibility` (9 existing + 18 new) | 27 passed |
| `unittests.test_api_notes_nplusone`, `test_apiv2_prefetch_rbac`, `test_apiv2_test_create_notes_readonly`, `test_apiv2_methods_and_endpoints`, `test_display_tags_popover`, `test_pdf_report_rendering`, `test_risk_acceptance`, `test_risk_acceptance_api` | 69 passed |
| every other `unittests.test_apiv2_*` module | 98 passed |
| `unittests.test_rest_framework` | 887 passed (412 skipped) |

`ruff check --output-format=github .` with the pinned 0.16.0 passes over the tree.

**Documentation**

None needed. The behavior #15570 documented is unchanged — this restores it on the input shape where it raised instead of applying.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.
