### PR TITLE
fix(locations): scope /api/v2/location/ by RBAC instead of superuser only

### DIFF
--- a/dojo/location/api/views.py
+++ b/dojo/location/api/views.py
@@ -1,11 +1,10 @@
 from django.db.models import QuerySet
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from dojo.api_v2.views import PrefetchDojoModelViewSet
 from dojo.authorization.api_permissions import (
-    IsSuperUser,
     LocationFindingReferencePermission,
     LocationProductReferencePermission,
 )
@@ -27,6 +26,7 @@ from dojo.location.models import (
 from dojo.location.queries import (
     get_authorized_location_finding_reference,
     get_authorized_location_product_reference,
+    get_authorized_locations,
 )
 
 
@@ -38,11 +38,11 @@ class LocationViewSet(ReadOnlyModelViewSet):
     queryset = Location.objects.none()
     filterset_class = LocationFilter
     filter_backends = [DjangoFilterBackend]
-    permission_classes = (IsSuperUser, DjangoModelPermissions)
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self) -> QuerySet[Location]:
-        """Return the queryset of Locations."""
-        return Location.objects.order_by_id()
+        """Return the queryset of Locations the requesting user may view."""
+        return get_authorized_locations("view", Location.objects.order_by_id())
 
 
 class LocationFindingReferenceViewSet(PrefetchDojoModelViewSet):

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -1625,18 +1625,6 @@ class LocationTest(BaseClass.ListRequestTest, BaseClass.RetrieveRequestTest):
         self.permission_check_class = Location
         BaseClass.RESTEndpointTest.__init__(self, *args, **kwargs)
 
-    def test_list_object_not_authorized(self):
-        self.setUp_not_authorized()
-        response = self.client.get(self.url, format="json")
-        self.assertEqual(403, response.status_code, response.content[:1000])
-
-    def test_detail_object_not_authorized(self):
-        self.setUp_not_authorized()
-        current_objects = self.endpoint_model.objects.all()
-        relative_url = self.url + f"{current_objects[0].id}/"
-        response = self.client.get(relative_url)
-        self.assertEqual(403, response.status_code, response.content[:1000])
-
 
 @skip_unless_v3
 class LocationFindingReferenceTest(BaseClass.BaseClassTest):


### PR DESCRIPTION
**Description**

`GET /api/v2/location/{id}/` returned 403 for anyone who is not a superuser.

`LocationViewSet` used `IsSuperUser` and returned every location, so the superuser check was the only thing keeping the endpoint scoped. This swaps it for `IsAuthenticated` plus `get_authorized_locations()`, which is what the other two viewsets in the same file already do. Locations a user cannot see now drop out of the queryset instead of the whole endpoint being denied.

**Test results**

`LocationTest` had two overrides expecting the 403. The base class already checks the right behaviour for this kind of endpoint (empty list, 404 on detail), so deleting the overrides puts that coverage back.

Also checked by hand on a running instance as a user with only a global Reader role: reading a reference from `/api/v2/location_findings/` and then reading the location it points at both return 200. Reverting just this file brings the 403 back.

**Documentation**

None needed.

**Checklist**

This checklist is for your information.

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [x] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
