### PR TITLE
docs: asset versions, BOM snapshots, and per-version SBOM/VEX export

### DIFF
--- a/docs/content/asset_modelling/locations/PRO__exporting_sboms_and_vex.md
+++ b/docs/content/asset_modelling/locations/PRO__exporting_sboms_and_vex.md
@@ -19,13 +19,27 @@ GET /api/v2/sbom/{asset_id}/?spec=spdx
 | Parameter | Values | Default |
 | --- | --- | --- |
 | `spec` | `cyclonedx` (CycloneDX 1.6 JSON), `spdx` (SPDX 2.3 JSON) | `cyclonedx` |
+| `version` | An Asset version name, e.g. `5.2.0` | *(none — the current inventory)* |
 
 The response is a downloadable JSON document (`Content-Disposition: attachment`). Components carry their Package URL, group/namespace, version, artifact hashes (algorithms each specification supports), and — when the SBOM import recorded one — the license expression for this Asset's use of the component.
 
-Two current-state boundaries to be aware of:
+Without a `version`, the export describes the Asset's **current** inventory, and its `dependencies` section declares root → component edges only: the aggregate inventory is a set of libraries, not a graph.
 
-- The export describes the Asset's **current** inventory. Version-pinned snapshots (the SBOM of release 5.2 specifically) are on the roadmap alongside Asset versions.
-- Imports flatten the dependency graph today, so the exported `dependencies` section declares root → component edges only.
+### Exporting one release
+
+Deployments with [Asset Versions](../pro__working_with_sboms/#asset-versions-and-bom-snapshots) enabled can export a specific release instead of the current aggregate:
+
+```
+GET /api/v2/sbom/{asset_id}/?version=5.2.0
+```
+
+The document is then built from the BOM snapshot recorded for that version, which changes three things:
+
+- **Components** are the ones that version's SBOM declared, with the licenses recorded for it — not everything the Asset has accumulated since.
+- **`dependencies`** reproduces the structure the imported document declared — root → direct components, then component → component — instead of the flat root → everything fan.
+- **The version** appears on `metadata.component` (SPDX: the root package's `versionInfo`), so the document says which release it describes.
+
+A version the Asset does not have returns 404 rather than quietly exporting the aggregate inventory under a version label — a document labelled 5.2.0 that does not describe 5.2.0 is the wrong thing to hand a downstream consumer or a regulator. A version that exists but has no SBOM uploaded yet exports an empty inventory, correctly labelled with that version.
 
 ## Exporting a VEX document
 
@@ -50,3 +64,16 @@ The status of each **finding ↔ location edge** (where per-location triage live
 | Mitigated | `resolved` | |
 
 When the same vulnerability × component pair carries conflicting statuses across findings, the **least-resolved status wins** — exporting `resolved` while any observation is still active would be the dangerous direction to be wrong in.
+
+### VEX for one release
+
+```
+GET /api/v2/sbom/{asset_id}/vex/?version=5.2.0
+```
+
+With Asset Versions enabled, a VEX document can answer for a single release. A Finding carrying a `fixed_in` record for the requested version is reported `resolved` there, while the same Finding stays exploitable at the versions where it was found and on the Asset overall. That is the point of the model: one Finding row, per-version answers, rather than a copy of every Finding in every release.
+
+Two deliberate conservatisms:
+
+- A Finding mitigated on the Asset, but with no `fixed_in` record for the requested version, **keeps its status** for that version. Claiming a fix in a release requires evidence for that release.
+- Nothing is inferred across versions. A Finding found in 5.0 and fixed in 5.2 says nothing here about 5.1, because version strings carry no ordering (see [Asset Versions](../pro__working_with_sboms/#asset-versions-and-bom-snapshots)).

--- a/docs/content/asset_modelling/locations/PRO__working_with_sboms.md
+++ b/docs/content/asset_modelling/locations/PRO__working_with_sboms.md
@@ -49,7 +49,8 @@ POST /api/v2/sbom-import/
 | `product` | The target Product (Asset) ID |
 | `file` | The SBOM file |
 | `scan_type` | The SBOM format — see supported formats below |
-| `replace` *(optional)* | If `true`, stale Product associations not backed by an existing Finding reference are removed. Default: `false` (cumulative) |
+| `replace_dependencies` *(optional)* | If `true`, stale Product associations not backed by an existing Finding reference are removed. Default: `false` (cumulative) |
+| `version` *(optional)* | The Asset version this SBOM describes, e.g. `5.2.0`. Requires Asset Versions — see [below](#asset-versions-and-bom-snapshots) |
 
 The importer parses the file, extracts `Dependency` records, deduplicates them against existing Locations (creating new ones as needed), and creates Asset References linking each Dependency to the Product. The Pro UI exposes the same upload flow — see the **Upload SBOM** action on a Product's Locations tab.
 
@@ -66,7 +67,44 @@ SWID Tag format is not yet supported.
 
 By default, repeated uploads are **additive**: dependencies that already exist on the Asset are kept, new ones are added, and nothing is removed. This matches the typical workflow of incremental SBOM updates.
 
-Set `replace=true` to prune. When replace mode is on, after a successful import the importer removes Product associations that were not present in the new SBOM **and** are not currently referenced by an active Finding. References tied to active Findings are preserved even in replace mode, so you do not lose vulnerability context just because a new SBOM omits a package.
+Set `replace_dependencies=true` to prune. When replace mode is on, after a successful import the importer removes Product associations that were not present in the new SBOM **and** are not currently referenced by an active Finding. References tied to active Findings are preserved even in replace mode, so you do not lose vulnerability context just because a new SBOM omits a package.
+
+## Asset Versions and BOM Snapshots
+
+An SBOM describes an Asset at a point in its release history — *the dependencies of Payments API 5.2.0* — but by default DefectDojo records only the Asset's current inventory. Re-uploading either accumulates forever or prunes, and *what shipped in 5.1?* is not a question the data can answer.
+
+Deployments that opt in to **Asset Versions** can bind each upload to a version. This behavior is managed by deployment configuration: set `DD_V3_ASSET_VERSIONS=True` (self-hosted) or contact support (cloud). It is off by default, and while it is off nothing described in this section is recorded — uploads behave exactly as above.
+
+A version is **metadata about an Asset, not another Asset**, and that distinction is the whole point. Modelling releases as child Assets copies every Finding into every release; one customer's 30,000 Findings became 360,000 that way. A Finding stays a single row on its Asset no matter how many versions mention it.
+
+### Binding an upload to a version
+
+Pass `version` to `POST /api/v2/sbom-import/`. The version is created on first sight, so there is no setup step.
+
+If you omit it, the document's own subject version is used — `metadata.component.version` in CycloneDX, the root package's version in SPDX. Most producers stamp it, so uploads usually bind correctly without you passing anything. Omitting `version` *and* uploading a document that declares none leaves the import on the unversioned stream, which is today's behavior.
+
+Versions carry **no ordering**. DefectDojo does not parse or compare version strings — package ecosystems disagree about what "newer" means — so nothing infers that 5.1 sits between 5.0 and 5.2. `released_at` on a version is an optional display and reporting hint.
+
+### Snapshots supersede rather than merge
+
+Each upload records a **BOM snapshot**: the components the document declared, the dependency relationships between them, and the document's own identity (specification, serial number, timestamp, and declared subject).
+
+Uploading again for the same version and format **supersedes** the previous snapshot — the newest one is what per-version reads return — and the superseded snapshots remain queryable as history. Nothing is deleted. Snapshots are scoped per format, so a CycloneDX document and an SPDX document for the same release supersede independently instead of clobbering each other.
+
+This is a separate axis from `replace_dependencies`, which still governs the Asset's aggregate dependency list. A snapshot answers *what did this document say*; the aggregate answers *what is on this Asset now*.
+
+Snapshots also preserve the BOM's **structure**. Each component records whether the document listed it as a direct dependency of its subject, and component → component relationships are recorded as declared, so a per-version export reproduces the graph instead of flattening it (see [Exporting SBOMs and VEX](../pro__exporting_sboms_and_vex/#exporting-one-release)). CycloneDX JSON and XML and SPDX 2 JSON carry full structure; SPDX XML, tag-value, and v3 record components only.
+
+### `found_in` and `fixed_in`
+
+Scan imports contribute the other half of the version story. When an import or reimport carries a `version` — the field `/api/v2/import-scan/` and `/api/v2/reimport-scan/` already accept — and Asset Versions is enabled:
+
+- Findings the import processes are recorded as **found_in** that version.
+- Findings the import mitigates because the scan no longer reports them are recorded as **fixed_in** that version. Previously that version reached the record only as prose inside the auto-close note.
+
+These claims are **additive and never withdrawn automatically**: an import that stops seeing a Finding does not un-say that an earlier version contained it. Because a Finding's mitigation timestamp is write-once while claims are per-version, a reopen-and-refix cycle appends a second `fixed_in` instead of rewriting the first. Re-importing the same version is a no-op.
+
+The claims are what makes [per-version VEX](../pro__exporting_sboms_and_vex/#vex-for-one-release) possible: they let one Finding report *resolved in 5.2* and *exploitable in 5.1* without existing twice.
 
 ## Findings That Reference Libraries
 
@@ -88,8 +126,12 @@ Because Findings and SBOM uploads share the same underlying Dependency objects, 
 | List Dependency Locations | `GET /api/v2/location/?location_type=dependency` |
 | Link a Dependency to a Finding | `POST /api/v2/location_findings/` |
 | Link a Dependency to a Product (with `owned_by` / `used_by`) | `POST /api/v2/location_products/` |
+| List or create Asset versions | `GET` / `POST /api/v2/asset_versions/` |
+| Record a `found_in` / `fixed_in` claim by hand | `POST /api/v2/finding_version_affects/` |
 
 Filters on `/api/v2/dependencies/` include the pURL component fields, tags, and ordering on `name`, `version`, and active-finding count.
+
+The two version endpoints follow the same rule as the rest of the Asset surface: reading is open to anyone who can already see the Asset, while writing requires edit permission on it plus `DD_V3_ASSET_VERSIONS`. Neither offers an update action, deliberately — a version is a name that exported documents and claims already point at, so renaming one would silently rewrite the meaning of every document exported under it, and a claim is stated or withdrawn rather than edited into a different claim. Hand-recorded claims are marked as such, so they stay distinguishable from the ones imports write.
 
 ## In the Pro UI
 


### PR DESCRIPTION
Documentation for the DefectDojo Pro asset-version work landing in the same release: SBOM
uploads can bind to an Asset version, each upload records a BOM snapshot, and SBOM/VEX
exports can describe one release instead of the Asset's current aggregate inventory.

Two existing pages under `docs/content/asset_modelling/locations/` are updated; no new
pages.

### Working with SBOMs

A new **Asset Versions and BOM Snapshots** section covers:

- The `DD_V3_ASSET_VERSIONS` deployment flag, off by default. While it is off, nothing in
  the section is recorded and uploads behave exactly as the rest of the page describes.
- Why a version is metadata about an Asset rather than another Asset — modelling releases
  as child Assets copies every Finding into every release.
- Binding an upload with the `version` field, and the fallback to the document's own
  subject version (`metadata.component` in CycloneDX, the root package in SPDX) when the
  field is omitted.
- That versions carry no ordering: version strings are not parsed or compared, so nothing
  infers that 5.1 sits between 5.0 and 5.2.
- Snapshots superseding per (version, format) while superseded snapshots stay queryable —
  and that this is a separate axis from `replace_dependencies`, which still governs the
  Asset's aggregate dependency list.
- Structure preservation, including which formats carry it (CycloneDX JSON/XML and SPDX 2
  JSON) and which record components only (SPDX XML, tag-value, and v3).
- `found_in` / `fixed_in` claims stamped from scan imports that carry a version, why they
  are additive and never withdrawn automatically, and how they interact with a Finding's
  write-once mitigation timestamp.
- The `/api/v2/asset_versions/` and `/api/v2/finding_version_affects/` endpoints, their
  permission rule, and why neither offers an update action.

It also corrects a field name on the same page: the SBOM upload API field is
`replace_dependencies`, not `replace`. A request sending `replace` was silently importing
cumulatively, so the documented pruning behavior did not happen.

### Exporting SBOMs and VEX

- Adds the `version` parameter, replacing the roadmap note that previously stood in for it.
- Describes what changes in a per-version export: components come from that version's
  snapshot, the `dependencies` section reproduces the declared graph rather than a flat
  root → everything fan, and the version lands on `metadata.component` (SPDX: the root
  package's `versionInfo`).
- Documents the 404 on an unknown version, and the empty-but-correctly-labelled document
  for a version that exists without an SBOM yet.
- Adds per-version VEX: a `fixed_in` claim reports `resolved` at that version while the
  same Finding stays exploitable where it was found, with the two conservatisms spelled
  out — a global mitigation is not a per-version fix claim, and nothing is inferred across
  versions.
- Keeps the flat-`dependencies` statement accurate for the unversioned export, which still
  declares root → component edges only.
