### PR TITLE
fix(findings): retry bulk finding delete chunks on transient DB conflicts

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -6,7 +6,7 @@ from itertools import batched
 from time import sleep, strftime
 
 from django.conf import settings
-from django.db import transaction
+from django.db import OperationalError, transaction
 from django.db.models import Count
 from django.db.models.query_utils import Q
 from django.db.models.signals import post_delete, pre_delete
@@ -19,6 +19,7 @@ from fieldsignals import pre_save_changed
 
 import dojo.risk_acceptance.helper as ra_helper
 from dojo.celery import app
+from dojo.db_utils import is_transient_db_conflict
 from dojo.endpoint.utils import endpoint_get_or_create, save_endpoints_to_add
 from dojo.file_uploads.helper import delete_related_files
 from dojo.finding.cwe import finding_cwe_labels
@@ -1028,6 +1029,14 @@ def resolve_inbound_duplicate_references(chunk_ids, delete_scope_ids):
     return len(survivors)
 
 
+# A synchronous bulk delete that loses a concurrency race (deadlock or serialization
+# failure) rolls the offending chunk back and would otherwise surface as a 500 to the
+# caller. Retry that chunk a few times, mirroring async_delete_task's backstop for the
+# background cascade deletes that deterministic lock ordering cannot fully rule out.
+BULK_DELETE_RETRY_DELAY = 0.5  # seconds before the first retry of a chunk; doubled each attempt
+BULK_DELETE_MAX_CONFLICT_RETRIES = 3
+
+
 def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=False):
     """
     Delete findings and all related objects efficiently. Including any related object in Dojo-Pro
@@ -1076,11 +1085,31 @@ def _bulk_delete_findings_internal(finding_qs, chunk_size=1000, *, order_desc=Fa
         start=1,
     ):
         chunk_qs = Finding.objects.filter(id__in=chunk_ids)
-        with transaction.atomic():
-            bulk_clear_finding_m2m(chunk_qs)
-            resolve_inbound_duplicate_references(chunk_ids, delete_scope_ids)
-            cascade_delete_related_objects(Finding, chunk_qs, skip_relations={Finding}, skip_m2m_for={Finding})
-            execute_delete_sql(chunk_qs)
+        for attempt in range(BULK_DELETE_MAX_CONFLICT_RETRIES + 1):
+            try:
+                with transaction.atomic():
+                    bulk_clear_finding_m2m(chunk_qs)
+                    resolve_inbound_duplicate_references(chunk_ids, delete_scope_ids)
+                    cascade_delete_related_objects(Finding, chunk_qs, skip_relations={Finding}, skip_m2m_for={Finding})
+                    execute_delete_sql(chunk_qs)
+            except OperationalError as exc:
+                # A deadlock or serialization failure aborts and rolls the whole chunk
+                # transaction back, so the aborted work is not wrong -- only undone -- and
+                # re-running the chunk is safe. Earlier chunks already committed and are
+                # untouched. Only transient conflicts are retried; anything else (a
+                # statement timeout, a dropped connection) re-raises at once, as does a
+                # conflict that survives every attempt. Without this backstop a delete
+                # overlapping a concurrent import or dedup returns a 500 to the caller.
+                if not is_transient_db_conflict(exc) or attempt == BULK_DELETE_MAX_CONFLICT_RETRIES:
+                    raise
+                backoff = BULK_DELETE_RETRY_DELAY * (2 ** attempt)
+                logger.warning(
+                    "bulk_delete_findings: transient DB conflict on chunk %d, retry %d/%d in %.1fs: %s",
+                    chunk_num, attempt + 1, BULK_DELETE_MAX_CONFLICT_RETRIES, backoff, exc,
+                )
+                sleep(backoff)
+            else:
+                break
         logger.info(
             "bulk_delete_findings: deleted chunk %d (%d findings)",
             chunk_num, len(chunk_ids),

--- a/unittests/test_bulk_delete_findings_deadlock_retry.py
+++ b/unittests/test_bulk_delete_findings_deadlock_retry.py
@@ -1,0 +1,194 @@
+"""
+Unit tests for the transient-conflict retry in the chunked bulk finding delete.
+
+The synchronous bulk finding delete (``/findings/bulk_delete/``) runs each chunk in its
+own ``transaction.atomic()``. When that delete overlaps a concurrent import or dedup, the
+two transactions can update the same ``dojo_finding`` rows in opposite order and Postgres
+aborts one with ``deadlock detected`` (SQLSTATE 40P01). Deterministic lock ordering rules
+out most such races, but not this one, so a lost race must be retried rather than surfaced
+to the caller as a 500 -- mirroring the backstop the async cascade-delete task already has.
+
+A deadlock rolls the whole chunk transaction back, so re-running the chunk is safe and
+earlier committed chunks are untouched. Only transient conflicts (deadlock / serialization
+failure) are retried; any other database error, and a conflict that survives every attempt,
+must still propagate.
+"""
+
+import logging
+
+from django.db import OperationalError
+from django.utils import timezone
+
+from dojo import utils_cascade_delete
+from dojo.finding import helper as finding_helper
+from dojo.finding.helper import BULK_DELETE_MAX_CONFLICT_RETRIES, bulk_delete_findings
+from dojo.models import (
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+    User,
+    UserContactInfo,
+)
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+
+def _transient_conflict():
+    """
+    Build an OperationalError that ``is_transient_db_conflict`` treats as retryable.
+
+    In production Django re-raises the driver error as its own OperationalError and keeps
+    the psycopg exception -- the one carrying the 40P01 SQLSTATE -- as ``__cause__``, so
+    the SQLSTATE is fabricated on the cause here rather than on the message text.
+    """
+    cause = Exception("deadlock detected")
+    cause.sqlstate = "40P01"
+    exc = OperationalError("deadlock detected")
+    exc.__cause__ = cause
+    return exc
+
+
+class TestBulkDeleteFindingsDeadlockRetry(DojoTestCase):
+
+    """A chunk that loses a concurrency race is retried; other failures are not."""
+
+    def setUp(self):
+        super().setUp()
+        self.testuser = User.objects.create(
+            username="bulk_delete_deadlock_user",
+            is_staff=True,
+            is_superuser=True,
+        )
+        UserContactInfo.objects.create(user=self.testuser, block_execution=True)
+        self.system_settings(enable_deduplication=False)
+        self.system_settings(enable_product_grade=False)
+
+        self.product_type = Product_Type.objects.create(name="Bulk Delete Deadlock PT")
+        self.product = Product.objects.create(
+            name="Bulk Delete Deadlock Product",
+            description="Test",
+            prod_type=self.product_type,
+        )
+        self.test_type = Test_Type.objects.get_or_create(name="Manual Test")[0]
+        self.engagement = Engagement.objects.create(
+            name="Bulk Delete Deadlock Engagement",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        self.test = Test.objects.create(
+            engagement=self.engagement,
+            test_type=self.test_type,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        # The retry backs off with sleep(); make it a no-op so the tests stay fast and
+        # deterministic rather than actually waiting between attempts.
+        self._real_sleep = finding_helper.sleep
+        finding_helper.sleep = lambda _seconds: None
+
+    def tearDown(self):
+        finding_helper.sleep = self._real_sleep
+        super().tearDown()
+
+    def _create_finding(self, title):
+        return Finding.objects.create(
+            test=self.test,
+            title=title,
+            severity="High",
+            description="Test",
+            mitigation="Test",
+            impact="Test",
+            reporter=self.testuser,
+        )
+
+    def _delete_with_execute_delete_sql(self, findings, fake_execute):
+        """
+        Run the bulk delete with ``execute_delete_sql`` replaced by ``fake_execute``.
+
+        The delete imports ``execute_delete_sql`` from ``utils_cascade_delete`` at call
+        time, so the patch has to land on the defining module -- the same seam the M2M
+        tests use.
+        """
+        real_execute_delete_sql = utils_cascade_delete.execute_delete_sql
+        utils_cascade_delete.execute_delete_sql = fake_execute
+        try:
+            bulk_delete_findings(
+                Finding.objects.filter(id__in=[finding.id for finding in findings]),
+                # One chunk for the whole set, so each attempt is a single delete call.
+                chunk_size=100,
+            )
+        finally:
+            utils_cascade_delete.execute_delete_sql = real_execute_delete_sql
+
+    def test_transient_conflict_on_chunk_is_retried_and_succeeds(self):
+        """A deadlock on the first attempt is retried, and the chunk then deletes."""
+        first = self._create_finding("Deadlock F1")
+        second = self._create_finding("Deadlock F2")
+
+        real_execute_delete_sql = utils_cascade_delete.execute_delete_sql
+        state = {"calls": 0}
+
+        def execute_delete_sql_deadlock_once(queryset, *args, **kwargs):
+            state["calls"] += 1
+            if state["calls"] == 1:
+                raise _transient_conflict()
+            return real_execute_delete_sql(queryset, *args, **kwargs)
+
+        self._delete_with_execute_delete_sql([first, second], execute_delete_sql_deadlock_once)
+
+        self.assertEqual(state["calls"], 2, "The chunk should have been attempted twice: one conflict, one success.")
+        self.assertFalse(
+            Finding.objects.filter(id__in=[first.id, second.id]).exists(),
+            "Both findings should have been deleted after the retry.",
+        )
+
+    def test_non_transient_operational_error_is_not_retried(self):
+        """A non-conflict OperationalError (e.g. a statement timeout) must propagate at once."""
+        first = self._create_finding("Deadlock F3")
+        second = self._create_finding("Deadlock F4")
+
+        state = {"calls": 0}
+
+        def execute_delete_sql_timeout(queryset, *args, **kwargs):
+            state["calls"] += 1
+            msg = "canceling statement due to statement timeout"
+            raise OperationalError(msg)
+
+        with self.assertRaises(OperationalError):
+            self._delete_with_execute_delete_sql([first, second], execute_delete_sql_timeout)
+
+        self.assertEqual(state["calls"], 1, "A non-transient error must not be retried.")
+        self.assertTrue(
+            Finding.objects.filter(id__in=[first.id, second.id]).exists(),
+            "The findings must survive a failed delete that was not retried.",
+        )
+
+    def test_persistent_transient_conflict_gives_up_after_max_retries(self):
+        """A conflict that never clears is retried a bounded number of times, then raised."""
+        first = self._create_finding("Deadlock F5")
+        second = self._create_finding("Deadlock F6")
+
+        state = {"calls": 0}
+
+        def execute_delete_sql_always_deadlock(queryset, *args, **kwargs):
+            state["calls"] += 1
+            raise _transient_conflict()
+
+        with self.assertRaises(OperationalError):
+            self._delete_with_execute_delete_sql([first, second], execute_delete_sql_always_deadlock)
+
+        self.assertEqual(
+            state["calls"],
+            BULK_DELETE_MAX_CONFLICT_RETRIES + 1,
+            "The chunk should be tried once plus the configured number of retries.",
+        )
+        self.assertTrue(
+            Finding.objects.filter(id__in=[first.id, second.id]).exists(),
+            "Nothing should be deleted when every attempt loses the race.",
+        )

--- a/unittests/test_bulk_delete_findings_deadlock_retry.py
+++ b/unittests/test_bulk_delete_findings_deadlock_retry.py
@@ -132,17 +132,23 @@ class TestBulkDeleteFindingsDeadlockRetry(DojoTestCase):
         second = self._create_finding("Deadlock F2")
 
         real_execute_delete_sql = utils_cascade_delete.execute_delete_sql
-        state = {"calls": 0}
+        # execute_delete_sql runs several times per chunk (once per cascaded relation,
+        # then for the findings themselves), so do not assume one call per chunk. Fail
+        # only the very first call, then delegate; the retry re-runs the whole chunk and
+        # must complete the delete.
+        state = {"calls": 0, "raised": False}
 
         def execute_delete_sql_deadlock_once(queryset, *args, **kwargs):
             state["calls"] += 1
-            if state["calls"] == 1:
+            if not state["raised"]:
+                state["raised"] = True
                 raise _transient_conflict()
             return real_execute_delete_sql(queryset, *args, **kwargs)
 
         self._delete_with_execute_delete_sql([first, second], execute_delete_sql_deadlock_once)
 
-        self.assertEqual(state["calls"], 2, "The chunk should have been attempted twice: one conflict, one success.")
+        self.assertTrue(state["raised"], "The test must actually inject a transient conflict.")
+        self.assertGreater(state["calls"], 1, "The chunk must be re-run after the injected conflict.")
         self.assertFalse(
             Finding.objects.filter(id__in=[first.id, second.id]).exists(),
             "Both findings should have been deleted after the retry.",


### PR DESCRIPTION
## Description

A bulk finding delete (`POST /findings/bulk_delete/`) of a few hundred findings failed in production with a hard 500:

```
psycopg.errors.DeadlockDetected: deadlock detected
DETAIL:  Process A waits for ShareLock on transaction X; blocked by process B.
         Process B waits for ShareLock on transaction Y; blocked by process A.
CONTEXT:  while updating tuple (...) in relation "dojo_finding"
```

### Root cause

`_bulk_delete_findings_internal` (`dojo/finding/helper.py`) deletes findings one chunk at a time, each chunk in its own `transaction.atomic()`. Within that transaction it **updates** `dojo_finding` rows — clearing M2M through rows and resolving inbound `duplicate_finding` references — before issuing the delete. When a bulk delete overlaps a concurrent import or deduplication that touches the same rows in the opposite order, Postgres detects a deadlock and aborts one of the two transactions (SQLSTATE `40P01`).

The **background** cascade-delete task (`async_delete_task` in `dojo/utils.py`) already treats a deadlock / serialization failure as a lost race worth retrying — the rolled-back work is not wrong, only undone — using `is_transient_db_conflict`. The **synchronous** bulk-delete path had no such backstop, so the aborted chunk surfaced to the API caller as a 500.

### The fix

Wrap each per-chunk atomic block in a bounded retry that re-runs the chunk only on a transient DB conflict (`is_transient_db_conflict`), with exponential backoff. Anything else — a statement timeout, a dropped connection — and a conflict that survives every attempt still propagate unchanged.

This is safe because:
- The delete is already chunked with **per-chunk transactions**, so earlier committed chunks are untouched and only the aborted chunk re-runs.
- `ATOMIC_REQUESTS` is not enabled, so each chunk is its own top-level transaction; a deadlock rolls it back cleanly and a fresh retry can commit (an in-request savepoint retry would not, hence this check matters).

No schema change, so **no migration** is required — this is a pure control-flow change around an existing transaction.

### Pro impact

Dojo-Pro overrides `BULK_DELETE_FINDINGS_METHOD` but its implementation delegates straight to `_bulk_delete_findings_internal`, so the Pro `/api/vue/findings/bulk_delete/` path (the one that hit this in production) inherits the retry with **no companion Pro PR needed**. No public API, serializer, or user-visible behavior changes — a delete that previously 500'd on a race now completes — so no docs change is required.

## Test results

New `unittests/test_bulk_delete_findings_deadlock_retry.py` covers:
- a transient conflict on the first attempt that is retried and then deletes the chunk;
- a non-transient `OperationalError` (e.g. statement timeout) that propagates without retry, leaving the findings intact;
- a persistent transient conflict that gives up after the configured number of retries and raises, deleting nothing.

The tests patch `utils_cascade_delete.execute_delete_sql` (the same seam the existing `test_bulk_delete_findings_m2m` suite uses) to simulate the conflict deterministically, and no-op the backoff `sleep` so they run fast.

`ruff check` passes under the pinned config.

## Checklist

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR.
- [x] Your code is Ruff compliant.
- [x] Your code is python 3.13 compliant.
- [x] Add applicable tests to the unit tests.
- [x] Add the proper label to categorize your PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CHk1DJ3wrYkSL3E8K7RBug)_