### PR TITLE
fix(notes): visible_notes handles a paginated list, not just a queryset

### DIFF
--- a/dojo/notes/helper.py
+++ b/dojo/notes/helper.py
@@ -30,12 +30,22 @@ def visible_notes(notes, user):
     Every read path goes through here, so the API and the UI cannot drift apart
     on what ``private`` means. A caller with no user (report rendering) gets the
     non-private notes only.
+
+    ``notes`` is usually a queryset, but DRF pagination evaluates the queryset
+    before serialization and hands the note serializer the page as a plain
+    ``list``, which has no ``filter``. Apply the same rule to either form so a
+    paginated read does not 500 for a non-superuser.
     """
-    if user is None:
-        return notes.filter(private=False)
-    if user.is_superuser:
+    if user is not None and user.is_superuser:
         return notes
-    return notes.filter(Q(private=False) | Q(author=user))
+    if hasattr(notes, "filter"):
+        if user is None:
+            return notes.filter(private=False)
+        return notes.filter(Q(private=False) | Q(author=user))
+    # An already-evaluated collection (e.g. a pagination page): filter in Python.
+    if user is None:
+        return [note for note in notes if not note.private]
+    return [note for note in notes if not note.private or note.author_id == user.pk]
 
 
 def delete_related_notes(obj):

--- a/unittests/test_apiv2_note_visibility.py
+++ b/unittests/test_apiv2_note_visibility.py
@@ -151,6 +151,26 @@ class NoteVisibilityTest(DojoAPITestCase):
     def test_helper_without_a_user_gives_only_the_public_one(self):
         self.assertEqual({PUBLIC}, self._entries(None))
 
+    def test_helper_accepts_an_already_evaluated_list(self):
+        """A paginated notes page arrives as a list, not a queryset.
+
+        DRF pagination evaluates the queryset before serialization, so
+        ``VisibleNotesSerializer.to_representation`` hands ``visible_notes`` a
+        plain ``list``. The non-superuser and no-user branches used to call
+        ``list.filter(...)``, so every paginated notes read 500'd for a
+        non-superuser. The rule must apply identically whether it is given a
+        queryset or an already-evaluated page.
+        """
+        page = list(self.finding.notes.all())  # exactly what DRF pagination passes
+
+        def entries(user):
+            return {n.entry for n in visible_notes(page, user)}
+
+        self.assertEqual({PUBLIC}, entries(self.colleague))
+        self.assertEqual({PRIVATE, PUBLIC}, entries(self.author))
+        self.assertEqual({PRIVATE, PUBLIC}, entries(self.superuser))
+        self.assertEqual({PUBLIC}, entries(None))
+
     def test_finding_page_context_is_filtered(self):
         client = Client()
         client.force_login(self.colleague)

--- a/unittests/test_apiv2_note_visibility.py
+++ b/unittests/test_apiv2_note_visibility.py
@@ -152,7 +152,8 @@ class NoteVisibilityTest(DojoAPITestCase):
         self.assertEqual({PUBLIC}, self._entries(None))
 
     def test_helper_accepts_an_already_evaluated_list(self):
-        """A paginated notes page arrives as a list, not a queryset.
+        """
+        A paginated notes page arrives as a list, not a queryset.
 
         DRF pagination evaluates the queryset before serialization, so
         ``VisibleNotesSerializer.to_representation`` hands ``visible_notes`` a


### PR DESCRIPTION
## Description

`dojo/notes/helper.py::visible_notes()` assumed its input is always a queryset and called `.filter()` on it. But `NoteSerializer.Meta.list_serializer_class = VisibleNotesSerializer`, and under DRF pagination the list serializer's `to_representation` receives the page as a plain **`list`** — the queryset is evaluated into a page before serialization. `VisibleNotesSerializer` only special-cases a `Manager`, so it passed that list straight to `visible_notes()`, which then did `list.filter(...)`:

```
AttributeError: 'list' object has no attribute 'filter'   ->   HTTP 500 on the notes read
```

Superusers skip the `.filter()` branch (they receive everything), so this only surfaced for **non-superusers** and the no-user report-rendering path — on any **paginated** notes read.

## Fix

Make `visible_notes()` apply the same visibility rule whether it receives a queryset or an already-evaluated iterable:

- queryset / manager → keep the existing ORM `.filter(...)`,
- an already-evaluated page (a `list`) → apply the identical rule in Python.

`visible_notes` is the single choke-point every read path (API + UI) shares, so this needs no changes at any call site, and the UI callers (which pass querysets) are unaffected.

## Tests

Added `unittests/test_apiv2_note_visibility.py::NoteVisibilityTest::test_helper_accepts_an_already_evaluated_list`, which passes a `list` (exactly what pagination hands the serializer) for author / colleague / superuser / no-user and asserts the same visibility the queryset path already enforces. It fails before this change with `AttributeError: 'list' object has no attribute 'filter'` and passes after.

Regression introduced with the private-note visibility work (`VisibleNotesSerializer` / `visible_notes`); the existing helper tests only exercised the queryset form, so the paginated-list path went uncovered.
