### PR TITLE
refactor(importers): reconcile a finding's child rows before the finding is written

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -1077,10 +1077,18 @@ class BaseImporter(ImporterOptions):
         """Accumulate a delete+insert of Finding_CWE rows for a reimported finding when its CWEs changed."""
         new_cwes = set(self.finding_cwe_values(finding))
         # finding_cwe_set is prefetched on reimport candidates (build_candidate_scope_queryset).
-        existing_cwes = {row.cwe for row in finding.finding_cwe_set.all()}
+        # A finding that has not been written yet has no persisted CWEs, and reading the reverse
+        # relation on it raises ("instance needs to have a primary key value before this
+        # relationship can be used"). Treating it as empty is exact rather than a workaround:
+        # there are no rows to compare against, so every parsed CWE is new. This lets an importer
+        # that buffers inserts reconcile a finding's CWEs before flushing the buffer.
+        existing_cwes = {row.cwe for row in finding.finding_cwe_set.all()} if finding.pk else set()
         if existing_cwes == new_cwes:
             return
-        self.pending_cwe_deletes.append(finding.id)
+        # Nothing to delete for a finding with no row yet; appending None would put a NULL in the
+        # filter that flush_vulnerability_ids() builds.
+        if finding.pk:
+            self.pending_cwe_deletes.append(finding.id)
         self.pending_cwes.extend([Finding_CWE(finding=finding, cwe=cwe) for cwe in new_cwes])
 
     def flush_vulnerability_ids(self) -> None:

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -1088,7 +1088,12 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         # stays a no-query read.
         from dojo.vulnerability.queries import finding_vulnerability_id_strings  # noqa: PLC0415 -- avoid import cycle
 
-        existing_vuln_ids = set(finding_vulnerability_id_strings(finding))
+        # A finding that has not been written yet has no persisted vulnerability ids, and the read
+        # helper raises on it ("instance needs to have a primary key value before this relationship
+        # can be used"). Treating it as empty is exact rather than a workaround: there are no rows
+        # to compare against, so every parsed id is new. This lets an importer that buffers inserts
+        # reconcile a finding's vulnerability ids before flushing the buffer.
+        existing_vuln_ids = set(finding_vulnerability_id_strings(finding)) if finding.pk else set()
         new_vuln_ids = set(vulnerability_ids_to_process)
 
         # Early exit if unchanged — no DB work needed
@@ -1154,7 +1159,12 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         finding = self.reconcile_vulnerability_ids(finding)
         # Save the finding only if the cve field was changed by save_vulnerability_ids
         # This is temporary as the cve field will be phased out
-        if finding.cve != old_cve:
+        #
+        # Only for a finding that already has a row. This save exists to push a changed cve onto
+        # an existing record; for a finding an importer is still buffering there is nothing to
+        # update, and saving here would insert it early -- defeating the buffering and splitting
+        # one batched INSERT into per-finding ones. The value rides along when the buffer flushes.
+        if finding.cve != old_cve and finding.pk:
             finding.save()
         return finding
 

--- a/unittests/test_importers_deleted_finding_child_rows.py
+++ b/unittests/test_importers_deleted_finding_child_rows.py
@@ -252,3 +252,139 @@ class TestImportersDeletedFindingChildRows(DojoTestCase):
                 self._buffered_request_response_count(finding),
                 msg=f"finding {finding.pk} lost its request/response pair",
             )
+
+
+class TestReconcileBeforeFindingIsWritten(DojoTestCase):
+
+    """
+    A finding's child rows must be reconcilable before the finding itself is written.
+
+    Vulnerability ids and CWEs are already buffered and flushed at the batch boundary rather
+    than written per finding. Reconciling them, though, read the finding's existing rows back
+    through a reverse relation, and Django refuses that on an instance with no primary key
+    ("instance needs to have a primary key value before this relationship can be used"). So an
+    importer that buffers the finding inserts themselves -- writing them in bulk at the same
+    batch boundary -- could not reconcile at all.
+
+    For a finding with no row there is nothing to read: no persisted vulnerability ids, no
+    persisted CWEs, and nothing to delete. Treating the existing set as empty is exact, not a
+    workaround. Every path here already runs today with a saved finding; these tests cover the
+    case that previously raised.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user, _ = User.objects.get_or_create(username="admin")
+        product_type, _ = Product_Type.objects.get_or_create(name="reconcile_before_write")
+        self.environment, _ = Development_Environment.objects.get_or_create(name="Development")
+        self.product, _ = Product.objects.get_or_create(
+            name="TestReconcileBeforeFindingIsWritten",
+            description="Test",
+            prod_type=product_type,
+        )
+        self.engagement, _ = Engagement.objects.get_or_create(
+            name="Reconcile Before Write",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        with (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan:
+            self.test, _, _, _, _, _, _ = DefaultImporter(
+                close_old_findings=False,
+                user=self.user,
+                lead=self.user,
+                scan_date=None,
+                environment=self.environment,
+                active=True,
+                verified=False,
+                scan_type=SCAN_TYPE,
+                engagement=self.engagement,
+            ).process_scan(scan)
+
+    def _reimporter(self):
+        return DefaultReImporter(
+            close_old_findings=False,
+            user=self.user,
+            lead=self.user,
+            scan_date=None,
+            environment=self.environment,
+            active=True,
+            verified=False,
+            scan_type=SCAN_TYPE,
+            test=self.test,
+        )
+
+    def _unsaved_finding(self, title="Buffered finding"):
+        return Finding(test=self.test, title=title, severity="Medium", reporter=self.user)
+
+    def test_reconcile_vulnerability_ids_accepts_an_unsaved_finding(self):
+        reimporter = self._reimporter()
+        finding = self._unsaved_finding()
+        finding.unsaved_vulnerability_ids = ["CVE-2026-0001"]
+
+        self.assertIsNone(finding.pk, "premise: the finding under test must be unsaved")
+        reimporter.reconcile_vulnerability_ids(finding)
+
+        self.assertEqual("CVE-2026-0001", finding.cve)
+        self.assertIsNone(finding.pk, "reconciling must not write the finding")
+
+    def test_buffered_vulnerability_ids_are_written_once_the_finding_is(self):
+        """The sequence a batched writer uses: reconcile while unsaved, write, then flush."""
+        reimporter = self._reimporter()
+        finding = self._unsaved_finding("Buffered then written")
+        finding.unsaved_vulnerability_ids = ["CVE-2026-0002"]
+
+        reimporter.reconcile_vulnerability_ids(finding)
+        # The buffered insert happens here, exactly as a batched writer would flush it.
+        finding.save()
+        reimporter.flush_vulnerability_ids()
+
+        self.assertEqual(
+            ["CVE-2026-0002"],
+            [
+                ref.vulnerability.vulnerability_id
+                for ref in FindingVulnerabilityReference.objects.filter(
+                    finding_id=finding.pk,
+                ).select_related("vulnerability").order_by("order")
+            ],
+        )
+
+    def test_reconcile_cwes_accepts_an_unsaved_finding_and_queues_no_delete(self):
+        reimporter = self._reimporter()
+        finding = self._unsaved_finding("Buffered with cwes")
+        finding.cwe = 79
+
+        self.assertIsNone(finding.pk, "premise: the finding under test must be unsaved")
+        reimporter.reconcile_cwes(finding)
+
+        # Stored as canonical CWE-<n> labels, not the raw Finding.cwe integer.
+        self.assertEqual({"CWE-79"}, {row.cwe for row in reimporter.pending_cwes})
+        self.assertEqual(
+            [],
+            reimporter.pending_cwe_deletes,
+            msg="a finding with no row has no CWE rows to delete, so nothing may be queued",
+        )
+
+    def test_a_changed_cve_does_not_write_an_unsaved_finding(self):
+        """
+        finding_post_processing() saves on a cve change to update an existing row.
+
+        A buffered finding has no row to update, and saving here would insert it early --
+        defeating the buffering by splitting one batched INSERT into per-finding ones.
+        """
+        reimporter = self._reimporter()
+        from_report = self._unsaved_finding("Report side")
+        from_report.unsaved_vulnerability_ids = ["CVE-2026-0003"]
+        finding = self._unsaved_finding("Buffered cve change")
+
+        finding_count_before = Finding.objects.count()
+        reimporter.finding_post_processing(
+            finding,
+            from_report,
+            is_matched_finding=False,
+            tag_accumulator=[],
+        )
+
+        self.assertEqual("CVE-2026-0003", finding.cve, "premise: the cve must actually have changed")
+        self.assertIsNone(finding.pk, "the buffered finding must not have been written")
+        self.assertEqual(finding_count_before, Finding.objects.count())


### PR DESCRIPTION
## What

Vulnerability ids and CWEs are already buffered during an import and flushed at the batch boundary rather than written per finding. Reconciling them, though, reads the finding's existing rows back through a reverse relation, and Django refuses that on an instance with no primary key:

```
ValueError: 'Finding' instance needs to have a primary key value before
            this relationship can be used.
```

Both reads are unconditional — `reconcile_cwes()` reads `finding_cwe_set`, and `reconcile_vulnerability_ids()` reads through `finding_vulnerability_id_strings()` *before* it compares anything — so every finding hits them.

This adds three guards so those paths tolerate a finding that has not been written yet.

## Why

An importer that buffers the finding inserts themselves, to write them in bulk at the same batch boundary, cannot reconcile at all today: the first buffered finding raises.

For a finding with no row there is nothing to read — no persisted CWEs, no persisted vulnerability ids, and nothing to delete. Treating the existing set as empty is exact rather than a workaround: every parsed value is new, which is precisely what those comparisons would conclude from an empty row set anyway.

This extends the same accommodation `get_original_findings`, `get_reimport_match_candidates_for_batch` and `_flush_post_processing_batch` already provide. `get_original_findings`' own docstring describes the case:

> This is intentionally a separate method (like get_reimport_match_candidates_for_batch) so downstream editions can override it without copying the full process_findings() implementation

## The three guards

All three are no-ops on today's paths, because the finding is always saved before `finding_post_processing()` runs.

1. **`reconcile_cwes()`** — skip the `finding_cwe_set` read when there is no pk, and do not append `None` to `pending_cwe_deletes`. A finding with no row has no CWE rows to delete, and the `None` would otherwise land in the `finding_id__in` filter that `flush_vulnerability_ids()` builds.
2. **`reconcile_vulnerability_ids()`** — skip the `finding_vulnerability_id_strings()` read when there is no pk.
3. **`finding_post_processing()`** — the trailing save on a changed `cve` exists to push that change onto an existing row. A buffered finding has no row to update, and saving there would insert it early, splitting one batched INSERT into per-finding ones. The value rides along when the buffer flushes.

## Tests

Four new tests in `unittests/test_importers_deleted_finding_child_rows.py`, alongside the existing buffered-child-row coverage: reconciling vulnerability ids on an unsaved finding, the record-then-write-then-flush sequence writing the reference correctly, reconciling CWEs while queueing no delete, and a changed `cve` not writing a buffered finding.

**Falsifiability was checked per guard rather than in aggregate, and that mattered.** Reverting both reconcile guards makes all four tests error with the `ValueError` above — but that run never reaches the `cve` save, so it proves nothing about the third guard. Reverting *only* the save guard, with the other two in place, makes the buffered finding get written (`103 is not None`). Each guard is independently necessary.

Run natively (Django runner, PostgreSQL) on the rebased branch:

- `test_importers_deleted_finding_child_rows`, `test_import_reimport`, `test_importers_performance` — **153 OK**, with the pinned query counts unchanged
- earlier full sweep also covering `test_importers_importer`, `test_importers_closeold`, `test_importers_deduplication`, `test_finding_cwe`, `test_vulnerability_id`, `test_vulnerability_id_type`, `test_bulk_locations` — **343 OK**

`ruff` clean at the `requirements-lint.txt` pin (0.16.1).

## Scope

Deliberately narrow. This clears the reconcile paths only; it does not make buffered inserts possible on its own. `process_files()`' m2m `finding.files.add()` still needs a primary key, and remains untouched here.
