### PR TITLE
docs(findings): document Apply/Make Finding Template actions in the Pro UI

### DIFF
--- a/docs/content/asset_modelling/engagements_tests/PRO__findings.md
+++ b/docs/content/asset_modelling/engagements_tests/PRO__findings.md
@@ -257,9 +257,14 @@ Finding Templates can be created by clicking the **New Finding Template** button
 The ensuing page provides an overview of the metadata that will be applied to a Finding when a Finding Template is used.
 
 ### Applying Finding Templates
-Finding Templates differ between OS DefectDojo and DefectDojo Pro. In Pro, Finding Templates can’t be applied to preexisting Findings, and they can’t be created based on preexisting Findings. 
+Finding Templates can be applied to preexisting Findings, and created from preexisting Findings, using the gear menu on a Finding:
 
-However, you can manually add a Finding to a Test based on a Finding Template using either the ⋮ kebab menu next to the Test in the parent Engagement’s view, or using the gear menu in the Test’s view. 
+- **Apply Template to Finding** opens a dialog to select a template. For each field you can keep the Finding's current value, replace it with the template's value, or combine both. Applying the template also copies the template's CVSS scores, remediation and technical detail fields, adds the template's endpoints, and records the template's note on the Finding.
+- **Make Finding a Template** creates a new Finding Template from the Finding, copying its details, tags, vulnerability IDs, and endpoints. Each template title must be unique.
+
+Applying a template requires edit access to the Finding plus access to Finding Templates; creating a template from a Finding requires the "add finding template" configuration permission.
+
+You can also manually add a Finding to a Test based on a Finding Template using either the ⋮ kebab menu next to the Test in the parent Engagement's view, or using the gear menu in the Test's view.
 
 ![image](images/profindings_ss3.png)
 


### PR DESCRIPTION
Documents the two finding-template actions available from a Finding's gear menu in DefectDojo Pro, replacing the outdated note that said templates could not be applied to or created from existing Findings:

- **Apply Template to Finding**: select a template and, per field, keep the Finding's value, replace it with the template's, or combine both. Also copies the template's CVSS, remediation and technical-detail fields, its endpoints, and its note.
- **Make Finding a Template**: create a reusable template from a Finding (details, tags, vulnerability IDs, endpoints); each template title must be unique.

Docs-only change to `docs/content/asset_modelling/engagements_tests/PRO__findings.md`. No code changes.
