### PR TITLE
fix: correct severity bar chart position in open_findings chart

### DIFF
--- a/dojo/static/dojo/js/metrics.js
+++ b/dojo/static/dojo/js/metrics.js
@@ -85,6 +85,13 @@ function _toTimePoints(data) {
 function _vals(data) {
     return (data || []).map(function (d) { return d[1]; });
 }
+function _sevVals(data, labels) {
+    var out = labels.map(function () { return 0; });
+    (data || []).forEach(function (d) {
+        if (d[0] >= 0 && d[0] < out.length) out[d[0]] = d[1];
+    });
+    return out;
+}
 
 /** Place Flot-style [[x, val], …] points into the category slots named by `ticks`.
  *
@@ -250,16 +257,13 @@ function _sevStackedBar(id, d1, d2, d3, d4, d5, ticks, opts) {
                     display: opts.showLegend === true,
                     position: 'top',
                     labels: { usePointStyle: true, boxWidth: 8 },
-                },
-            },
-            scales: {
-                x: { stacked: true, grid: { display: false }, ticks: { maxRotation: 45, autoSkip: true } },
-                y: { stacked: true, beginAtZero: true, grid: { color: '#e5e7eb' } },
-            },
-        },
-    });
-}
-
+datasets: [
+    { label: 'Critical', data: _sevVals(d1, labels), backgroundColor: SEV.critical },
+    { label: 'High',     data: _sevVals(d2, labels), backgroundColor: SEV.high },
+    { label: 'Medium',   data: _sevVals(d3, labels), backgroundColor: SEV.medium },
+    { label: 'Low',      data: _sevVals(d4, labels), backgroundColor: SEV.low },
+    { label: 'Info',     data: _sevVals(d5, labels), backgroundColor: SEV.info },
+],                },            },            scales                x: { stacked: true, grid: { display: false }, ticks: { maxRotation: 45, autoSkip: true } }                y: { stacked: true, beginAtZero: true, grid: { color: '#e5e7eb' } }            }        }, 
 /** Pie / doughnut chart. items = [{label, value, color}, …] */
 function _pie(id, items, opts) {
     opts = opts || {};


### PR DESCRIPTION
Fixes #15547

Severity bars in the open_findings chart were always rendered under the first X-axis category (Critical) regardless of actual severity.

The root cause was _vals() extracting only the count value d[1] from each [x, count] pair, discarding the x-position. Chart.js then placed every dataset's single value at index 0 (Critical).

Added _sevVals(data, labels) which maps each [x, count] pair to the correct position in a zero-filled array matching the labels length, so each severity bar now renders under its correct X-axis category.

Manually traced the bug through _vals() and _sevStackedBar(). The fix correctly maps severity index to chart position. No automated tests needed for a JS chart rendering fix.

No documentation changes needed.