### PR TITLE
refactor(reimporter): a seam for deferring the new-finding write

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -1047,7 +1047,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         unsaved_finding = self.process_cve(unsaved_finding)
         # Hash code is already calculated earlier as it's the primary matching criteria for reimport
         # Save it. Don't dedupe before endpoints/locations are added.
-        unsaved_finding.save_no_options()
+        self.persist_new_finding(unsaved_finding)
         finding = unsaved_finding
         # Force parsers to use unsaved_tags (stored in finding_post_processing function below)
         finding.tags = None
@@ -1066,6 +1066,26 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         # Process any request/response pairs
         self.process_request_response_pairs(unsaved_finding)
         return unsaved_finding, finding_will_be_grouped
+
+    def persist_new_finding(self, finding: Finding) -> None:
+        """
+        Write a finding the report did not match to an existing one.
+
+        This is intentionally a separate method (like get_original_findings and
+        get_reimport_match_candidates_for_batch) so downstream editions can override it
+        without copying the full process_finding_that_was_not_matched() implementation.
+
+        The override this exists for buffers new findings and writes them in bulk at the batch
+        boundary, where locations, vulnerability ids, tags and post-processing are already
+        flushed. Such an edition overrides this to accumulate, and _flush_post_processing_batch
+        to write the buffer before calling super() -- so the rows exist by the time anything in
+        that block reads a primary key.
+
+        Overriding this is the only supported way to defer the write. Everything after the call
+        in the caller -- grouping, the new_items list, request/response pairs -- is safe on an
+        unwritten finding, and the caller's remaining work is deliberately kept that way.
+        """
+        finding.save_no_options()
 
     def reconcile_vulnerability_ids(
         self,

--- a/unittests/test_reimporter_persist_seam.py
+++ b/unittests/test_reimporter_persist_seam.py
@@ -1,0 +1,161 @@
+from django.utils import timezone
+
+from dojo.importers.default_importer import DefaultImporter
+from dojo.importers.default_reimporter import DefaultReImporter
+from dojo.models import Development_Environment, Engagement, Finding, Product, Product_Type, User
+
+from .dojo_test_case import DojoTestCase, get_unit_tests_scans_path
+
+SCAN_TYPE = "Acunetix Scan"
+SCAN_FILE = "many_findings.xml"
+
+
+class BufferingReImporter(DefaultReImporter):
+
+    """
+    A downstream edition that defers new-finding writes to the batch boundary.
+
+    This is the shape persist_new_finding() exists for, written out in full so the seam is
+    tested by a real user of it rather than by a mock. It buffers instead of writing, and
+    flushes the buffer at the start of the batch flush -- before anything in that block
+    (locations, vulnerability ids, tags, post-processing dispatch) reads a primary key.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.buffered: list[Finding] = []
+        self.flush_calls = 0
+        self.max_buffer_seen = 0
+
+    def persist_new_finding(self, finding: Finding) -> None:
+        self.buffered.append(finding)
+        self.max_buffer_seen = max(self.max_buffer_seen, len(self.buffered))
+
+    def _flush_post_processing_batch(self, *args, **kwargs) -> None:
+        self.flush_calls += 1
+        for finding in self.buffered:
+            finding.save_no_options()
+        self.buffered.clear()
+        super()._flush_post_processing_batch(*args, **kwargs)
+
+
+class TestNewFindingPersistSeam(DojoTestCase):
+
+    """
+    persist_new_finding() must let a downstream edition defer the write.
+
+    The importer writes each unmatched finding as it is processed. An edition that wants to
+    write them in bulk cannot do that without a seam: overriding
+    process_finding_that_was_not_matched() means copying its whole body, which then drifts
+    from upstream. This pins that overriding the one call is sufficient, and that the caller's
+    remaining work stays safe on a finding that has not been written yet.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user, _ = User.objects.get_or_create(username="admin")
+        product_type, _ = Product_Type.objects.get_or_create(name="persist_seam")
+        self.environment, _ = Development_Environment.objects.get_or_create(name="Development")
+        self.product, _ = Product.objects.get_or_create(
+            name="TestNewFindingPersistSeam",
+            description="Test",
+            prod_type=product_type,
+        )
+        self.engagement, _ = Engagement.objects.get_or_create(
+            name="Persist Seam",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+
+    def _options(self, **overrides):
+        options = {
+            "user": self.user,
+            "lead": self.user,
+            "scan_date": None,
+            "environment": self.environment,
+            "active": True,
+            "verified": False,
+            "scan_type": SCAN_TYPE,
+        }
+        options.update(overrides)
+        return options
+
+    def _empty_test(self, name):
+        """A Test with no findings, created by importing into a fresh engagement."""
+        engagement = Engagement.objects.create(
+            name=name,
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        with (get_unit_tests_scans_path("acunetix") / "one_finding.xml").open(encoding="utf-8") as scan:
+            test, _, _, _, _, _, _ = DefaultImporter(
+                close_old_findings=False, **self._options(engagement=engagement),
+            ).process_scan(scan)
+        Finding.objects.filter(test=test).delete()
+        return test
+
+    def _reimport(self, test, importer_class):
+        with (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan:
+            importer = importer_class(close_old_findings=False, **self._options(test=test))
+            importer.process_scan(scan)
+        return importer
+
+    @staticmethod
+    def _comparable(test):
+        """Findings as comparable tuples -- ids differ between runs, so they are excluded."""
+        return sorted(
+            (f.title, f.severity, f.cve, f.component_name, f.component_version, f.active, f.verified)
+            for f in Finding.objects.filter(test=test)
+        )
+
+    def test_the_default_still_writes_each_finding_as_it_is_processed(self):
+        """The seam must not change stock behaviour."""
+        test = self._empty_test("seam-default")
+        self._reimport(test, DefaultReImporter)
+        self.assertGreater(Finding.objects.filter(test=test).count(), 0)
+
+    def test_an_override_can_defer_the_write_to_the_batch_boundary(self):
+        test = self._empty_test("seam-buffered")
+
+        importer = self._reimport(test, BufferingReImporter)
+
+        self.assertGreater(
+            importer.max_buffer_seen,
+            0,
+            msg="premise: the override must actually have buffered something, or this proves nothing",
+        )
+        self.assertEqual(importer.buffered, [], "the buffer must be drained by the final flush")
+        self.assertGreater(Finding.objects.filter(test=test).count(), 0)
+
+    def test_deferring_the_write_produces_the_same_findings(self):
+        """The point of the seam: same result, different write timing."""
+        stock_test = self._empty_test("seam-equiv-stock")
+        buffered_test = self._empty_test("seam-equiv-buffered")
+
+        self._reimport(stock_test, DefaultReImporter)
+        self._reimport(buffered_test, BufferingReImporter)
+
+        stock = self._comparable(stock_test)
+        buffered = self._comparable(buffered_test)
+        self.assertEqual(len(stock), len(buffered))
+        self.assertEqual(stock, buffered)
+
+    def test_child_rows_still_land_for_a_deferred_finding(self):
+        """
+        The flush block writes locations, vulnerability ids and tags off the finding.
+
+        Those all need a primary key, which is why the buffer drains at the *start* of the
+        flush. If that ordering broke, the findings would exist with no vulnerability ids.
+        """
+        stock_test = self._empty_test("seam-children-stock")
+        buffered_test = self._empty_test("seam-children-buffered")
+
+        self._reimport(stock_test, DefaultReImporter)
+        self._reimport(buffered_test, BufferingReImporter)
+
+        def cve_set(test):
+            return {f.cve for f in Finding.objects.filter(test=test) if f.cve}
+
+        self.assertEqual(cve_set(stock_test), cve_set(buffered_test))


### PR DESCRIPTION
## What

`process_finding_that_was_not_matched()` writes each unmatched finding inline:

```python
unsaved_finding.save_no_options()
```

That single call moves into `persist_new_finding()`, which defaults to exactly what it replaced. **Behaviour is unchanged** — one method call where there was one method call.

## Why

A downstream edition that wants to buffer those inserts and write them in bulk at the batch boundary has no way to do it today. The call sits in the middle of a ~35-line method, so overriding means copying the whole body — which then drifts from upstream on every subsequent change to it.

This is the same accommodation `get_original_findings` and `get_reimport_match_candidates_for_batch` already provide, and the docstring of the former states the intent directly:

> This is intentionally a separate method (like get_reimport_match_candidates_for_batch) so downstream editions can override it without copying the full process_findings() implementation

## The seam is placed where it is on purpose

Everything the caller does *after* this call is already safe on a finding that has not been written — finding groups keys a dict by group-name string, `new_items` is a list append, and `process_request_response_pairs` constructs `BurpRawRequestResponse(finding=...)` and defers it. #15620 made the reconcile paths safe as well.

So overriding this one method, plus `_flush_post_processing_batch` to write the buffer before calling `super()`, is sufficient to defer the write — the rows exist by the time anything in the flush block reads a primary key. The docstring records that contract so the next reader does not have to re-derive it.

## Tests

`unittests/test_reimporter_persist_seam.py` drives a **real** `BufferingReImporter` — an actual downstream edition written out in full rather than a mock — through a genuine Acunetix reimport. Four tests:

- the default still writes each finding inline (the seam must not change stock behaviour)
- an override can defer to the batch boundary, and its buffer is drained by the final flush
- deferring produces **identical findings** to the stock path, compared id-free
- child rows still land for a deferred finding — this is what breaks if the buffer flushes *after* the block that needs primary keys instead of before it

The buffering test asserts its own premise (`max_buffer_seen > 0`), so it cannot silently degrade into a run where nothing was ever buffered and the comparison passes trivially.

That test is also what established #15620 was a **prerequisite rather than a nicety**: against a `dev` without those guards it errors in `reconcile_cwes` on `finding_cwe_set.all()`; with them it passes. I found that by running it, not by reasoning about it.

## Testing

Run natively (Django runner, PostgreSQL) against current `dev`:

`test_reimporter_persist_seam`, `test_importers_deleted_finding_child_rows`, `test_reimport_batch_flush`, `test_import_reimport`, `test_importers_closeold`, `test_importers_deduplication`, `test_importers_performance` — **216 OK**, with the pinned query counts unchanged.

`ruff` clean at the `requirements-lint.txt` pin (0.16.1).
