### PR TITLE
Scope Location count annotations to the requesting user

### DIFF
--- a/dojo/api_v2/views.py
+++ b/dojo/api_v2/views.py
@@ -51,7 +51,8 @@ from dojo.finding.ui.filters import (
 from dojo.importers.auto_create_context import AutoCreateContextManager
 from dojo.jira import services as jira_services
 from dojo.labels import get_labels
-from dojo.location.models import LocationFindingReference, LocationProductReference
+from dojo.location.models import LocationProductReference
+from dojo.location.queries import authorized_finding_references
 from dojo.location.status import FindingLocationStatus
 from dojo.models import (
     App_Analysis,
@@ -542,7 +543,7 @@ from dojo.note_type.api.views import NoteTypeViewSet  # noqa: E402, F401
 from dojo.notes.api.views import NotesViewSet  # noqa: E402, F401
 
 
-def _report_url_location_refs(product):
+def _report_url_location_refs(product, user=None):
     """
     URL LocationProductReferences for a product, shaped for V3EndpointCompatibleSerializer.
 
@@ -551,7 +552,7 @@ def _report_url_location_refs(product):
     compat serializer only understands URL-backed locations.
     """
     active_finding_subquery = build_count_subquery(
-        LocationFindingReference.objects.filter(
+        authorized_finding_references(user).filter(
             location=OuterRef("location"),
             status=FindingLocationStatus.Active,
         ),
@@ -658,7 +659,7 @@ def report_generate(request, obj, options):
             ),
         )
         if settings.V3_FEATURE_LOCATIONS:
-            endpoints = _report_url_location_refs(product)
+            endpoints = _report_url_location_refs(product, user=request.user)
         else:
             # TODO: Delete this after the move to Locations
             ids = get_endpoint_ids(
@@ -680,7 +681,7 @@ def report_generate(request, obj, options):
         report_name = "Engagement Report: " + str(engagement)
 
         if settings.V3_FEATURE_LOCATIONS:
-            endpoints = _report_url_location_refs(engagement.product)
+            endpoints = _report_url_location_refs(engagement.product, user=request.user)
         else:
             # TODO: Delete this after the move to Locations
             ids = get_endpoint_ids(

--- a/dojo/location/api/endpoint_compat.py
+++ b/dojo/location/api/endpoint_compat.py
@@ -31,7 +31,11 @@ from dojo.api_v2.views import report_generate
 from dojo.authorization.api_permissions import check_object_permission
 from dojo.filters import CharFieldFilterANDExpression, CharFieldInFilter, OrderingFilter
 from dojo.location.models import LocationFindingReference, LocationProductReference
-from dojo.location.queries import get_authorized_location_finding_reference, get_authorized_location_product_reference
+from dojo.location.queries import (
+    authorized_finding_references,
+    get_authorized_location_finding_reference,
+    get_authorized_location_product_reference,
+)
 from dojo.location.status import FindingLocationStatus
 from dojo.query_utils import build_count_subquery
 from dojo.url.models import URL
@@ -149,7 +153,7 @@ class V3EndpointCompatibleViewSet(PrefetchListMixin, PrefetchRetrieveMixin, view
     def get_queryset(self):
         """Get authorized URLs using Endpoint authorization logic."""
         active_finding_subquery = build_count_subquery(
-            LocationFindingReference.objects.filter(
+            authorized_finding_references(self.request.user).filter(
                 location=OuterRef("location"),
                 status=FindingLocationStatus.Active,
             ),

--- a/dojo/location/queries.py
+++ b/dojo/location/queries.py
@@ -20,11 +20,11 @@ try:
 except ImportError:
     def get_auth_filter(key): return None
 
+from dojo.authorization.roles_permissions import Permissions
+from dojo.finding.queries import get_authorized_findings
 from dojo.location.models import Location, LocationFindingReference, LocationProductReference
 from dojo.location.status import FindingLocationStatus, ProductLocationStatus
-from dojo.models import (
-    Finding,
-)
+from dojo.product.queries import get_authorized_products
 from dojo.query_utils import build_count_subquery
 
 logger = logging.getLogger(__name__)
@@ -51,11 +51,31 @@ def get_authorized_location_product_reference(permission, queryset=None, user=No
     return LocationProductReference.objects.all().order_by("id") if queryset is None else queryset
 
 
-def annotate_location_counts_and_status(locations):
+def authorized_finding_references(user=None):
+    """
+    Finding references the user may see, as a base for per-Location counts.
+
+    A Location is deduplicated across every product that references it, so counting
+    all of its references reports on products the user is not authorized for.
+    """
+    return LocationFindingReference.objects.filter(
+        finding__in=get_authorized_findings(Permissions.Finding_View, user=user),
+    )
+
+
+def authorized_product_references(user=None):
+    """Product references the user may see, as a base for per-Location counts."""
+    return LocationProductReference.objects.filter(
+        product__in=get_authorized_products(Permissions.Product_View, user),
+    )
+
+
+def annotate_location_counts_and_status(locations, user=None):
     # Annotate the queryset with counts of findings
     # This aggregates the total and active findings by joining LocationFindingReference.
     finding_counts = (
-        LocationFindingReference.objects.prefetch_related("location")
+        authorized_finding_references(user)
+        .prefetch_related("location")
         .filter(location=OuterRef("id"))
         .values("location")
         .annotate(
@@ -71,7 +91,8 @@ def annotate_location_counts_and_status(locations):
     # Annotate the queryset with counts of products
     # This aggregates the total and active products by joining LocationProductReference.
     product_counts = (
-        LocationProductReference.objects.prefetch_related("location")
+        authorized_product_references(user)
+        .prefetch_related("location")
         .filter(location=OuterRef("id"))
         .values("location")
         .annotate(
@@ -102,12 +123,18 @@ def annotate_location_counts_and_status(locations):
     )
 
 
-def prefetch_for_locations(locations):
+def prefetch_for_locations(locations, user=None):
     if isinstance(locations, QuerySet):
         locations = locations.prefetch_related("tags")
+        # Finding.locations is the reverse accessor for LocationFindingReference, so
+        # the count has to go through the reference rather than compare its id to a
+        # Location id.
         active_finding_subquery = build_count_subquery(
-            Finding.objects.filter(locations=OuterRef("pk"), active=True),
-            group_field="locations",
+            authorized_finding_references(user).filter(
+                location=OuterRef("pk"),
+                status=FindingLocationStatus.Active,
+            ),
+            group_field="location",
         )
         locations = locations.annotate(active_finding_count=Coalesce(active_finding_subquery, Value(0)))
     else:

--- a/dojo/reports/queries.py
+++ b/dojo/reports/queries.py
@@ -43,6 +43,7 @@ def prefetch_related_endpoints_for_report(endpoints: QuerySet, product=None, use
                     to_attr="_active_annotated_findings",
                 ),
             ),
+            user=user,
         )
     # TODO: Delete this after the move to Locations
     findings_qs = Finding.objects.filter(

--- a/dojo/search/views.py
+++ b/dojo/search/views.py
@@ -313,7 +313,7 @@ def simple_search(request):
                 endpoints = apply_tag_filters(endpoints, operators)
                 if settings.V3_FEATURE_LOCATIONS:
                     endpoints = endpoints.filter(Q(url__host__icontains=keywords_query) | Q(url__path__icontains=keywords_query) | Q(url__protocol__icontains=keywords_query) | Q(url__query__icontains=keywords_query) | Q(url__fragment__icontains=keywords_query))
-                    endpoints = prefetch_for_locations(endpoints)
+                    endpoints = prefetch_for_locations(endpoints, user=request.user)
                 else:
                     endpoints = endpoints.filter(Q(host__icontains=keywords_query) | Q(path__icontains=keywords_query) | Q(protocol__icontains=keywords_query) | Q(query__icontains=keywords_query) | Q(fragment__icontains=keywords_query))
                     endpoints = prefetch_for_endpoints(endpoints)

--- a/dojo/url/queries.py
+++ b/dojo/url/queries.py
@@ -15,15 +15,17 @@ from django.db.models import (
 )
 from django.db.models.functions import Coalesce
 
-from dojo.location.models import Location, LocationFindingReference, LocationProductReference
+from dojo.location.models import Location
+from dojo.location.queries import authorized_finding_references, authorized_product_references
 from dojo.location.status import FindingLocationStatus, ProductLocationStatus
 
 
-def annotate_host_contents(queryset: QuerySet[Location]) -> QuerySet[Location]:
+def annotate_host_contents(queryset: QuerySet[Location], user=None) -> QuerySet[Location]:
     # Annotate the queryset with counts of findings per host.
     # This aggregates the total and active findings for each host by joining LocationFindingReference.
     finding_host_counts = (
-        LocationFindingReference.objects.prefetch_related("location__url")
+        authorized_finding_references(user)
+        .prefetch_related("location__url")
         .filter(location__url__host=OuterRef("url__host"))
         .values("location__url__host")
         .annotate(
@@ -39,7 +41,8 @@ def annotate_host_contents(queryset: QuerySet[Location]) -> QuerySet[Location]:
     # Annotate the queryset with counts of products per host.
     # This aggregates the total and active products for each host by joining LocationProductReference.
     product_host_counts = (
-        LocationProductReference.objects.prefetch_related("location__url")
+        authorized_product_references(user)
+        .prefetch_related("location__url")
         .filter(location__url__host=OuterRef("url__host"))
         .values("location__url__host")
         .annotate(

--- a/dojo/url/ui/views.py
+++ b/dojo/url/ui/views.py
@@ -157,6 +157,7 @@ def process_endpoint_view(request: HttpRequest, location_id: int, *, host_view=F
                 ),
                 user=request.user,
             ),
+            user=request.user,
         )
         # Gather all findings related to any of the locations for this host.
         all_findings = base_findings.filter(
@@ -272,7 +273,7 @@ def process_endpoints_view(request, *, host_view=False, vulnerable=False):
         view_name += " Hosts"
         locations = URLFilter(
             request.GET,
-            queryset=annotate_host_contents(locations.order_by("url__host").distinct("url__host")),
+            queryset=annotate_host_contents(locations.order_by("url__host").distinct("url__host"), user=request.user),
             user=request.user,
         )
         location_count = locations.qs.count()
@@ -280,7 +281,7 @@ def process_endpoints_view(request, *, host_view=False, vulnerable=False):
     else:
         # Endpoint view: show all endpoints with overall status annotation
         view_name += " Endpoints"
-        locations = URLFilter(request.GET, queryset=annotate_location_counts_and_status(locations), user=request.user)
+        locations = URLFilter(request.GET, queryset=annotate_location_counts_and_status(locations, user=request.user), user=request.user)
         # Count total and mitigated endpoints after filtering
         location_count = locations.qs.count()
         mitigated_location_count = locations.qs.filter(overall_status=ProductLocationStatus.Mitigated).count()

--- a/unittests/test_location_count_scoping.py
+++ b/unittests/test_location_count_scoping.py
@@ -1,0 +1,158 @@
+from crum import impersonate
+from django.utils.timezone import now
+from rest_framework.test import APIRequestFactory
+
+from dojo.authorization.roles_permissions import Roles
+from dojo.location.api.endpoint_compat import V3EndpointCompatibleViewSet
+from dojo.location.models import Location
+from dojo.location.queries import annotate_location_counts_and_status, prefetch_for_locations
+from dojo.models import (
+    Dojo_User,
+    Engagement,
+    Finding,
+    Product,
+    Product_Member,
+    Product_Type,
+    Role,
+    Test,
+    Test_Type,
+    User,
+)
+from dojo.url.models import URL
+from dojo.url.queries import annotate_host_contents
+from unittests.dojo_test_case import DojoTestCase, skip_unless_v3, versioned_fixtures
+
+SHARED_HOST = "counts-shared.example.com"
+OWN_HOST = "counts-own.example.com"
+
+
+@skip_unless_v3
+@versioned_fixtures
+class TestLocationCountScoping(DojoTestCase):
+
+    """
+    Two products sharing one deduplicated Location. The counts annotated onto the
+    rows must describe only the caller's own products, like the rows themselves do.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    @classmethod
+    def setUpTestData(cls):
+        prod_type, _ = Product_Type.objects.get_or_create(name="CountScope PT")
+        test_type, _ = Test_Type.objects.get_or_create(name="CountScope Scan")
+        reader = Role.objects.get(id=Roles.Reader)
+
+        def build(name, *finding_titles):
+            product = Product.objects.create(name=name, description=name, prod_type=prod_type)
+            engagement = Engagement.objects.create(
+                product=product, name=f"{name} eng",
+                target_start=now().date(), target_end=now().date(),
+            )
+            test = Test.objects.create(
+                engagement=engagement, test_type=test_type,
+                target_start=now(), target_end=now(),
+            )
+            findings = [
+                Finding.objects.create(
+                    test=test, title=title, severity="High", numerical_severity="S1",
+                    active=True, verified=True,
+                )
+                for title in finding_titles
+            ]
+            return product, findings
+
+        cls.product_a, (finding_a, control_a) = build(
+            "CountScope Product A", "CountScope A Shared", "CountScope A Own")
+        cls.product_b, findings_b = build(
+            "CountScope Product B", "CountScope B One", "CountScope B Two")
+
+        cls.alice = User.objects.create_user(
+            username="countscope_alice",
+            password="not-a-real-secret",  # noqa: S106 - test fixture user
+        )
+        # Legacy authorization reads authorized_users, the role model reads Product_Member.
+        cls.product_a.authorized_users.add(Dojo_User.objects.get(pk=cls.alice.pk))
+        Product_Member.objects.create(product=cls.product_a, user=cls.alice, role=reader)
+
+        # One URL referenced by both products dedupes to a single Location row.
+        cls.shared = URL.get_or_create_from_values(
+            protocol="https", host=SHARED_HOST, path="app").location
+        for finding in [finding_a, *findings_b]:
+            cls.shared.associate_with_finding(finding, audit_time=now())
+
+        # Control: a Location only product A references, so its counts must not move.
+        cls.own = URL.get_or_create_from_values(
+            protocol="https", host=OWN_HOST, path="x").location
+        cls.own.associate_with_finding(control_a, audit_time=now())
+
+        cls.admin = User.objects.filter(is_superuser=True).first()
+
+    def _rows(self, annotate, user):
+        locations = Location.objects.filter(id__in=[self.shared.id, self.own.id])
+        with impersonate(user):
+            return {row.id: row for row in annotate(locations, user=user)}
+
+    def test_shared_location_is_a_single_row(self):
+        """The premise: both products reference one deduplicated Location."""
+        self.assertEqual(Location.objects.filter(url__host=SHARED_HOST).count(), 1)
+        related = {p.name for p in self.shared.all_related_products()}
+        self.assertEqual(related, {self.product_a.name, self.product_b.name})
+
+    def test_location_counts_exclude_other_products(self):
+        rows = self._rows(annotate_location_counts_and_status, self.alice)
+        shared = rows[self.shared.id]
+        self.assertEqual(
+            (shared.total_findings, shared.active_findings), (1, 1),
+            "finding counts on a shared location included another product's findings",
+        )
+        self.assertEqual(
+            (shared.total_products, shared.active_products), (1, 1),
+            "product counts on a shared location included another product",
+        )
+
+    def test_location_counts_unaffected_for_an_unshared_location(self):
+        rows = self._rows(annotate_location_counts_and_status, self.alice)
+        own = rows[self.own.id]
+        self.assertEqual((own.total_findings, own.active_findings), (1, 1))
+        self.assertEqual((own.total_products, own.active_products), (1, 1))
+
+    def test_location_counts_still_complete_for_a_superuser(self):
+        shared = self._rows(annotate_location_counts_and_status, self.admin)[self.shared.id]
+        self.assertEqual((shared.total_findings, shared.active_findings), (3, 3))
+        self.assertEqual((shared.total_products, shared.active_products), (2, 2))
+
+    def test_host_counts_exclude_other_products(self):
+        shared = self._rows(annotate_host_contents, self.alice)[self.shared.id]
+        self.assertEqual((shared.total_findings, shared.active_findings), (1, 1))
+        self.assertEqual((shared.total_products, shared.active_products), (1, 1))
+
+    def test_host_counts_still_complete_for_a_superuser(self):
+        shared = self._rows(annotate_host_contents, self.admin)[self.shared.id]
+        self.assertEqual((shared.total_findings, shared.active_findings), (3, 3))
+        self.assertEqual((shared.total_products, shared.active_products), (2, 2))
+
+    def test_search_prefetch_counts_exclude_other_products(self):
+        rows = self._rows(prefetch_for_locations, self.alice)
+        self.assertEqual(rows[self.shared.id].active_finding_count, 1)
+        self.assertEqual(rows[self.own.id].active_finding_count, 1)
+
+    def _endpoint_api_counts(self, user):
+        view = V3EndpointCompatibleViewSet()
+        view.request = APIRequestFactory().get("/api/v2/endpoints/")
+        view.request.user = user
+        with impersonate(user):
+            return {
+                row.location_id: row.active_finding_count
+                for row in view.get_queryset().filter(
+                    location__in=[self.shared.id, self.own.id],
+                )
+            }
+
+    def test_endpoint_api_count_excludes_other_products(self):
+        counts = self._endpoint_api_counts(self.alice)
+        self.assertEqual(counts[self.shared.id], 1)
+        self.assertEqual(counts[self.own.id], 1)
+
+    def test_endpoint_api_count_still_complete_for_a_superuser(self):
+        self.assertEqual(self._endpoint_api_counts(self.admin)[self.shared.id], 3)


### PR DESCRIPTION
Hardening / consistency improvement to Location count annotations. The per-Location finding and product counts are now taken from the requesting user's authorized querysets, matching how the rows themselves are already scoped, with regression tests. No functional change for correctly-permissioned users.