### PR TITLE
docs(universal parser): document editing field mappings from the UI

### DIFF
--- a/docs/content/import_data/pro/specialized_import/universal_parser.md
+++ b/docs/content/import_data/pro/specialized_import/universal_parser.md
@@ -168,13 +168,16 @@ What you can do from the UI:
 
 * **Deactivate** a parser to hide it from the "Scan Type" drop-down on import. Open **Import → Universal Parser** in the sidebar to see all of your Universal Parsers, and toggle "Active" off. (Alternatively, you can edit the underlying Test_Type and uncheck "active".) Deactivated parsers no longer appear as a Scan Type option on the **Add Findings** page, but existing Tests that were imported with this parser are unaffected and continue to work.
 * **Reactivate** a parser from the same screen by toggling "Active" back on.
+* **Edit the field mappings** from the same screen — see [Editing a Universal Parser's field mappings](#editing-a-universal-parsers-field-mappings) below.
 * **Edit the Test_Type fields** described in the section above (active/inactive, static/dynamic, deduplication hash codes).
 
 Deleting a parser configuration is still not possible, because Universal Parser configurations are tied to Test_Type records that existing Findings, Tests and import history reference. If you need one permanently removed (for example, because it contains sensitive field names), contact [DefectDojo Support](mailto:support@defectdojo.com).
 
 ## Editing a Universal Parser's field mappings
 
-Field mappings can be changed after a parser has been created, through the API. Each edit is recorded as a numbered revision, so you can see what changed, when, and who changed it.
+Field mappings can be changed after a parser has been created, from the UI or through the API. Each edit is recorded as a numbered revision, so you can see what changed, when, and who changed it.
+
+Editing mappings requires the **Universal Parser Edit** permission. Viewing a parser only requires Universal Parser View, so a user who can see your parsers cannot necessarily change how they read a file.
 
 Some mapping edits are riskier than others, and DefectDojo classifies each edit before applying it:
 
@@ -183,9 +186,25 @@ Some mapping edits are riskier than others, and DefectDojo classifies each edit 
 
 Which fields count as identity-relevant depends on your own deduplication settings for that scan type, not on a fixed list, so it follows any change you make under **Enterprise Settings**.
 
+### Editing from the UI
+
+Open **Import → Universal Parser** in the sidebar, then choose **Edit Field Mappings** from the menu on the parser's row.
+
+The first step asks you to upload a scan file. This is not the file the parser was created with — nothing is kept from that one. It is a current sample of the kind of report this parser reads, and it is what the available fields are read from, so the mapping choices have something to point at.
+
+Your saved mappings are pre-selected against that sample, and the screen tells you if any of them could not be found in it. That normally means the file you uploaded has a different shape from the one the parser was built for. Mappings that could not be found are **not** pre-selected and will be dropped if you save, so either upload a closer sample or re-select them by hand.
+
+The second step is the same field-mapping screen used when creating a parser. The third shows you what your change would do before it is applied:
+
+* whether the edit is presentation-only or identity-relevant;
+* which fields are changing, split into those that reach identity and those that do not;
+* how many findings currently exist under this parser's scan type.
+
+If the edit is identity-relevant you have to tick a box confirming you understand it opens a transition window. A presentation-only edit does not ask, so the confirmation stays meaningful.
+
 ### Checking an edit before you make it
 
-`POST` your proposed mappings to the `impact` endpoint to see how they will be classified, without applying anything:
+The UI does this for you in its third step. Through the API, `POST` your proposed mappings to the `impact` endpoint to see how they will be classified, without applying anything:
 
 ```
 POST /api/vue/universal_parser/{id}/impact/
@@ -222,7 +241,9 @@ Each revision records the full mapping set in force at that point, which fields 
 
 ### Changing mappings through the Django admin
 
-Editing a `FieldMapping` directly in the Django admin bypasses all of the above: no revision is recorded, no version is bumped, and no transition window opens, so findings imported before that change become unreachable from findings imported after it. Use the API instead.
+Editing a `FieldMapping` directly in the Django admin bypasses all of the above: no revision is recorded, no version is bumped, and no transition window opens, so findings imported before that change become unreachable from findings imported after it. Use the UI or the API instead.
+
+If it has already happened, the impact step says so: it reports that this parser's mappings were changed once without being recorded, and warns that findings imported before that change have no previous generation to be matched from — which a later edit cannot recover.
 
 ### Rolling forward to a new parser
 


### PR DESCRIPTION
Universal Parser field mappings can now be edited from the UI. The docs page still
described the API as the only way to do it, so this updates the section to cover both.

What the page now says:

- **Where the screen is** — Import → Universal Parser in the sidebar, then "Edit Field
  Mappings" from the menu on the parser's row.
- **Why it opens by asking for a scan file.** This is the part most likely to surprise
  someone: it is not the file the parser was created with. Nothing is retained from that
  one, so the available fields have to be read from a current sample. The page says so
  plainly, and explains what it means when saved mappings cannot be found in the sample
  you upload — they are not pre-selected, and they are dropped if you save.
- **What the impact step shows** before anything is applied: whether the edit is
  presentation-only or identity-relevant, which fields are changing split by whether they
  reach identity, and how many findings exist under the parser's scan type. An
  identity-relevant edit requires ticking a confirmation; a presentation-only one does not,
  which is what keeps the confirmation meaningful.
- **The permission split**, which the page did not previously cover: editing mappings
  requires Universal Parser Edit, while seeing the parsers only requires Universal Parser
  View. A user who can see your parsers cannot necessarily change how they read a file.
- **The Django admin caveat**, extended: the impact step now reports when a parser's
  mappings were previously changed without being recorded, and warns that findings imported
  before that change have no previous generation to match from — something a later edit
  cannot recover.

The existing API instructions are unchanged; the "check before you make it" section just
notes that the UI performs the same impact call as its third step.

Docs-only change — one file, no code touched.

Validated locally with a Hugo production build pinned to the version CI uses (0.153.4
extended): 790 pages built, and the new in-page anchor resolves.
