### PR TITLE
perf(locations): clean and stringify each URL location once per import

### DIFF
--- a/dojo/finding/deduplication.py
+++ b/dojo/finding/deduplication.py
@@ -33,12 +33,19 @@ def get_finding_models_for_deduplication(finding_ids):
         logger.debug("get_finding_models_for_deduplication called with no finding_ids")
         return []
 
+    # are_locations_duplicates reads the new finding's locations (V3) or endpoints (V2)
+    # once per candidate pair, so the pair loop N+1s unless the right relation is
+    # prefetched here. The V3 prefetch pulls the reference -> Location -> URL subtype
+    # chain that finding_locations() walks. ("endpoints" is the V2 relation —
+    # TODO: delete it after the move to Locations.)
+    location_prefetch = "locations__location__url" if settings.V3_FEATURE_LOCATIONS else "endpoints"
+
     return list(
         Finding.objects.filter(id__in=finding_ids)
         .only(*Finding.DEDUPLICATION_FIELDS)
         .select_related("test", "test__engagement", "test__engagement__product", "test__test_type")
         .prefetch_related(
-            "endpoints",
+            location_prefetch,
             # Prefetch duplicates of each finding to avoid N+1 when set_duplicate iterates
             Prefetch(
                 "original_finding",
@@ -50,7 +57,13 @@ def get_finding_models_for_deduplication(finding_ids):
 
 @app.task
 def do_dedupe_finding_task(new_finding_id, *args, **kwargs):
-    return do_dedupe_finding_task_internal(Finding.objects.get(id=new_finding_id), *args, **kwargs)
+    # Same loader as the batch task: are_locations_duplicates walks locations (V3) /
+    # endpoints (V2) per candidate pair, which N+1s on an unprefetched instance.
+    findings = get_finding_models_for_deduplication([new_finding_id])
+    if not findings:
+        logger.debug(f"no finding found for deduplication with ID: {new_finding_id}")
+        return None
+    return do_dedupe_finding_task_internal(findings[0], *args, **kwargs)
 
 
 @app.task
@@ -249,8 +262,17 @@ def are_urls_equal(url1, url2, fields):
 
 
 def finding_locations(location_refs):
-    """Extract URLs from a list of location references."""
-    return [ref.location.url for ref in location_refs]
+    """
+    Extract URL subtype rows from a list of LocationFindingReferences.
+
+    Only URL locations participate in the endpoint-fields comparison. Non-URL
+    locations (dependency, code) have no `url` reverse row at all, so touching
+    `.url` on them unconditionally raises RelatedObjectDoesNotExist — a finding
+    with a mixed location set would crash the dedupe task.
+    """
+    from dojo.url.models import URL  # noqa: PLC0415 -- lazy import, avoids circular dependency
+    url_type = URL.get_location_type()
+    return [ref.location.url for ref in location_refs if ref.location.location_type == url_type]
 
 
 def are_location_urls_equal(url1, url2, fields):
@@ -266,6 +288,25 @@ def are_location_urls_equal(url1, url2, fields):
     return True
 
 
+def unsaved_url_locations(finding):
+    """
+    URL AbstractLocation objects from finding.unsaved_locations (preview-mode path,
+    where the finding has no PK and therefore no location references yet). The raw
+    list mixes LocationData and AbstractLocation entries, neither of which can go
+    through finding_locations() — clean them into model instances instead. The
+    per-finding memo makes this free when the import pipeline already cleaned them.
+    """
+    from dojo.importers.location_manager import (  # noqa: PLC0415 -- lazy import, avoids circular dependency
+        LocationManager,
+    )
+    from dojo.url.models import URL  # noqa: PLC0415 -- lazy import, avoids circular dependency
+
+    if not getattr(finding, "unsaved_locations", None):
+        return []
+    url_type = URL.get_location_type()
+    return [loc for loc in LocationManager.cleaned_unsaved_locations(finding) if loc.get_location_type() == url_type]
+
+
 def are_locations_duplicates(new_finding, to_duplicate_finding):
     fields = settings.DEDUPE_ALGO_ENDPOINT_FIELDS
     if len(fields) == 0:
@@ -274,10 +315,8 @@ def are_locations_duplicates(new_finding, to_duplicate_finding):
 
     if settings.V3_FEATURE_LOCATIONS:
         # Use unsaved_locations for unsaved findings (preview mode), saved M2M otherwise
-        locs1 = new_finding.locations.all() if new_finding.pk else getattr(new_finding, "unsaved_locations", [])
-        locs2 = to_duplicate_finding.locations.all() if to_duplicate_finding.pk else getattr(to_duplicate_finding, "unsaved_locations", [])
-        list1 = finding_locations(locs1)
-        list2 = finding_locations(locs2)
+        list1 = finding_locations(new_finding.locations.all()) if new_finding.pk else unsaved_url_locations(new_finding)
+        list2 = finding_locations(to_duplicate_finding.locations.all()) if to_duplicate_finding.pk else unsaved_url_locations(to_duplicate_finding)
 
         deduplicationLogger.debug(
             f"Starting deduplication by location fields for finding {new_finding.id} with locations {list1} and finding {to_duplicate_finding.id} with locations {list2}",

--- a/dojo/finding/models.py
+++ b/dojo/finding/models.py
@@ -964,7 +964,7 @@ class Finding(BaseModel):
                     LocationManager,
                 )
                 from dojo.url.models import URL  # noqa: PLC0415 -- lazy import, avoids circular dependency
-                unsaved_locations = LocationManager.clean_unsaved_locations(finding.unsaved_locations)
+                unsaved_locations = LocationManager.cleaned_unsaved_locations(finding)
                 # Only URL locations feed the "endpoints" hash ingredient — the
                 # saved path below filters to URL references, and hashing other
                 # location types here would make a finding's hash change between

--- a/dojo/importers/location_manager.py
+++ b/dojo/importers/location_manager.py
@@ -61,7 +61,15 @@ class LocationManager(BaseLocationManager):
     ) -> None:
         """Record locations to be associated with a finding (and its product). Flushed by persist()."""
         if locations:
-            cleaned = self.clean_unsaved_locations(locations)
+            self._record_cleaned_locations(finding, self.clean_unsaved_locations(locations))
+
+    def _record_cleaned_locations(
+        self,
+        finding: Finding,
+        cleaned: list[AbstractLocation],
+    ) -> None:
+        """Record locations that have already been through clean_unsaved_locations()."""
+        if cleaned:
             self._locations_by_finding.setdefault(finding, []).extend(cleaned)
             self._product_locations.extend(cleaned)
 
@@ -80,11 +88,11 @@ class LocationManager(BaseLocationManager):
 
     def clean_unsaved(self, finding: Finding) -> None:
         """Clean the unsaved locations on this finding."""
-        self.clean_unsaved_locations(finding.unsaved_locations)
+        self.cleaned_unsaved_locations(finding)
 
     def record_for_finding(self, finding: Finding, extra_locations: list[UnsavedLocation] | None = None) -> None:
         """Record locations from the finding + any form-added extras for later batch creation."""
-        self.record_locations_for_finding(finding, finding.unsaved_locations)
+        self._record_cleaned_locations(finding, self.cleaned_unsaved_locations(finding))
         if extra_locations:
             self.record_locations_for_finding(finding, extra_locations)
 
@@ -298,7 +306,7 @@ class LocationManager(BaseLocationManager):
                     # The new finding is not mitigated; we need to reactivate locations that are in the new finding and
                     # mitigate statuses that are NOT in the new finding.
                     new_loc_values = {
-                        str(loc) for loc in self.clean_unsaved_locations(new_finding.unsaved_locations)
+                        str(loc) for loc in self.cleaned_unsaved_locations(new_finding)
                     }
                     for ref in finding_refs:
                         if ref.location.location_value in new_loc_values:
@@ -456,6 +464,28 @@ class LocationManager(BaseLocationManager):
             except ValidationError as e:
                 logger.warning("DefectDojo is storing broken locations because cleaning wasn't successful: %s", e)
         return locations
+
+    @classmethod
+    def cleaned_unsaved_locations(cls, finding: Finding) -> list[AbstractLocation]:
+        """
+        Clean finding.unsaved_locations exactly once per finding and memoize the result.
+
+        The import pipeline needs the cleaned list several times per finding — hash_code
+        computation (Finding.get_locations), recording for persistence, and reimport
+        status comparison. Cleaning converts LocationData to model instances and
+        re-parses/re-hashes every URL, so repeating it is pure CPU waste and was the
+        dominant cost of a locations-on import for endpoint-heavy reports. The memo is
+        keyed on the identity of the raw list, so code that assigns a fresh
+        unsaved_locations list gets a fresh clean; mutating the list in place after the
+        first clean is not supported (no in-tree caller does).
+        """
+        raw = finding.unsaved_locations
+        cached = getattr(finding, "_cleaned_unsaved_locations_cache", None)
+        if cached is not None and cached[0] is raw:
+            return cached[1]
+        cleaned = cls.clean_unsaved_locations(raw)
+        finding._cleaned_unsaved_locations_cache = (raw, cleaned)
+        return cleaned
 
     # ------------------------------------------------------------------
     # Bulk internals

--- a/dojo/location/models.py
+++ b/dojo/location/models.py
@@ -414,7 +414,12 @@ class AbstractLocation(BaseModelWithoutTimeMeta):
             if not isinstance(loc, cls):
                 error_message = f"Invalid location type; expected {cls} but got {type(loc)}"
                 raise TypeError(error_message)
-            loc.clean()
+            # A set identity_hash means the instance already went through clean()
+            # (locations are hashed only there) — re-cleaning would repeat idna/URL
+            # normalization work per row for nothing. Callers that mutate a location
+            # after cleaning it must re-clean before passing it in.
+            if not loc.identity_hash:
+                loc.clean()
             hashes.append(loc.identity_hash)
 
         # Look up existing objects, grouping by hash

--- a/dojo/url/models.py
+++ b/dojo/url/models.py
@@ -219,11 +219,30 @@ class URL(AbstractLocation):
             value += f"#{self.fragment}"
         return value
 
+    # Memoized canonical string, stored as (field-values key, value). unparse() does a
+    # full hyperlink round-trip plus idna encoding on every call, and a single import
+    # stringifies the same unsaved URL many times (set-dedupe hashing, __eq__,
+    # identity_hash, location_value), which made str() the top CPU cost of a
+    # locations-on import. Keying the cache by the field values keeps it correct if a
+    # field is mutated after the first str() — no invalidation hook required.
+    _str_cache: tuple[tuple, str] | None = None
+
+    def _str_key(self) -> tuple:
+        return (self.protocol, self.user_info, self.host, self.port, self.path, self.query, self.fragment)
+
     def __str__(self) -> str:
         """Return the string representation of a URL."""
+        key = self._str_key()
+        cached = self._str_cache
+        if cached is not None and cached[0] == key:
+            return cached[1]
+        value = None
         with suppress(Exception):
-            return URL.URL_PARSING_CLASS().unparse(self)
-        return self.manual_str()
+            value = URL.URL_PARSING_CLASS().unparse(self)
+        if value is None:
+            value = self.manual_str()
+        self._str_cache = (key, value)
+        return value
 
     @classmethod
     def get_location_type(cls) -> str:

--- a/unittests/test_bulk_locations.py
+++ b/unittests/test_bulk_locations.py
@@ -8,19 +8,26 @@ Covers:
 - Query efficiency
 """
 
+import hashlib
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.db import connection
+from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
+from dojo.finding.deduplication import (
+    are_locations_duplicates,
+    finding_locations,
+    get_finding_models_for_deduplication,
+)
 from dojo.importers.location_manager import LocationManager
 from dojo.location.models import Location, LocationFindingReference, LocationProductReference
 from dojo.location.status import FindingLocationStatus, ProductLocationStatus
 from dojo.models import Engagement, Finding, Product, Product_Type, Test, Test_Type
 from dojo.tools.locations import LocationAssociationData, LocationData
-from dojo.url.models import URL
+from dojo.url.models import URL, HyperlinkParser
 from unittests.dojo_test_case import DojoTestCase, skip_unless_v2, skip_unless_v3
 
 User = get_user_model()
@@ -539,3 +546,125 @@ class TestStatusUpdateQueryEfficiency(DojoTestCase):
 
         product_ref.refresh_from_db()
         self.assertEqual(product_ref.status, ProductLocationStatus.Active)
+
+
+# ---------------------------------------------------------------------------
+# URL string memoization + clean-once (locations import perf regression)
+# ---------------------------------------------------------------------------
+@skip_unless_v3
+class TestURLStringMemo(DojoTestCase):
+
+    def test_str_memoized_for_unchanged_fields(self):
+        url = _make_url("memo.example.com", "a/b")
+        first = str(url)
+        with patch.object(HyperlinkParser, "unparse", autospec=True) as mock_unparse:
+            self.assertEqual(str(url), first)
+            mock_unparse.assert_not_called()
+
+    def test_str_recomputed_after_field_change(self):
+        url = _make_url("memo-one.example.com")
+        before = str(url)
+        url.host = "memo-two.example.com"
+        after = str(url)
+        self.assertNotEqual(before, after)
+        self.assertIn("memo-two.example.com", after)
+
+    def test_identity_hash_matches_rendered_string(self):
+        url = _make_url("memo-hash.example.com", "x")
+        expected = hashlib.blake2b(str(url).encode(), digest_size=32).hexdigest()
+        self.assertEqual(url.identity_hash, expected)
+
+
+@skip_unless_v3
+class TestCleanedUnsavedLocationsMemo(DojoTestCase):
+
+    def test_cleaning_runs_once_per_unsaved_list(self):
+        finding = _make_finding()
+        finding.unsaved_locations = [LocationData.url(url="https://memo-once.example.com/a")]
+        first = LocationManager.cleaned_unsaved_locations(finding)
+        with patch.object(LocationManager, "clean_unsaved_locations") as mock_clean:
+            second = LocationManager.cleaned_unsaved_locations(finding)
+            mock_clean.assert_not_called()
+        self.assertIs(first, second)
+
+    def test_reassigned_list_is_recleaned(self):
+        finding = _make_finding()
+        finding.unsaved_locations = [LocationData.url(url="https://memo-a.example.com/")]
+        first = LocationManager.cleaned_unsaved_locations(finding)
+        finding.unsaved_locations = [LocationData.url(url="https://memo-b.example.com/")]
+        second = LocationManager.cleaned_unsaved_locations(finding)
+        self.assertNotEqual([str(u) for u in first], [str(u) for u in second])
+
+    def test_record_for_finding_reuses_prior_clean(self):
+        """The hash-code pass cleans first; record_for_finding must not clean again."""
+        finding = _make_finding()
+        finding.unsaved_locations = [LocationData.url(url="https://memo-rec.example.com/a")]
+        manager = LocationManager(finding.test.engagement.product)
+        LocationManager.cleaned_unsaved_locations(finding)
+        with patch.object(LocationManager, "clean_unsaved_locations") as mock_clean:
+            manager.record_for_finding(finding)
+            mock_clean.assert_not_called()
+        manager.persist()
+        self.assertEqual(finding.locations.count(), 1)
+
+
+@skip_unless_v3
+class TestBulkGetOrCreateSkipsReclean(DojoTestCase):
+
+    def test_cleaned_urls_are_not_recleaned(self):
+        urls = [_make_url("noreclean.example.com")]
+        with patch.object(URL, "clean", autospec=True) as mock_clean:
+            saved = URL.bulk_get_or_create(urls)
+            mock_clean.assert_not_called()
+        self.assertIsNotNone(saved[0].pk)
+
+    def test_uncleaned_urls_are_still_cleaned(self):
+        url = URL(protocol="https", host="RECLEAN.example.com")
+        saved = URL.bulk_get_or_create([url])
+        self.assertEqual(saved[0].host, "reclean.example.com")
+        self.assertTrue(saved[0].identity_hash)
+
+
+@skip_unless_v3
+class TestDedupeLocationAccess(DojoTestCase):
+
+    def _finding_with_location(self, host):
+        finding = _make_finding()
+        manager = LocationManager(finding.test.engagement.product)
+        finding.unsaved_locations = [LocationData.url(url=f"https://{host}/login")]
+        manager.record_for_finding(finding)
+        manager.persist()
+        return finding
+
+    @override_settings(DEDUPE_ALGO_ENDPOINT_FIELDS=["host", "path"])
+    def test_loader_prefetches_locations_for_pair_comparison(self):
+        f1 = self._finding_with_location("dedupe-prefetch.example.com")
+        f2 = self._finding_with_location("dedupe-prefetch.example.com")
+        loaded = get_finding_models_for_deduplication([f1.id, f2.id])
+        with self.assertNumQueries(0):
+            self.assertTrue(are_locations_duplicates(loaded[0], loaded[1]))
+
+    def test_finding_locations_skips_non_url_locations(self):
+        """A dependency/code Location has no `url` reverse row; it must be skipped, not crash."""
+        finding = self._finding_with_location("mixed-loc.example.com")
+        dep_location = Location.objects.create(location_type="dependency", location_value="pkg:pypi/x@1.0")
+        LocationFindingReference.objects.create(
+            location=dep_location, finding=finding, status=FindingLocationStatus.Active,
+        )
+        urls = finding_locations(finding.locations.select_related("location__url").all())
+        self.assertEqual(len(urls), 1)
+
+    @override_settings(DEDUPE_ALGO_ENDPOINT_FIELDS=["host", "path"])
+    def test_unsaved_finding_comparison_uses_unsaved_locations(self):
+        saved = self._finding_with_location("unsaved-cmp.example.com")
+        saved = get_finding_models_for_deduplication([saved.id])[0]
+        unsaved = Finding(test=saved.test, title="preview", severity="Medium")
+        unsaved.unsaved_locations = [LocationData.url(url="https://unsaved-cmp.example.com/login")]
+        self.assertTrue(are_locations_duplicates(unsaved, saved))
+
+    @override_settings(DEDUPE_ALGO_ENDPOINT_FIELDS=["host", "path"])
+    def test_mismatched_locations_are_not_duplicates(self):
+        f1 = self._finding_with_location("host-a.example.com")
+        f2 = self._finding_with_location("host-b.example.com")
+        loaded = get_finding_models_for_deduplication([f1.id, f2.id])
+        self.assertFalse(are_locations_duplicates(loaded[0], loaded[1]))

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -694,11 +694,11 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._import_reimport_performance(
-            expected_num_queries1=194,
+            expected_num_queries1=196,
             expected_num_async_tasks1=2,
-            expected_num_queries2=154,
+            expected_num_queries2=156,
             expected_num_async_tasks2=1,
-            expected_num_queries3=53,
+            expected_num_queries3=55,
             expected_num_async_tasks3=1,
             expected_num_queries4=110,
             expected_num_async_tasks4=0,
@@ -719,11 +719,11 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self.system_settings(enable_product_grade=True)
 
         self._import_reimport_performance(
-            expected_num_queries1=207,
+            expected_num_queries1=209,
             expected_num_async_tasks1=5,
-            expected_num_queries2=167,
+            expected_num_queries2=169,
             expected_num_async_tasks2=4,
-            expected_num_queries3=62,
+            expected_num_queries3=64,
             expected_num_async_tasks3=3,
             expected_num_queries4=122,
             expected_num_async_tasks4=3,
@@ -846,8 +846,8 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         testuser.usercontactinfo.save()
 
         self._deduplication_performance(
-            expected_num_queries1=130,
+            expected_num_queries1=132,
             expected_num_async_tasks1=2,
-            expected_num_queries2=211,
+            expected_num_queries2=107,
             expected_num_async_tasks2=2,
         )

--- a/unittests/test_tag_inheritance_perf.py
+++ b/unittests/test_tag_inheritance_perf.py
@@ -624,9 +624,15 @@ class TagInheritanceImportPerfBaselines(DojoAPITestCase):
     # from close_old_findings; the one with nothing to write is the pair that goes.
     # V2 is unaffected -- EndpointManager.persist() opens no transaction -- which is
     # why only the V3 constants move.
+    # The V3 constants carry +2 since the dedupe loader
+    # (get_finding_models_for_deduplication) prefetches the
+    # locations__location__url chain (3 queries) instead of the V2 endpoints
+    # relation (1 query). That cost is per post-processing batch — one loader
+    # call per import — and is what removes the per-candidate-pair location
+    # queries in are_locations_duplicates, so it doesn't scale with findings.
     EXPECTED_ZAP_IMPORT_V2 = 301
-    EXPECTED_ZAP_IMPORT_V3 = 325
+    EXPECTED_ZAP_IMPORT_V3 = 327
     EXPECTED_ZAP_REIMPORT_NO_CHANGE_V2 = 82
-    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V3 = 92
+    EXPECTED_ZAP_REIMPORT_NO_CHANGE_V3 = 94
     EXPECTED_ZAP_REIMPORT_WITH_NEW_V2 = 166
-    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 193
+    EXPECTED_ZAP_REIMPORT_WITH_NEW_V3 = 195


### PR DESCRIPTION
## Summary

With `DD_V3_FEATURE_LOCATIONS=True`, imports of endpoint-heavy reports regress hard
(measured 37s vs 2.5s flag-off on a UAT instance — ~15×). Profiling a synthetic
100-finding × 40-endpoint import shows the cost is CPU in the URL location pipeline,
not queries: `URL.__str__` (a full hyperlink round-trip + idna encode per call) ran
11,510× (30.8s of a 63s profiled import), `idna.encode` 29,530×, and `URL.clean`
6,510× — because each location is re-parsed, re-cleaned, and re-stringified several
times per import:

- the hash_code pass (`Finding.get_locations`) cleans `unsaved_locations` and throws
  the objects away;
- `record_for_finding` re-parses and re-cleans the same raw list;
- `bulk_get_or_create` cleans every location a third time;
- every set-dedupe hash, `__eq__`, `identity_hash`, and `location_value` call
  re-runs `unparse()` (2× HyperlinkURL construction + normalize + idna + to_uri).

The flag-on overhead is linear in location instances while the flag-off baseline
scales with findings, so DAST-shaped scans (dozens to hundreds of endpoints per
finding) hit the reported multiples.

### Changes

1. **`URL.__str__` is memoized**, keyed by the field values it renders — correct
   under post-clean mutation with no invalidation hooks. `identity_hash`,
   `__hash__`/`__eq__`, `get_location_value`, and parent-`Location` value creation
   all reuse the one computed string.
2. **`LocationManager.cleaned_unsaved_locations(finding)`** cleans
   `finding.unsaved_locations` once per finding and memoizes (keyed on the raw list
   identity). The hash_code pass, `record_for_finding`, `clean_unsaved`, and the
   reimport status-compare path all share it.
3. **`AbstractLocation.bulk_get_or_create` skips `clean()`** for instances whose
   `identity_hash` is already set (i.e. they went through `clean()`); all in-tree
   callers pre-clean (importer pipeline, endpoint→location migration command).
4. **Dedupe loader prefetch (V3):** `get_finding_models_for_deduplication`
   prefetched only the V2 `endpoints` relation, so `are_locations_duplicates`
   N+1-queried `locations` → `Location` → `URL` per candidate pair
   (`DEDUPE_ALGO_ENDPOINT_FIELDS` defaults to `["host", "path"]`, so this runs by
   default). It now prefetches `locations__location__url` under the flag, and the
   single-finding dedupe task uses the same loader instead of a bare
   `Finding.objects.get`.
5. **`finding_locations` robustness:** it dereferenced `ref.location.url`
   unconditionally — a finding carrying a non-URL location (dependency/code) raised
   `RelatedObjectDoesNotExist` inside the dedupe task. It now filters to URL-type
   references (matching how the hash-code "endpoints" ingredient is computed), and
   the unsaved-finding branch converts `unsaved_locations` (LocationData) properly
   instead of crashing.

### Benchmarks (same rig, sync post-processing, dedupe enabled)

| shape | flag off | flag on (before) | flag on (after) |
|---|---|---|---|
| 500 findings × 4 eps | 18.0s / 1561q | 23.4s / 1576q (+30%) | **21.2s / 1575q (+18%)** |
| 100 findings × 40 eps | 9.1s / 361q | 27.0s / 381q (**3.0×**) | **16.1s / 374q (1.87×)** |

Flag-off walls are unchanged after the fix (17.99s vs 17.98s / 8.62s vs 9.08s).
The residual flag-on cost is one hyperlink parse + one idna host normalization +
one canonical render per location instance — the feature's real work, now paid
once. (Absolute numbers are from an emulated arm64 rig; ratios are the signal.
The flag-on/flag-off ratio grows with endpoints-per-finding, which is what made
the UAT regression look 15×.)

The three `TagInheritanceImportPerfBaselines` V3 constants move +2: the dedupe
loader's V3 prefetch chain is 3 queries where the V2 `endpoints` prefetch was 1 —
a per-batch constant that removes the per-candidate-pair location queries.

### Tests

- `TestURLStringMemo` — memo hit, field-change recompute, identity_hash contract.
- `TestCleanedUnsavedLocationsMemo` — clean-once across hash+record passes,
  re-clean on list reassignment.
- `TestBulkGetOrCreateSkipsReclean` — cleaned objects not re-cleaned, uncleaned
  objects still cleaned.
- `TestDedupeLocationAccess` — zero queries for a prefetched pair comparison,
  non-URL location no longer crashes, unsaved-finding comparison works, mismatch
  still rejected.

Full native suite run (all three CI passes): 6,504 + 45 + 7 tests — green except
the documented macOS-resolver-text JIRA test that fails on any branch locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
