### PR TITLE
docs: notifications follow every organization membership

### DIFF
--- a/docs/content/asset_modelling/engagements_tests/PRO__organizations.md
+++ b/docs/content/asset_modelling/engagements_tests/PRO__organizations.md
@@ -123,6 +123,13 @@ Findings) with the permissions that role grants. Pinning an Asset into an
 Organization therefore extends visibility, which is why creating a pin requires edit
 permission on **both** the Organization and the Asset.
 
+**Notifications follow the same rule.** Notifications about an Asset — and about its
+Engagements, Tests, and Findings — reach the members of every Organization the Asset
+belongs to, not only its primary one, subject as always to each user's own
+notification preferences. So pinning an Asset into a Compliance Scope Organization
+also makes that scope's members an audience for its findings, and removing the
+membership removes them again.
+
 ### Managing memberships
 
 - The Organization view gains a **Member Assets** table listing every member with


### PR DESCRIPTION
## Description

Follow-up to #15619 (organization types + non-exclusive membership), documenting one behavior that section did not yet cover: **notification fan-out follows every Organization membership**, not only an Asset's primary Organization.

Notifications about an Asset — and its Engagements, Tests, and Findings — now reach the members of every Organization the Asset belongs to (still subject to each user's own notification preferences), matching the access rule documented directly above it. Pinning an Asset into a Compliance Scope Organization therefore makes that scope's members an audience for its findings; removing the membership removes them again.

Behavior is gated by the same deployment flag as the rest of non-exclusive membership (`DD_V3_ORGANIZATION_NONEXCLUSIVE`, off by default), so default deployments are unchanged.

One paragraph added to `docs/content/asset_modelling/engagements_tests/PRO__organizations.md` (Membership and access). Text only, no screenshots.

## Checklist

- [x] Documentation-only change on the `dev` line, paired with the DefectDojo Pro change for the same release.
