### PR TITLE
feat(locations): make the endpoint->location migration resumable and memory-bounded

### DIFF
--- a/dojo/management/commands/migrate_endpoints_to_locations.py
+++ b/dojo/management/commands/migrate_endpoints_to_locations.py
@@ -71,6 +71,25 @@ class _ChunkRows:
         # (location_id, product_id) -> (status, product, location, endpoint_id)
         self._product_refs: dict[tuple[int, int], tuple[str, Product, Location, int | None]] = {}
 
+        # (product, location) pairs contributed by this chunk, for the per-chunk
+        # tag inheritance pass. Held per chunk — not for the whole run — so
+        # memory stays bounded by --batch-size no matter how large the install
+        # is (retaining every migrated Location object for a single end-of-run
+        # pass is what made multi-million-endpoint runs balloon).
+        self.inheritance_by_product: dict[int, set[int]] = defaultdict(set)
+        self.product_by_id: dict[int, Product] = {}
+        self.location_by_id: dict[int, Location] = {}
+
+    def track_product_location(self, product: Product, location: Location) -> None:
+        """Record a (product, location) pair for this chunk's tag inheritance pass."""
+        if product is None or product.id is None:
+            return
+        if location is None or location.id is None:
+            return
+        self.inheritance_by_product[product.id].add(location.id)
+        self.product_by_id.setdefault(product.id, product)
+        self.location_by_id.setdefault(location.id, location)
+
     def add_meta(self, meta: DojoMeta, location: Location, endpoint_id: int | None) -> None:
         """Queue a DojoMeta copy, keyed on its unique_together (location, name)."""
         key = (location.id, meta.name)
@@ -135,6 +154,7 @@ PHASES = (
     "finding_refs",     # LocationFindingReference creation per Endpoint_Status
     "product_refs",     # LocationProductReference creation
     "reconcile",        # recompute product-reference status from finding refs
+    "inheritance",      # per-chunk inherited-tag application
 )
 
 
@@ -164,6 +184,16 @@ class Command(BaseCommand):
       are visited in.
     - ``DojoMeta`` rows and tag copies are insert-only, so re-runs neither
       duplicate them nor overwrite edits made after the first migration.
+
+    Built to survive large installs:
+
+    - Endpoints are scanned in id order and every progress line prints the last
+      migrated id, so an interrupted run resumes with ``--start-after-id`` instead
+      of re-scanning from the start (a full re-run also converges, it just costs
+      the whole scan again).
+    - Memory is bounded by ``--batch-size``: every per-endpoint structure —
+      including the (product, location) pairs for tag inheritance, which is applied
+      per chunk — lives on the chunk and is dropped with it.
     """
 
     help = "Usage: manage.py migrate_endpoints_to_locations"
@@ -195,6 +225,16 @@ class Command(BaseCommand):
             help="Force-debug the DB cursor and count queries per chunk. "
                  "Has measurable overhead; use only for profiling runs.",
         )
+        parser.add_argument(
+            "--start-after-id",
+            type=int,
+            default=None,
+            help="Resume after this endpoint id (exclusive). Endpoints are processed "
+                 "in id order and every progress line reports the last id written, so "
+                 "an interrupted run can be resumed from its final progress line "
+                 "instead of rescanning from the start. Re-running without it is also "
+                 "safe — the migration converges — it just repays the full scan.",
+        )
 
     # -- Per-phase timing helpers --------------------------------------------
 
@@ -205,29 +245,6 @@ class Command(BaseCommand):
         if self.benchmark:
             self.timings[phase] += time.perf_counter() - t0
             self.counts[phase] += 1
-
-    # -- Tag inheritance bookkeeping -----------------------------------------
-
-    def _track_product_location(self, product: Product, location: Location) -> None:
-        """
-        Record a (product, location) pair for the post-migration tag inheritance pass.
-
-        The migration creates locations that may be linked to multiple products
-        (via the endpoint's own product and via each finding's product). We
-        collect every contributing product per location so the post-pass can
-        call ``apply_inherited_tags_for_locations`` once per product group —
-        covering the case where a location is shared across products with
-        differing ``enable_product_tag_inheritance`` flags (the helper
-        short-circuits via its own diff check on repeat visits, so redundancy
-        is safe).
-        """
-        if product is None or product.id is None:
-            return
-        if location is None or location.id is None:
-            return
-        self.locations_by_product_id[product.id].add(location.id)
-        self.product_obj_by_id.setdefault(product.id, product)
-        self.location_obj_by_id.setdefault(location.id, location)
 
     # -- Endpoint tag batching -----------------------------------------------
 
@@ -247,12 +264,19 @@ class Command(BaseCommand):
             self.pending_tag_locations[tag_name][location.id] = location
         self.pending_endpoint_tags[endpoint.id] = (location, tag_names)
 
+    # Detailed (id, error) tuples retained for the failure summary. The id SET is
+    # unbounded (needed for dedup and the final count; ints are cheap) but the
+    # error strings are capped: a pathological run where most endpoints fail
+    # would otherwise accumulate an exception string per endpoint.
+    MAX_FAILURE_DETAILS = 1000
+
     def _record_endpoint_failure(self, endpoint_id: int | None, exc: Exception) -> None:
         """Record an Endpoint once even if more than one migration phase fails."""
         if endpoint_id in self.failed_endpoint_ids:
             return
         self.failed_endpoint_ids.add(endpoint_id)
-        self.failed_endpoints.append((endpoint_id, str(exc)))
+        if len(self.failed_endpoints) < self.MAX_FAILURE_DETAILS:
+            self.failed_endpoints.append((endpoint_id, str(exc)))
 
     def _flush_location_tags(self) -> None:
         """Persist queued tags, retrying per Endpoint if the batch write fails."""
@@ -544,11 +568,11 @@ class Command(BaseCommand):
                     rows.add_meta(meta, location, endpoint_id)
 
                 # Track the endpoint's own product as a contributor for the
-                # post-migration tag inheritance pass (the no-findings branch
+                # per-chunk tag inheritance pass (the no-findings branch
                 # of `_collect_references` also depends on this product, and it
                 # won't be tracked otherwise).
                 if endpoint.product_id:
-                    self._track_product_location(endpoint.product, location)
+                    rows.track_product_location(endpoint.product, location)
 
                 self._collect_references(endpoint, location, rows)
             except Exception as exc:
@@ -587,6 +611,10 @@ class Command(BaseCommand):
 
         self._reconcile_product_statuses(list({location.id for _, location in resolved}))
 
+        # Inheritance runs per chunk (bounded memory, converging) — see the
+        # method's docstring for why this is equivalent to an end-of-run pass.
+        self._run_tag_inheritance_for_chunk(rows)
+
     def _collect_references(
         self,
         endpoint: Endpoint,
@@ -620,10 +648,10 @@ class Command(BaseCommand):
             if finding is None:
                 continue
             product = finding.test.engagement.product
-            # Track this contributing product for the post-migration tag
+            # Track this contributing product for the per-chunk tag
             # inheritance pass (covers the case where a finding's product
             # differs from endpoint.product).
-            self._track_product_location(product, location)
+            rows.track_product_location(product, location)
             status = self._convert_endpoint_status_to_string_status(endpoint_status)
             rows.record_product(
                 product,
@@ -690,6 +718,7 @@ class Command(BaseCommand):
         run_t0: float,
         queries_this_window: int | None,
         endpoints_this_window: int,
+        last_id: int | None = None,
     ) -> None:
         elapsed = time.time() - run_t0
         rate = i / elapsed if elapsed > 0 else 0.0
@@ -700,6 +729,10 @@ class Command(BaseCommand):
         if queries_this_window is not None and endpoints_this_window:
             # Per-endpoint query count for this reporting window only.
             line += f" — {queries_this_window / endpoints_this_window:.1f} queries/endpoint"
+        if last_id is not None:
+            # The resume cursor: an interrupted run restarts from here with
+            # --start-after-id instead of rescanning everything before it.
+            line += f" — last id {last_id} (resume: --start-after-id {last_id})"
         self.stdout.write(self.style.SUCCESS(line))
 
         if self.benchmark:
@@ -723,52 +756,68 @@ class Command(BaseCommand):
 
     # -- Post-migration tag inheritance --------------------------------------
 
-    def _run_tag_inheritance(self) -> None:
+    def _run_tag_inheritance_for_chunk(self, rows: _ChunkRows) -> None:
         """
-        Apply inherited tags once per contributing product.
+        Apply inherited tags for this chunk's (product, location) pairs.
 
-        Each product batch is wrapped in its own try/except so a
-        failure on one product group doesn't prevent the rest from running —
-        same philosophy as the per-endpoint loop. The underlying
-        location/reference rows are already committed by the main loop, so
-        partial failure here leaves a consistent (if incompletely reconciled)
-        inheritance state that a targeted re-run can finish.
+        Runs at every chunk boundary instead of once at the end of the run,
+        for the same reason ``_reconcile_product_statuses`` does: the helper
+        rediscovers each location's *full* product set from the committed
+        reference rows at call time, so when a shared location gains another
+        product's references in a later chunk, that chunk's pass recomputes the
+        union and the result converges regardless of chunk order. Running
+        per-chunk is what lets the run hold only one chunk's Location objects
+        at a time — the previous end-of-run pass retained every migrated
+        Location for the whole run, which is unsustainable at
+        multi-million-endpoint scale.
+
+        Each product group is wrapped in its own try/except so a failure on one
+        group doesn't prevent the rest — the same philosophy as the
+        per-endpoint loop. The reference rows are already committed, so partial
+        failure leaves a consistent (if incompletely reconciled) inheritance
+        state that a re-run repairs.
         """
-        if not self.locations_by_product_id:
+        if not rows.inheritance_by_product:
             return
 
         # Lazy import: the inheritance module imports the full model layer, so
         # keep it out of management-command discovery.
         from dojo.tags import inheritance as tag_inheritance  # noqa: PLC0415
 
-        t0 = time.time()
-        n_products = len(self.locations_by_product_id)
-        n_pairs = sum(len(loc_ids) for loc_ids in self.locations_by_product_id.values())
-        n_unique_locations = len(self.location_obj_by_id)
-        n_failures = 0
-        for prod_id, loc_ids in self.locations_by_product_id.items():
-            product = self.product_obj_by_id[prod_id]
-            locations = [self.location_obj_by_id[lid] for lid in loc_ids]
-            try:
-                tag_inheritance.apply_inherited_tags_for_locations(
-                    locations,
-                    product=product,
-                )
-            except Exception:
-                logger.exception(
-                    "Tag inheritance pass failed for product id=%s "
-                    "(%d location(s)); continuing with remaining products",
-                    prod_id, len(locations),
-                )
-                n_failures += 1
-        elapsed = time.time() - t0
+        t = self._bench_start()
+        try:
+            for prod_id, loc_ids in rows.inheritance_by_product.items():
+                product = rows.product_by_id[prod_id]
+                locations = [rows.location_by_id[lid] for lid in loc_ids]
+                try:
+                    tag_inheritance.apply_inherited_tags_for_locations(
+                        locations,
+                        product=product,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Tag inheritance pass failed for product id=%s "
+                        "(%d location(s)); continuing with remaining products",
+                        prod_id, len(locations),
+                    )
+                    self.inheritance_failures += 1
+                else:
+                    self.inheritance_pairs += len(loc_ids)
+                    self.inheritance_product_ids.add(prod_id)
+        finally:
+            self._bench_end("inheritance", t)
+
+    def _print_tag_inheritance_summary(self) -> None:
+        if not (self.inheritance_pairs or self.inheritance_failures):
+            return
         msg = (
-            f"Tag inheritance pass: visited {n_pairs:,} (product, location) pair(s) "
-            f"across {n_products:,} product(s), {n_unique_locations:,} unique location(s), "
-            f"in {elapsed:.2f}s"
+            f"Tag inheritance: applied to {self.inheritance_pairs:,} (product, location) "
+            f"pair(s) across {len(self.inheritance_product_ids):,} product(s), "
+            f"per chunk during the run"
         )
-        if n_failures:
-            self.stdout.write(self.style.WARNING(f"{msg} — {n_failures} product group(s) failed"))
+        if self.inheritance_failures:
+            self.stdout.write(self.style.WARNING(
+                f"{msg} — {self.inheritance_failures} product group(s) failed"))
         else:
             self.stdout.write(self.style.SUCCESS(msg))
 
@@ -779,20 +828,17 @@ class Command(BaseCommand):
         self.query_count = bool(options.get("query_count"))
         self.batch_size = int(options["batch_size"])
         self.progress_every = int(options["progress_every"])
+        self.start_after_id = options.get("start_after_id")
 
         # Per-phase wall-clock accumulators.
         self.timings = dict.fromkeys(PHASES, 0.0)
         self.counts = dict.fromkeys(PHASES, 0)
 
-        # Bookkeeping for the post-migration tag inheritance pass.
-        # `locations_by_product_id` maps product.id -> set of location.ids
-        # contributed by that product (via endpoint.product OR finding.test.
-        # engagement.product). We hold the Product/Location objects in
-        # parallel maps so the post-pass can hand them directly to the bulk
-        # inheritance helper.
-        self.locations_by_product_id: dict[int, set[int]] = defaultdict(set)
-        self.product_obj_by_id: dict[int, Product] = {}
-        self.location_obj_by_id: dict[int, Location] = {}
+        # Aggregate counters for the per-chunk tag inheritance pass (the pairs
+        # themselves live on each chunk's _ChunkRows and are dropped with it).
+        self.inheritance_pairs = 0
+        self.inheritance_product_ids: set[int] = set()
+        self.inheritance_failures = 0
 
         # Endpoint tags are copied to Locations once per migration batch.
         # The nested Location-id mapping prevents duplicate through rows and
@@ -829,7 +875,7 @@ class Command(BaseCommand):
         #
         # The work is redundant regardless: a freshly created Location has no
         # product references yet, so the signal has nothing to inherit. Correct
-        # inheritance is applied in bulk by `_run_tag_inheritance()` once the
+        # inheritance is applied in bulk by `_run_tag_inheritance_for_chunk()` once the
         # references exist, which is why that pass already exists.
         with Endpoint.allow_endpoint_init():
             # Prefetch everything the per-endpoint loop will touch so the
@@ -840,8 +886,12 @@ class Command(BaseCommand):
             #   - `status_endpoint` is prefetched together with the FK chain
             #     `finding -> test -> engagement -> product` and `mitigated_by`
             #     so the reference rows can be built without queries.
+            # Explicit id ordering makes the scan deterministic across runs,
+            # which is what gives the progress lines' "last id" its meaning as
+            # a resume cursor for --start-after-id.
             queryset = (
                 Endpoint.objects.all()
+                .order_by("id")
                 .select_related("product")
                 .prefetch_related(
                     "tags",
@@ -855,13 +905,19 @@ class Command(BaseCommand):
                     ),
                 )
             )
+            if self.start_after_id is not None:
+                queryset = queryset.filter(id__gt=self.start_after_id)
             # Grab the total count so we can communicate progress
             endpoint_count = queryset.count()
+            resume_note = (
+                f", resuming after endpoint id {self.start_after_id}"
+                if self.start_after_id is not None else ""
+            )
             self.stdout.write(self.style.WARNING(
                 f"Starting migration of {endpoint_count:,} endpoints "
                 f"(batch={self.batch_size}, progress every {self.progress_every}, "
                 f"benchmark={'on' if self.benchmark else 'off'}, "
-                f"query-count={'on' if self.query_count else 'off'})",
+                f"query-count={'on' if self.query_count else 'off'}{resume_note})",
             ))
 
             run_t0 = time.time()
@@ -874,10 +930,14 @@ class Command(BaseCommand):
             # failures itself: per-endpoint for anything that can raise while
             # building rows, and per-row on a failed batch write, so one bad
             # endpoint still can't abort a multi-hour migration.
+            last_id = None
             with tag_inheritance.suppress_tag_inheritance():
                 for chunk in self._iter_chunks(queryset):
                     self._process_chunk(chunk)
                     i += len(chunk)
+                    # Chunks arrive in id order, so the chunk's last endpoint id
+                    # is the resume cursor for everything migrated so far.
+                    last_id = chunk[-1].id
 
                     # Flush independently of per-endpoint success so a failing
                     # endpoint at a chunk boundary cannot leave the queue growing.
@@ -895,34 +955,30 @@ class Command(BaseCommand):
                             queries_at_window_start = 0
                         self._log_progress(
                             i, endpoint_count, run_t0, queries_in_window, i - last_reported,
+                            last_id=last_id,
                         )
                         last_reported = i
 
             elapsed = time.time() - run_t0
-            successful = i - len(self.failed_endpoints)
+            n_failed = len(self.failed_endpoint_ids)
+            successful = i - n_failed
             self.stdout.write(self.style.SUCCESS(
                 f"Done. Migrated {successful:,}/{i:,} endpoints in {self._fmt_duration(elapsed)} "
                 f"({(i / elapsed if elapsed else 0):.2f} endpoints/sec).",
             ))
-            if self.failed_endpoints:
+            if n_failed:
                 preview_ids = [eid for eid, _ in self.failed_endpoints[:10]]
                 self.stdout.write(self.style.WARNING(
-                    f"{len(self.failed_endpoints):,} endpoint(s) failed; see logger output above "
+                    f"{n_failed:,} endpoint(s) failed; see logger output above "
                     f"for tracebacks. First failing endpoint IDs: {preview_ids}",
                 ))
 
-            # Run the post-migration tag inheritance pass. `bulk_create` skips
-            # the `inherit_tags_on_linked_instance` post_save signal, so for
-            # deployments with `enable_product_tag_inheritance` enabled (per
-            # product or system-wide) the migrated Locations would otherwise
-            # not pick up inherited product tags. We grouped (product,
-            # location) pairs during the main loop and now drive
-            # `apply_inherited_tags_for_locations` once per contributing
-            # product. The helper rediscovers each location's full product
-            # set via LocationProductReference/LocationFindingReference and
-            # diff-checks before writing, so revisits of shared locations
-            # across product groups are idempotent.
-            self._run_tag_inheritance()
+            # Inherited tags were applied per chunk during the loop
+            # (`bulk_create` skips the `inherit_tags_on_linked_instance`
+            # post_save signal, so deployments with
+            # `enable_product_tag_inheritance` on would otherwise miss them);
+            # this just reports the aggregate.
+            self._print_tag_inheritance_summary()
 
             self._print_benchmark_summary(i, elapsed)
 

--- a/unittests/test_migrate_endpoints_to_locations.py
+++ b/unittests/test_migrate_endpoints_to_locations.py
@@ -497,7 +497,7 @@ class MigrateEndpointsToLocationsTest(TestCase):
     def test_inheritance_signal_is_suppressed_during_the_main_loop(self):
         # The per-Location post_save inheritance signal issues an OR-joined
         # query whose cost grows with LocationFindingReference, so the hot loop
-        # must not fire it; `_run_tag_inheritance` applies inheritance in bulk
+        # must not fire it; `_run_tag_inheritance_for_chunk` applies inheritance in bulk
         # once the reference rows exist.
         self.product.tags.add("product-inherited")
         self.product.enable_product_tag_inheritance = True
@@ -515,4 +515,98 @@ class MigrateEndpointsToLocationsTest(TestCase):
         self.assertEqual(
             [tag.name for tag in location.inherited_tags.all()],
             ["product-inherited"],
+        )
+
+    def test_start_after_id_resumes_from_the_cursor(self):
+        first = self._make_endpoint("resume-first.example.com", ["a"])
+        second = self._make_endpoint("resume-second.example.com", ["b"])
+
+        stdout = self._run(start_after_id=first.id)
+
+        # Only the endpoint after the cursor migrated.
+        self.assertIn("Starting migration of 1", stdout)
+        self.assertFalse(URL.objects.filter(host="resume-first.example.com").exists())
+        self.assertTrue(URL.objects.filter(host="resume-second.example.com").exists())
+        self.assertIn(f"resuming after endpoint id {first.id}", stdout)
+
+        # A follow-up full run converges: the skipped endpoint migrates,
+        # the already-migrated one is reused.
+        self._run()
+        self.assertTrue(URL.objects.filter(host="resume-first.example.com").exists())
+        self.assertEqual(URL.objects.filter(host="resume-second.example.com").count(), 1)
+        self.assertEqual(second.id > first.id, True)
+
+    def test_progress_line_reports_resume_cursor(self):
+        endpoints = [
+            self._make_endpoint(f"cursor-{i}.example.com", []) for i in range(3)
+        ]
+
+        stdout = self._run(progress_every=1, batch_size=1)
+
+        last = max(endpoint.id for endpoint in endpoints)
+        self.assertIn(f"resume: --start-after-id {last}", stdout)
+
+    def test_inheritance_converges_for_location_shared_across_chunks(self):
+        # One URL shared by two endpoints in DIFFERENT products, forced into
+        # different chunks (batch_size=1). The per-chunk inheritance pass must
+        # still produce the union of both products' tags on the shared
+        # location, because the helper recomputes the full product set from
+        # the committed reference rows each time it runs.
+        self.product.tags.add("tag-product-one")
+        self.product.enable_product_tag_inheritance = True
+        self.product.save(update_fields=["enable_product_tag_inheritance"])
+
+        other_product = Product.objects.create(
+            name="Endpoint migration product two",
+            description="Test product two",
+            prod_type=self.product.prod_type,
+            enable_product_tag_inheritance=True,
+        )
+        other_product.tags.add("tag-product-two")
+
+        self._make_endpoint_with_status("shared-inherit.example.com", active=True)
+
+        other_engagement = Engagement.objects.create(
+            name="Endpoint migration engagement two",
+            product=other_product,
+            target_start=timezone.now().date(),
+            target_end=timezone.now().date(),
+        )
+        test_type, _ = Test_Type.objects.get_or_create(name="Endpoint migration test type")
+        other_test = Test.objects.create(
+            engagement=other_engagement,
+            test_type=test_type,
+            scan_type="Endpoint migration scan",
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        other_finding = Finding.objects.create(
+            title="Finding in product two",
+            test=other_test,
+            severity="High",
+            numerical_severity="S1",
+            description="Test finding",
+            active=True,
+            verified=False,
+            reporter=self.reporter,
+        )
+        with Endpoint.allow_endpoint_init():
+            other_endpoint = Endpoint.objects.create(
+                protocol="https",
+                host="shared-inherit.example.com",
+                product=other_product,
+            )
+        Endpoint_Status.objects.create(
+            endpoint=other_endpoint,
+            finding=other_finding,
+            date=datetime.date(2024, 5, 17),
+            mitigated=False,
+        )
+
+        self._run(batch_size=1)
+
+        location = self._location_for("shared-inherit.example.com")
+        self.assertEqual(
+            sorted(tag.name for tag in location.inherited_tags.all()),
+            ["tag-product-one", "tag-product-two"],
         )


### PR DESCRIPTION
## Summary

The endpoint→location migration command is already chunked, converging on
re-runs, and failure-isolated — but it still fell over at large-install scale
(it has failed on a large on-prem evaluation) for two reasons this PR removes:

1. **Unbounded memory.** The command retained a full `Location` ORM object —
   plus product→location id maps — for **every endpoint it migrated, for the
   whole run**, solely to drive a single end-of-run tag inheritance pass. On a
   multi-million-endpoint install that is gigabytes of retained objects; the
   process dies long before the pass runs.
2. **No resume point.** An interrupted run could only start over. Re-running
   converges (by design), but only after re-paying the full scan — hours on the
   installs this command exists for.

### Changes

- **Tag inheritance runs per chunk.** `apply_inherited_tags_for_locations`
  recomputes each location's *full* product set from the committed reference
  rows at call time, so a shared location that gains another product's
  references in a later chunk converges exactly like the existing
  product-status reconcile pass (order-independent). All per-endpoint
  bookkeeping now lives on the chunk's `_ChunkRows` and is dropped with it —
  the run keeps only aggregate counters. The pass gets its own `--benchmark`
  phase (`inheritance`).
- **Resume cursor.** Endpoints are scanned in explicit `id` order; every
  progress line prints the last migrated id and the exact flag to resume with
  (`resume: --start-after-id N`). `--start-after-id` filters `id__gt`, so an
  interrupted run picks up where it stopped instead of rescanning. A full
  re-run without the flag remains safe (unchanged convergence semantics).
- **Failure-detail cap.** The per-endpoint failure list (id + exception
  string) is capped at 1,000 entries so a pathologically failing run can't
  balloon memory either; the failure *count* in the summary stays exact.

The `call_command("migrate_endpoints_to_locations")` invocation from the
migrate-endpoints UI view is unchanged — the new argument is optional.

### Tests

13/13 in `test_migrate_endpoints_to_locations` (10 existing + 3 new):

- `test_start_after_id_resumes_from_the_cursor` — cursor skips earlier
  endpoints; follow-up full run converges.
- `test_progress_line_reports_resume_cursor` — the resume flag is printed.
- `test_inheritance_converges_for_location_shared_across_chunks` — one URL
  shared by endpoints in two different products, forced into separate chunks
  (`batch_size=1`), ends with the union of both products' inherited tags.

Also green: `test_tag_inheritance`, `test_tag_inheritance_perf`,
`test_tag_utils_bulk` (92 tests). ruff 0.16.1 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
