### PR TITLE
docs: add 3.2.100 upgrade note for private note visibility

### DIFF
--- a/docs/content/releases/os_upgrading/3.2.100.md
+++ b/docs/content/releases/os_upgrading/3.2.100.md
@@ -1,0 +1,22 @@
+---
+title: 'Upgrading to DefectDojo Version 3.2.100'
+toc_hide: true
+weight: -20260810
+description: Notes marked private are now visible only to their author and to superusers.
+---
+
+## Private notes are now limited to their author
+
+Before 3.2.100, a note marked **Private** was still served to every user who could view the object it was attached to. The flag changed how the note was labelled, not who received it.
+
+Starting in 3.2.100, a private note is returned only to its author and to superusers. Every read path goes through one shared helper, so the API and the user interface behave the same way. Private notes are also left out of generated reports and issue-tracker sync.
+
+### Required actions
+
+- **No action is required, and nothing is deleted.** Every note that existed before the upgrade still exists.
+- **What changes for your users:** private notes written by other people disappear from the notes tab, from note popovers and from note counts on findings, tests and engagements. Authors still see their own private notes, marked "(private to you)".
+- **Superusers are unaffected** and continue to see every note.
+- **Public notes are unchanged.**
+- If your team used the private flag as a label while relying on everyone still reading the text, move that content into public notes. Nothing is lost, but only the author can read a private note now.
+
+For more information, check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.2.100).


### PR DESCRIPTION
Adds the missing 3.2.100 upgrade note for the private-note visibility change that shipped in that release.

Before 3.2.100 a note marked private was still shown to everyone who could view its parent object. It is now returned only to its author and to superusers. Operators upgrading will see other people's private notes disappear from the notes tab, popovers and note counts, so this needs a note in the upgrade docs.

Nothing is deleted, superusers are unaffected, and public notes are unchanged. Docs only, no code change.
