### PR TITLE
fix(importers): retry test tag write when a concurrent import races tag cleanup

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -46,6 +46,10 @@ from dojo.vulnerability.manager import VulnerabilityIdManager
 
 logger = logging.getLogger(__name__)
 
+# Number of times update_test_tags() re-runs Test.tags.set() when it loses a race against
+# tagulous' cleanup of unused tag rows (see set_test_tags_safe for the full explanation).
+TEST_TAG_SET_MAX_ATTEMPTS = 3
+
 
 class Parser:
 
@@ -437,7 +441,44 @@ class BaseImporter(ImporterOptions):
         # Make sure the list is not empty as we do not want to overwrite
         # any existing tags
         if self.tags is not None and len(self.tags) > 0:
-            self.test.tags.set(self.tags)
+            self.set_test_tags_safe()
+
+    def set_test_tags_safe(self):
+        """
+        Set the test's tags, retrying if a concurrent import races tagulous' tag cleanup.
+
+        Tagulous deletes tag rows whose reference count reaches zero. When two imports that
+        share a tag run at the same time, one can delete the ``dojo_tagulous_test_tags`` row
+        that the other's ``dojo_test_tags`` insert references, so the M2M write fails the
+        (deferred) foreign key check at commit with an IntegrityError -- surfacing as
+        ``Key (tagulous_test_tags_id)=(...) is not present in table
+        "dojo_tagulous_test_tags"``. Re-running ``.set()`` re-creates the vanished tag via
+        tagulous get_or_create and re-inserts the row, so a bounded retry clears the race.
+
+        The importer runs with no surrounding atomic block (no ATOMIC_REQUESTS, no atomic
+        around process_scan), so each attempt is wrapped in its own transaction: a losing
+        attempt rolls back cleanly and the next one starts fresh. Setting tags must never
+        fail an import whose findings are already saved, so a write that still fails after
+        every attempt is logged and swallowed -- the same way finding/endpoint tag writes
+        already tolerate this race in add_tags_safe().
+        """
+        test_id = getattr(self.test, "id", None)
+        for attempt in range(1, TEST_TAG_SET_MAX_ATTEMPTS + 1):
+            try:
+                with transaction.atomic():
+                    self.test.tags.set(self.tags)
+            except IntegrityError as e:
+                if attempt < TEST_TAG_SET_MAX_ATTEMPTS:
+                    logger.warning(
+                        "IntegrityError setting tags on test %s (attempt %d/%d), retrying: %s",
+                        test_id, attempt, TEST_TAG_SET_MAX_ATTEMPTS, e,
+                    )
+                    continue
+                logger.error(
+                    "Failed to set tags on test %s after %d attempts; leaving tags unchanged: %s",
+                    test_id, TEST_TAG_SET_MAX_ATTEMPTS, e,
+                )
+            return
 
     def apply_import_tags_for_batch(self, findings: list[Finding]) -> None:
         """

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -345,7 +345,7 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self._import_reimport_performance(
             expected_num_queries1=160,
             expected_num_async_tasks1=2,
-            expected_num_queries2=127,
+            expected_num_queries2=129,
             expected_num_async_tasks2=1,
             expected_num_queries3=27,
             expected_num_async_tasks3=1,
@@ -369,7 +369,7 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self._import_reimport_performance(
             expected_num_queries1=179,
             expected_num_async_tasks1=2,
-            expected_num_queries2=137,
+            expected_num_queries2=139,
             expected_num_async_tasks2=1,
             expected_num_queries3=37,
             expected_num_async_tasks3=1,
@@ -394,7 +394,7 @@ class TestDojoImporterPerformanceSmall(TestDojoImporterPerformanceBase):
         self._import_reimport_performance(
             expected_num_queries1=189,
             expected_num_async_tasks1=5,
-            expected_num_queries2=147,
+            expected_num_queries2=149,
             expected_num_async_tasks2=4,
             expected_num_queries3=46,
             expected_num_async_tasks3=3,
@@ -672,7 +672,7 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self._import_reimport_performance(
             expected_num_queries1=166,
             expected_num_async_tasks1=2,
-            expected_num_queries2=135,
+            expected_num_queries2=137,
             expected_num_async_tasks2=1,
             expected_num_queries3=34,
             expected_num_async_tasks3=1,
@@ -696,7 +696,7 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self._import_reimport_performance(
             expected_num_queries1=189,
             expected_num_async_tasks1=2,
-            expected_num_queries2=149,
+            expected_num_queries2=151,
             expected_num_async_tasks2=1,
             expected_num_queries3=48,
             expected_num_async_tasks3=1,
@@ -721,7 +721,7 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
         self._import_reimport_performance(
             expected_num_queries1=202,
             expected_num_async_tasks1=5,
-            expected_num_queries2=162,
+            expected_num_queries2=164,
             expected_num_async_tasks2=4,
             expected_num_queries3=57,
             expected_num_async_tasks3=3,

--- a/unittests/test_importers_tag_race.py
+++ b/unittests/test_importers_tag_race.py
@@ -1,0 +1,152 @@
+import logging
+from unittest import mock
+
+from django.db import IntegrityError
+from django.utils import timezone
+
+from dojo.importers.default_importer import DefaultImporter
+from dojo.importers.default_reimporter import DefaultReImporter
+from dojo.models import (
+    Development_Environment,
+    Engagement,
+    Product,
+    Product_Type,
+    Test,
+    User,
+)
+
+from .dojo_test_case import DojoTestCase, get_unit_tests_scans_path
+
+logger = logging.getLogger(__name__)
+
+SCAN_TYPE = "Acunetix Scan"
+SCAN_FILE = "one_finding.xml"
+
+
+class TestImportersTagRace(DojoTestCase):
+
+    """
+    Regression: a concurrent import that shared a tag could fail the whole reimport with
+    a 500.
+
+    `update_test_tags()` writes the test's tags with `Test.tags.set(...)`. Tagulous deletes
+    tag rows whose reference count drops to zero, so two imports touching the same tag can
+    race: one deletes the `dojo_tagulous_test_tags` row that the other's `dojo_test_tags`
+    insert references, and the M2M write fails the (deferred) foreign key check at commit
+    with an IntegrityError:
+
+        insert or update on table "dojo_test_tags" violates foreign key constraint
+        "dojo_test_tags_tagulous_test_tags_i_..._fk_dojo_tagu"
+        DETAIL: Key (tagulous_test_tags_id)=(...) is not present in table
+        "dojo_tagulous_test_tags".
+
+    Re-running `.set()` re-creates the vanished tag via tagulous get_or_create, so a bounded
+    retry clears the race. A write that still fails after every attempt is logged and
+    swallowed rather than failing an import whose findings are already saved.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user, _ = User.objects.get_or_create(username="admin")
+        product_type, _ = Product_Type.objects.get_or_create(name="tag_race")
+        self.environment, _ = Development_Environment.objects.get_or_create(name="Development")
+        self.product, _ = Product.objects.get_or_create(
+            name="TestImportersTagRace",
+            description="Test",
+            prod_type=product_type,
+        )
+        self.engagement, _ = Engagement.objects.get_or_create(
+            name="Tag Race Engagement",
+            product=self.product,
+            target_start=timezone.now(),
+            target_end=timezone.now(),
+        )
+        with (get_unit_tests_scans_path("acunetix") / SCAN_FILE).open(encoding="utf-8") as scan:
+            self.test, _, len_new_findings, _, _, _, _ = self._importer().process_scan(scan)
+        self.assertEqual(1, len_new_findings)
+
+    def _options(self, **overrides):
+        options = {
+            "user": self.user,
+            "lead": self.user,
+            "scan_date": None,
+            "environment": self.environment,
+            "active": True,
+            "verified": False,
+            "scan_type": SCAN_TYPE,
+        }
+        options.update(overrides)
+        return options
+
+    def _importer(self, **overrides):
+        return DefaultImporter(close_old_findings=False, **self._options(engagement=self.engagement, **overrides))
+
+    def _reimporter(self, **overrides):
+        return DefaultReImporter(close_old_findings=False, **self._options(test=self.test, **overrides))
+
+    def test_update_test_tags_retries_past_a_transient_integrity_error(self):
+        """A tag write that loses the race once is retried and the tags still land on the test."""
+        reimporter = self._reimporter(tags=["alpha", "beta"])
+        reimporter.test = self.test
+        real_set = self.test.tags.set
+        calls = {"n": 0}
+
+        def flaky_set(tags, *args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                msg = (
+                    'insert or update on table "dojo_test_tags" violates foreign key constraint '
+                    '"dojo_test_tags_tagulous_test_tags_i_6336441a_fk_dojo_tagu"'
+                )
+                raise IntegrityError(msg)
+            return real_set(tags, *args, **kwargs)
+
+        with mock.patch.object(type(self.test.tags), "set", side_effect=flaky_set, autospec=False):
+            # Must not raise: the first attempt loses the race, the second succeeds.
+            reimporter.update_test_tags()
+
+        self.assertGreaterEqual(calls["n"], 2, msg="update_test_tags must retry after an IntegrityError")
+        self.assertEqual(
+            {"alpha", "beta"},
+            {tag.name for tag in Test.objects.get(pk=self.test.pk).tags.all()},
+            msg="the tags must be persisted on the test after the retry",
+        )
+
+    def test_update_test_tags_swallows_a_persistent_integrity_error(self):
+        """A tag write that keeps losing the race must not fail an import whose findings are saved."""
+        reimporter = self._reimporter(tags=["alpha"])
+        reimporter.test = self.test
+
+        def always_fails(tags, *args, **kwargs):
+            msg = 'Key (tagulous_test_tags_id)=(1) is not present in table "dojo_tagulous_test_tags".'
+            raise IntegrityError(msg)
+
+        with mock.patch.object(type(self.test.tags), "set", side_effect=always_fails, autospec=False):
+            # Must not propagate: the reimport has already saved its findings.
+            reimporter.update_test_tags()
+
+    def test_update_test_tags_still_sets_tags_when_nothing_races(self):
+        """Control case: with no race the tags are written exactly as before."""
+        reimporter = self._reimporter(tags=["gamma", "delta"])
+        reimporter.test = self.test
+
+        reimporter.update_test_tags()
+
+        self.assertEqual(
+            {"gamma", "delta"},
+            {tag.name for tag in Test.objects.get(pk=self.test.pk).tags.all()},
+        )
+
+    def test_update_test_tags_is_a_noop_when_no_tags_supplied(self):
+        """An empty tag list must not touch existing tags (the guard the original method kept)."""
+        self.test.tags.set(["preexisting"])
+        reimporter = self._reimporter(tags=[])
+        reimporter.test = self.test
+
+        with mock.patch.object(type(self.test.tags), "set", side_effect=AssertionError("must not be called")):
+            reimporter.update_test_tags()
+
+        self.assertEqual(
+            {"preexisting"},
+            {tag.name for tag in Test.objects.get(pk=self.test.pk).tags.all()},
+        )


### PR DESCRIPTION
**Description**

`POST /api/v2/reimport-scan/` (and the async import path) intermittently failed with a `500` and a foreign key violation when the scan carried tags:

```
django.db.utils.IntegrityError: insert or update on table "dojo_test_tags"
violates foreign key constraint "dojo_test_tags_tagulous_test_tags_i_..._fk_dojo_tagu"
DETAIL: Key (tagulous_test_tags_id)=(...) is not present in table "dojo_tagulous_test_tags".
```

Reported repeatedly from production, on reimports that ran close together in time.

`BaseImporter.update_test_tags()` wrote the test's tags with a bare `self.test.tags.set(self.tags)`. Tagulous deletes tag rows whose reference count reaches zero, so two imports that touch the same tag can race:

- import A resolves/creates a tag row and inserts the `dojo_test_tags` M2M row referencing it;
- import B, processing the same tag, drives that tag's reference count to zero, deletes the tag row, and commits;
- A's transaction reaches commit, where the (deferred) foreign key check on `dojo_test_tags.tagulous_test_tags_id` now fails — the referenced tag row is gone.

Because the importer runs with no surrounding atomic block (no `ATOMIC_REQUESTS`, no atomic around `process_scan`), each ORM write is its own transaction, and the deferred FK check surfaces the error at the `.set()` commit. The whole reimport then fails with a `500`, even though its findings were already saved — the tag write is the very last step.

The finding- and endpoint-level forms of this same tagulous race are already tolerated (`apply_import_tags_for_batch` / `add_tags_safe` catch `IntegrityError`); the test-level tag write was the one unguarded call site.

**The change**

`update_test_tags()` now delegates to a new `set_test_tags_safe()`:

- it re-runs `Test.tags.set()` up to `TEST_TAG_SET_MAX_ATTEMPTS` (3) times; re-running `.set()` re-creates the vanished tag via tagulous `get_or_create` and re-inserts the M2M row, so a losing attempt clears on the retry;
- each attempt is wrapped in its own `transaction.atomic()`, so a losing attempt rolls back cleanly and the next starts fresh;
- a write that still fails after every attempt is logged (`error`) and swallowed rather than failing an import whose findings are already committed — the same posture the finding/endpoint tag writes already take.

The empty-tag-list guard is unchanged: an import with no tags still leaves existing tags untouched.

No schema change, so **no migration** is required — this is a pure control-flow change around an existing write.

**Test results**

New test module `unittests/test_importers_tag_race.py`, class `TestImportersTagRace` (4 tests):

- a tag write that loses the race once is retried and the tags still land on the test;
- a tag write that keeps losing the race is logged and swallowed, so the reimport does not fail;
- control case: with no race the tags are written exactly as before;
- an empty tag list is a no-op and does not touch existing tags.

On unmodified `bugfix` the first two fail with the reported `IntegrityError` raised straight out of `update_test_tags()`; with the change all four pass.

Verified against PostgreSQL 16 on Python 3.13:

- `unittests.test_importers_tag_race` — 4 tests, **OK** (2 errors before the change).
- `unittests.test_importers_tag_race` + `unittests.test_importers_deleted_target` — **15 tests, OK** (the deleted-target suite also exercises `update_test_tags`).
- `ruff check --config ruff.toml` clean on both files (pinned 0.16.0).

**Downstream / Pro consideration**

- Dojo Pro's async import path (`pro.importers`) reaches this code through the OSS reimporter's `process_scan` and does **not** override `update_test_tags`, so the fix covers the Pro reimport path with no companion Pro edit. This was the path the production `500`s came in on.
- `set_test_tags_safe()` is new API on `BaseImporter` that nothing overrides.
- No public API, serializer, or user-visible behavior changes — a tagged reimport that previously `500`'d on a tag race now completes — so no documentation change is required.

**Documentation**

None required — this restores expected behavior on an existing endpoint and adds no setting or API surface.

**Checklist**

- [x] Bugfix submitted against the `bugfix` branch.
- [x] Meaningful PR name (may be used in release notes).
- [x] Ruff compliant (0.16.0).
- [x] Python 3.13 compliant.
- [x] No model changes / no migration.
- [x] Unit tests added.

**Reported internally**

- https://defectdojo.slack.com/archives/C0BK62Q76P8/p1786477563505079
- https://defectdojo.slack.com/archives/C0BK62Q76P8/p1786477547856119

---
_Generated by [Claude Code](https://claude.ai/code/session_013xnRfCDHiszcYjngr95E8W)_