### PR TITLE
docs: link the Trust Center and Status page from the footer

### DIFF
--- a/docs/layouts/_partials/footer/footer.html
+++ b/docs/layouts/_partials/footer/footer.html
@@ -41,6 +41,8 @@
         <ul class="list-unstyled footer-links">
           <li><a href="https://defectdojo.com" rel="noopener">DefectDojo.com</a></li>
           <li><a href="https://defectdojo.com/pricing" rel="noopener">Pricing</a></li>
+          <li><a href="https://trust.defectdojo.com" rel="noopener">Trust Center</a></li>
+          <li><a href="https://status.defectdojo.com" rel="noopener">Status</a></li>
           <li><a href="mailto:support@defectdojo.com">Support</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Adds trust.defectdojo.com and status.defectdojo.com to the Company column of the docs footer, on every page. The status page already links to the docs site and the Trust Center from its own navigation, so this completes the loop between the three properties.

Verified with a local production build: both links render in the footer on the homepage and on article pages, and nothing else in the rendered output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)