### PR TITLE
refactor(locations): let locations be recorded before the finding is written

### DIFF
--- a/dojo/importers/location_manager.py
+++ b/dojo/importers/location_manager.py
@@ -38,8 +38,22 @@ class LocationManager(BaseLocationManager):
 
     def __init__(self, product: Product) -> None:
         super().__init__(product)
-        # Maps findings to a list of cleaned locations
-        self._locations_by_finding: dict[Finding, list[AbstractLocation]] = {}
+        # Findings paired with their cleaned locations, in first-recorded order.
+        #
+        # A list of pairs rather than a dict keyed by the finding, because a Finding that has not
+        # been written yet has no primary key and Django's Model.__hash__ raises on it
+        # ("Model instances without primary key value are unhashable"). Keying by the object would
+        # therefore forbid recording locations for a finding before it is saved -- and with it any
+        # importer that buffers inserts to write them in bulk at a batch boundary. Nothing here
+        # needs the object to be hashable: both consumers in _persist_locations() simply iterate,
+        # and they run inside persist(), by which point the findings are written. The tag
+        # accumulator threaded through finding_post_processing() already uses this same shape.
+        self._locations_by_finding: list[tuple[Finding, list[AbstractLocation]]] = []
+        # Slot index into the list above so repeated records for one finding coalesce, keyed by
+        # object identity rather than by the finding itself for the reason above. id() is safe
+        # here specifically because the list holds a strong reference to every finding recorded,
+        # so no entry can be collected and have its id reused while this accumulator is live.
+        self._location_slot_by_finding: dict[int, int] = {}
         # All locations needing product refs (finding-associated + product-only), cleaned at record time
         self._product_locations: list[AbstractLocation] = []
         # Status update entries, which we'll use at persist-time to determine Location statuses by comparing
@@ -70,7 +84,12 @@ class LocationManager(BaseLocationManager):
     ) -> None:
         """Record locations that have already been through clean_unsaved_locations()."""
         if cleaned:
-            self._locations_by_finding.setdefault(finding, []).extend(cleaned)
+            slot = self._location_slot_by_finding.get(id(finding))
+            if slot is None:
+                self._location_slot_by_finding[id(finding)] = len(self._locations_by_finding)
+                self._locations_by_finding.append((finding, list(cleaned)))
+            else:
+                self._locations_by_finding[slot][1].extend(cleaned)
             self._product_locations.extend(cleaned)
 
     def update_location_status(
@@ -153,8 +172,7 @@ class LocationManager(BaseLocationManager):
         # full set — _product_locations is the superset of all locations (finding-associated + product-only).
         all_locations = list({(type(loc), loc.identity_hash): loc for loc in self._product_locations}.values())
         if not all_locations:
-            self._locations_by_finding.clear()
-            self._product_locations.clear()
+            self._clear_location_accumulators()
             return
 
         # Bulk persist all locations to the database
@@ -193,7 +211,7 @@ class LocationManager(BaseLocationManager):
 
         # Determine necessary finding refs to create
         if self._locations_by_finding:
-            all_finding_ids = [finding.id for finding in self._locations_by_finding]
+            all_finding_ids = [finding.id for finding, _ in self._locations_by_finding]
             # Strictly speaking this returns more rows than we need (it's the cross of the location/finding lists rather
             # than scoped per-finding), but more straightforward than constructing a per-finding lookup. We won't create
             # any unwanted associations below anyway.
@@ -204,7 +222,7 @@ class LocationManager(BaseLocationManager):
                 ).values_list("finding_id", "location_id"),
             )
 
-            for finding, cleaned_locations in self._locations_by_finding.items():
+            for finding, cleaned_locations in self._locations_by_finding:
                 # Locations were already cleaned at record time — identity_hash is set, so we can
                 # look up the persisted location directly.
                 for location in cleaned_locations:
@@ -245,7 +263,17 @@ class LocationManager(BaseLocationManager):
             )
 
         # Clear accumulators
+        self._clear_location_accumulators()
+
+    def _clear_location_accumulators(self) -> None:
+        """
+        Reset the location accumulators together.
+
+        The slot index is derived from the pair list, so clearing one without the other would
+        leave stale slots pointing past the end of the list.
+        """
         self._locations_by_finding.clear()
+        self._location_slot_by_finding.clear()
         self._product_locations.clear()
 
     def _persist_status_updates(self) -> None:

--- a/unittests/test_bulk_locations.py
+++ b/unittests/test_bulk_locations.py
@@ -668,3 +668,100 @@ class TestDedupeLocationAccess(DojoTestCase):
         f2 = self._finding_with_location("host-b.example.com")
         loaded = get_finding_models_for_deduplication([f1.id, f2.id])
         self.assertFalse(are_locations_duplicates(loaded[0], loaded[1]))
+
+
+# ---------------------------------------------------------------------------
+# Recording locations before the finding is written
+# ---------------------------------------------------------------------------
+@skip_unless_v3
+class TestRecordBeforeFindingIsSaved(DojoTestCase):
+
+    """
+    Locations must be recordable for a finding that has not been written yet.
+
+    An importer that buffers inserts and writes them in bulk at a batch boundary records a
+    finding's locations while it is still unsaved. That used to be impossible for a reason
+    unrelated to locations: the accumulator was a dict keyed by the finding, and Django's
+    Model.__hash__ raises on an instance with no primary key. Nothing about persisting
+    locations needs the finding hashable -- persist() runs after the findings are written --
+    so the accumulator holds pairs instead.
+    """
+
+    def _unsaved_finding_on_a_real_product(self):
+        """A Finding with a real test/product but deliberately never saved."""
+        saved = _make_finding()
+        return Finding(test=saved.test, title="Unsaved", severity="Medium", reporter=saved.reporter), saved
+
+    def test_recording_for_an_unsaved_finding_does_not_raise(self):
+        unsaved, saved = self._unsaved_finding_on_a_real_product()
+        mgr = LocationManager(saved.test.engagement.product)
+
+        self.assertIsNone(unsaved.pk, "premise: the finding under test must be unsaved")
+        mgr.record_locations_for_finding(unsaved, [_make_url("unsaved-record.example.com")])
+
+        self.assertEqual(len(mgr._locations_by_finding), 1)
+        recorded_finding, recorded_locations = mgr._locations_by_finding[0]
+        self.assertIs(recorded_finding, unsaved)
+        self.assertEqual(len(recorded_locations), 1)
+
+    def test_repeated_records_for_one_unsaved_finding_coalesce(self):
+        """record_for_finding() records twice (unsaved_locations, then extras) for one finding."""
+        unsaved, saved = self._unsaved_finding_on_a_real_product()
+        mgr = LocationManager(saved.test.engagement.product)
+
+        mgr.record_locations_for_finding(unsaved, [_make_url("coalesce-a.example.com")])
+        mgr.record_locations_for_finding(unsaved, [_make_url("coalesce-b.example.com")])
+
+        self.assertEqual(len(mgr._locations_by_finding), 1, "one finding must occupy one slot")
+        self.assertEqual(len(mgr._locations_by_finding[0][1]), 2)
+
+    def test_two_distinct_unsaved_findings_do_not_collide(self):
+        """
+        Identity keying, not equality keying.
+
+        Two unsaved findings are `==` to each other under Django's Model.__eq__ (both have
+        pk None), so an equality-keyed accumulator would merge their locations. Keying on
+        object identity keeps them apart.
+        """
+        first, saved = self._unsaved_finding_on_a_real_product()
+        second = Finding(test=saved.test, title="Unsaved two", severity="Medium", reporter=saved.reporter)
+        mgr = LocationManager(saved.test.engagement.product)
+
+        mgr.record_locations_for_finding(first, [_make_url("distinct-a.example.com")])
+        mgr.record_locations_for_finding(second, [_make_url("distinct-b.example.com")])
+
+        self.assertEqual(len(mgr._locations_by_finding), 2)
+        self.assertEqual([entry[0] for entry in mgr._locations_by_finding], [first, second])
+
+    def test_locations_recorded_before_the_write_persist_after_it(self):
+        """The end-to-end shape a batched writer needs: record unsaved, write, then persist."""
+        unsaved, saved = self._unsaved_finding_on_a_real_product()
+        product = saved.test.engagement.product
+        mgr = LocationManager(product)
+
+        mgr.record_locations_for_finding(unsaved, [_make_url("deferred-write.example.com", "/api")])
+        # The buffered write happens here, exactly as a batched writer would flush it.
+        unsaved.save()
+        mgr.persist()
+
+        refs = LocationFindingReference.objects.filter(finding=unsaved)
+        self.assertEqual(refs.count(), 1)
+        self.assertEqual(refs.first().location.url.host, "deferred-write.example.com")
+
+    def test_accumulators_are_cleared_together(self):
+        """A stale slot index would point past the end of the emptied pair list."""
+        unsaved, saved = self._unsaved_finding_on_a_real_product()
+        mgr = LocationManager(saved.test.engagement.product)
+
+        mgr.record_locations_for_finding(unsaved, [_make_url("cleared.example.com")])
+        unsaved.save()
+        mgr.persist()
+
+        self.assertEqual(mgr._locations_by_finding, [])
+        self.assertEqual(mgr._location_slot_by_finding, {})
+
+        # A second cycle on the same manager must start from a clean slate, not reuse a slot.
+        again = Finding(test=saved.test, title="Second cycle", severity="Medium", reporter=saved.reporter)
+        mgr.record_locations_for_finding(again, [_make_url("second-cycle.example.com")])
+        self.assertEqual(len(mgr._locations_by_finding), 1)
+        self.assertIs(mgr._locations_by_finding[0][0], again)


### PR DESCRIPTION
## What

`LocationManager` accumulated a finding's locations in a dict keyed by the `Finding` itself:

```python
self._locations_by_finding.setdefault(finding, []).extend(cleaned)
```

Django's `Model.__hash__` raises when the instance has no primary key, so recording a location for a finding that has not been saved yet is a hard `TypeError`:

```
TypeError: cannot use 'dojo.finding.models.Finding' as a dict key
           (Model instances without primary key value are unhashable)
```

This changes the accumulator to a list of `(finding, locations)` pairs, with a slot index keyed on object identity so repeated records for one finding still coalesce.

## Why

Nothing about persisting locations needs the finding to be hashable. Both consumers in `_persist_locations()` just iterate — `[finding.id for finding, _ in ...]` and a `for finding, cleaned_locations in ...` — and both run inside `persist()`, by which point the findings are written. The dict was there only to coalesce, because `record_for_finding()` records twice: once for `unsaved_locations`, once for the form-added extras.

A list of pairs is also the shape this file's neighbour already uses — the tag accumulator threaded through `finding_post_processing()` is `tag_accumulator.append((finding, cleaned_tags))`, PK-free for the same reason.

**Identity keying is more correct than the dict was, independently of the above.** Two distinct unsaved findings compare equal under `Model.__eq__` (both have `pk` `None`), so an equality-keyed accumulator silently merges their locations. Keying on `id()` keeps them apart. `id()` is safe here specifically because the pair list holds a strong reference to every finding recorded, so no entry can be collected and have its id reused while the accumulator is live — that is the obvious objection to `id()` as a key, and it does not apply.

The two accumulators are now cleared through one `_clear_location_accumulators()` helper, since the slot index is derived from the pair list and clearing either alone would leave slots pointing past the end of the list.

## What it unblocks

An importer that buffers inserts and writes them in bulk at a batch boundary records a finding's locations while that finding is still unsaved. Today it cannot: the buffered finding hits the dict key and raises. That is the whole of this change's motivation, and it is the same accommodation `get_original_findings`, `get_reimport_match_candidates_for_batch` and `_flush_post_processing_batch` already provide so downstream editions can override behaviour without copying the full `process_findings()` implementation. `get_original_findings`' own docstring says so:

> This is intentionally a separate method (like get_reimport_match_candidates_for_batch) so downstream editions can override it without copying the full process_findings() implementation

To be clear about scope: this removes the location edge only. It is not by itself sufficient to buffer inserts — `process_files()`' m2m `finding.files.add()`, `process_finding_groups()`, and the trailing conditional `finding.save()` in `finding_post_processing()` all still read or need a primary key. Those are untouched here.

## Behaviour

Behaviour-neutral on every existing path. The same findings receive the same locations, in the same order, at the same time; only the container changed. The one difference is the previously-impossible case: recording for an unsaved finding now works instead of raising.

There is no change to query counts — `test_importers_performance` passes against the existing pinned baselines, unmodified.

## Tests

Five new tests in `unittests/test_bulk_locations.py`:

- recording for an unsaved finding does not raise, and lands in the accumulator
- repeated records for one unsaved finding coalesce into a single slot (the `record_for_finding()` double-record path)
- two distinct unsaved findings do **not** collide — the `Model.__eq__` trap above
- the end-to-end sequence a batched writer needs: record while unsaved, write, then `persist()`, and the `LocationFindingReference` comes out correct
- both accumulators clear together, and a second cycle on the same manager does not reuse a stale slot

**Falsifiability was checked by reverting the source with the tests in place**, rather than by reasoning about it: all five error with the `TypeError` quoted above, and pass with the change.

Run natively (Django runner, PostgreSQL):

- `test_bulk_locations`, `test_location_models`, `test_merge_findings_locations`, `test_code_location_emission`, `test_report_location_finding_scoping`, `test_importers_closeold`, `test_importers_deduplication`, `test_reimport_batch_flush` — **131 OK**
- `test_import_reimport`, `test_importers_performance` — **143 OK**, pinned query counts unchanged

`ruff` clean at the `requirements-lint.txt` pin (0.16.1).

`_locations_by_finding` has no other readers or writers anywhere in the repo, so the change is contained to this one file.
