### PR TITLE
fix(notes): keep note body on partial PATCH and avoid null NoteHistory

### DIFF
--- a/dojo/notes/api/serializer.py
+++ b/dojo/notes/api/serializer.py
@@ -34,7 +34,17 @@ class NoteSerializer(serializers.ModelSerializer):
     note_type = NoteTypeSerializer(read_only=True, many=False)
 
     def update(self, instance, validated_data):
-        instance.entry = validated_data.get("entry")
+        # A partial (PATCH) update may omit "entry" entirely -- e.g. a body that
+        # only carries read-only fields such as note_type. Previously this set
+        # entry to None, blanking the note body, and then built a NoteHistory
+        # with data=None, violating the NOT NULL constraint on
+        # dojo_notehistory.data (HTTP 500). Only record an edit + history
+        # revision when the body actually changes.
+        new_entry = validated_data.get("entry", instance.entry)
+        if "entry" not in validated_data or new_entry == instance.entry:
+            instance.save()
+            return instance
+        instance.entry = new_entry
         instance.edited = True
         instance.editor = self.context["request"].user
         instance.edit_time = timezone.now()

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -3008,6 +3008,51 @@ class NotesTest(BaseClass.BaseClassTest):
         self.test_type = TestType.STANDARD
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
+    # Regression: PATCH /api/v2/notes/<id>/ without an "entry" (e.g. a body that
+    # only carries read-only fields such as note_type) set entry to None and
+    # inserted a NoteHistory row with data=NULL, hitting the NOT NULL constraint
+    # on dojo_notehistory.data -> HTTP 500. It also silently blanked the note body.
+    @parameterized.expand([
+        # (patch payload, does the note body change?)
+        ({"note_type": None}, False),   # only a read-only field -> empty validated_data
+        ({}, False),                    # empty partial update
+        ({"entry": "changed via patch"}, True),
+    ])
+    def test_partial_update_entry_handling(self, patch_payload, entry_should_change):
+        listing = self.client.get(self.url, format="json").data
+        note_id = listing["results"][0]["id"]
+        detail_url = f"{self.url}{note_id}/"
+        original_entry = Notes.objects.get(id=note_id).entry
+        history_before = Notes.objects.get(id=note_id).history.count()
+
+        response = self.client.patch(detail_url, patch_payload, format="json")
+        self.assertEqual(200, response.status_code, response.content[:1000])
+
+        note = Notes.objects.get(id=note_id)
+        # A NoteHistory row is never written with data=NULL, whichever payload.
+        self.assertFalse(
+            note.history.filter(data__isnull=True).exists(),
+            msg="a NoteHistory row was persisted with data=NULL",
+        )
+        if entry_should_change:
+            self.assertEqual(
+                note.entry, "changed via patch",
+                msg=f"expected entry updated, persisted={note.entry!r}",
+            )
+            self.assertEqual(
+                note.history.count(), history_before + 1,
+                msg="an entry change should append exactly one history revision",
+            )
+        else:
+            self.assertEqual(
+                note.entry, original_entry,
+                msg=f"expected entry preserved={original_entry!r}, persisted={note.entry!r}",
+            )
+            self.assertEqual(
+                note.history.count(), history_before,
+                msg="a partial update that leaves the body unchanged must add no history",
+            )
+
 
 @versioned_fixtures
 class UsersTest(BaseClass.BaseClassTest):


### PR DESCRIPTION
**Description**

A `PATCH /api/v2/notes/<id>/` whose body does **not** include `entry` — for
example a partial update that only carries a read-only field such as
`note_type` — crashed with an HTTP 500.

`NoteSerializer.update()` (`dojo/notes/api/serializer.py`) unconditionally did:

```python
instance.entry = validated_data.get("entry")   # -> None when "entry" is absent
...
history = NoteHistory(data=instance.entry, ...)  # data=None
history.save()
```

On a partial update that omits `entry`, `validated_data.get("entry")` returns
`None`, so the code (1) blanked the note body and (2) tried to insert a
`NoteHistory` row with `data=None`, violating the `NOT NULL` constraint on
`dojo_notehistory.data`:

```
django.db.utils.IntegrityError: null value in column "data" of relation
"dojo_notehistory" violates not-null constraint
```

Because the DELETE-safe fields (`note_type` etc.) are read-only on the
serializer, a body like `{"note_type": 1}` produces empty `validated_data` and
reliably triggers this.

**Fix**

`update()` now preserves the existing `entry` when the request does not change
the body, and only records an edit (`edited` / `editor` / `edit_time`) plus a
`NoteHistory` revision when the body actually changes. A partial update that
touches nothing (or only read-only fields) is now a safe no-op that returns
`200` and leaves the note — and its history — untouched.

No migration is required; this is a pure serializer-logic change.

**Impact on downstream (Pro) behavior**

The Pro `NotesViewSet` replaces the OSS `/api/v2/notes/` route but delegates
edit semantics to this same serializer via `super().update()` (its `update()`
comment states "the serializer owns the edit semantics … which is how upstream
did it"). Fixing the serializer here therefore also fixes the partial-update
crash on the Pro notes endpoint, with no companion change needed.

**Test results**

Added `NotesTest.test_partial_update_entry_handling` in
`unittests/test_rest_framework.py`, parameterized over three request shapes:

- a body with only a read-only field (`{"note_type": None}`) — body preserved,
  no history added, no `data=NULL` row;
- an empty partial body (`{}`) — same;
- a real body change (`{"entry": ...}`) — entry updated and exactly one history
  revision appended.

Each case asserts on the **persisted** `Notes` row (entry value and history
count), not just the response. Before the fix the two entry-less cases fail
(500 / `NOT NULL` violation); after the fix all three pass. The pre-existing
`NotesTest` update coverage (which sends `entry`) is unchanged.

`ruff check --config ruff.toml` passes on both changed files with the pinned
0.16.0.

**Documentation**

None required — this restores expected API behavior on an existing endpoint and
adds no new setting or surface.

**Checklist**

- [x] Bugfix submitted against the `bugfix` branch.
- [x] Meaningful PR name (may be used in release notes).
- [x] Ruff compliant (0.16.0).
- [x] Python 3.13 compliant.
- [x] No model changes / no migration.
- [x] Unit tests added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R3YvxfHCUSuRuMMHG1eHZh)_