### PR TITLE
fix(notes): filter note visibility when the caller already has a list

### DIFF
--- a/dojo/notes/helper.py
+++ b/dojo/notes/helper.py
@@ -30,11 +30,25 @@ def visible_notes(notes, user):
     Every read path goes through here, so the API and the UI cannot drift apart
     on what ``private`` means. A caller with no user (report rendering) gets the
     non-private notes only.
+
+    ``notes`` is not always a queryset. ``VisibleNotesSerializer`` filters
+    whatever DRF hands its ``ListSerializer``, and on a list endpoint that is a
+    plain list: ``paginate_queryset`` returns ``list(queryset[offset:limit])``.
+    So the same rule is applied in Python when there is no queryset left to
+    apply it to in SQL. Filtering a page after the fact does shorten it, which
+    is a consequence of choosing to enforce the rule at serialization time; the
+    alternative -- leaking another user's private note -- is worse.
     """
+    if user is not None and user.is_superuser:
+        return notes
+    if not hasattr(notes, "filter"):
+        return [
+            note
+            for note in notes
+            if not note.private or (user is not None and note.author_id == user.pk)
+        ]
     if user is None:
         return notes.filter(private=False)
-    if user.is_superuser:
-        return notes
     return notes.filter(Q(private=False) | Q(author=user))
 
 

--- a/unittests/test_apiv2_note_visibility.py
+++ b/unittests/test_apiv2_note_visibility.py
@@ -8,6 +8,7 @@ marked private. Every read path now goes through ``visible_notes``.
 """
 
 import datetime
+from types import SimpleNamespace
 
 from django.test import Client
 from django.urls import reverse
@@ -26,6 +27,7 @@ from dojo.models import (
     Test,
     Test_Type,
 )
+from dojo.notes.api.serializer import NoteSerializer
 from dojo.notes.helper import visible_notes
 
 from .dojo_test_case import DojoAPITestCase
@@ -159,3 +161,38 @@ class NoteVisibilityTest(DojoAPITestCase):
         entries = {n.entry for n in response.context["notes"]}
         self.assertNotIn(PRIVATE, entries)
         self.assertIn(PUBLIC, entries)
+
+    # ---- the rule when the caller has already materialised the notes -------
+    #
+    # ``VisibleNotesSerializer`` is a ``ListSerializer``, and a list endpoint
+    # hands one a plain list rather than a queryset: DRF's
+    # ``paginate_queryset`` returns ``list(queryset[offset:limit])``. A
+    # queryset-only helper raises ``AttributeError: 'list' object has no
+    # attribute 'filter'`` there, which surfaces as a 500 rather than as a
+    # visibility bug -- and only for non-superusers, because a superuser
+    # returns before any filtering happens.
+
+    def _entries_from_list(self, user):
+        return {n.entry for n in visible_notes(list(self.finding.notes.all()), user)}
+
+    def test_helper_filters_an_already_materialised_list_for_a_colleague(self):
+        self.assertEqual({PUBLIC}, self._entries_from_list(self.colleague))
+
+    def test_helper_filters_an_already_materialised_list_for_the_author(self):
+        self.assertEqual({PRIVATE, PUBLIC}, self._entries_from_list(self.author))
+
+    def test_helper_filters_an_already_materialised_list_for_a_superuser(self):
+        self.assertEqual({PRIVATE, PUBLIC}, self._entries_from_list(self.superuser))
+
+    def test_helper_filters_an_already_materialised_list_without_a_user(self):
+        self.assertEqual({PUBLIC}, self._entries_from_list(None))
+
+    def test_note_serializer_accepts_a_paginated_page(self):
+        """The path that 500s: a page is a list, and the serializer filters it."""
+        page = list(self.finding.notes.all())
+
+        serializer = NoteSerializer(
+            page, many=True, context={"request": SimpleNamespace(user=self.colleague)},
+        )
+
+        self.assertEqual({PUBLIC}, {row["entry"] for row in serializer.data})


### PR DESCRIPTION
## Description

`visible_notes()` assumes it is given a queryset, but `VisibleNotesSerializer` filters
whatever DRF hands its `ListSerializer` — and on a list endpoint that is a plain list, because
`paginate_queryset()` returns `list(queryset[offset:limit])`. Filtering it raises
`AttributeError: 'list' object has no attribute 'filter'`, so the request answers 500 instead
of a filtered page.

The crash is invisible on this repository alone. `NotesViewSet` is superuser-gated, and
`visible_notes()` returns before any filtering happens for a superuser, so the only callers
who reach the filtering are non-superusers — which today cannot get past the permission class.
Any deployment that widens those permissions, or any future viewset that serializes a
paginated list of notes for an ordinary user, hits it immediately.

That asymmetry is worth naming, because it makes the failure read backwards: the users the
private-note filtering exists to protect are exactly the users who cannot load the page at all.

## What changed

The rule is unchanged and still lives in the single helper every read path shares, so the API
and the UI cannot drift apart on what `private` means. It is now applied in Python when there
is no queryset left to apply it to in SQL, and the superuser short-circuit moves ahead of the
branch so it keeps costing nothing.

Filtering a page after the fact does shorten that page. That is a property of enforcing the
rule at serialization time rather than in the queryset, it predates this change, and it is
noted in the docstring — the alternative available here, leaking another user's private note,
is worse. Moving the filter into the querysets so pagination counts agree with page contents
is a larger change and deliberately not folded in.

## Testing

`unittests/test_apiv2_note_visibility.py` gains five cases: the helper applied to an
already-materialised list for the author, a colleague, a superuser and no user, plus
`NoteSerializer(page, many=True)` over a list, which is the path that 500s.

Verified failing-first: with the helper reverted, four of the five error with
`AttributeError: 'list' object has no attribute 'filter'` and the superuser case passes —
matching the production asymmetry exactly. With the fix, `test_apiv2_note_visibility` runs 14
tests OK, and the neighbouring `test_api_notes_nplusone` and
`test_apiv2_test_create_notes_readonly` run 5 tests OK.
