### PR TITLE
Expose a flat test_type_name field on the finding serializer

### DIFF
--- a/dojo/finding/api/serializer.py
+++ b/dojo/finding/api/serializer.py
@@ -394,6 +394,14 @@ class FindingSerializer(serializers.ModelSerializer):
     sla_days_remaining = serializers.IntegerField(read_only=True, allow_null=True)
     finding_meta = FindingMetaSerializer(read_only=True, many=True)
     related_fields = serializers.SerializerMethodField(allow_null=True)
+    # Flat convenience field: the finding's test type name (e.g. "Cloud Posture
+    # Scan"), without requiring related_fields=true. API consumers that route on
+    # the scanner/tool that produced a finding (the Sensei engine keys IaC
+    # remediation on test_type_name) read this directly. A dotted-source CharField
+    # rather than a method: it is the same read, and allow_null makes DRF return
+    # None if any hop is missing. No extra query — FindingViewSet.get_queryset
+    # already prefetches test__test_type.
+    test_type_name = serializers.CharField(source="test.test_type.name", read_only=True, allow_null=True)
     # for backwards compatibility
     jira_creation = serializers.SerializerMethodField(read_only=True, allow_null=True)
     jira_change = serializers.SerializerMethodField(read_only=True, allow_null=True)


### PR DESCRIPTION
**Description**

The Finding API returns neither `test_type_name` nor `test_type`, so a client that needs to know which scanner/tool produced a finding has to make a second round-trip (`finding` → `test` → `test_type`) or request the heavier `related_fields=true` expansion just to read one string.

This adds `test_type_name` as a flat, read-only field on `FindingSerializer`, resolving to `test.test_type.name` (e.g. `"Cloud Posture Scan"`). It is available directly on the finding response and via `response_fields`, without `related_fields=true`.

It is implemented as a dotted-`source` `CharField` (`source="test.test_type.name"`, `allow_null=True`) rather than a `SerializerMethodField`: the read is identical, and `allow_null` makes DRF return `None` if any hop in the chain is missing.

The motivating consumer is tool-based routing: DefectDojo Pro's Sensei remediation keys its infrastructure-as-code fix path on `test_type_name`, and with the field absent every cloud-posture finding fell through to the file-centric path. The field is generally useful to any client that today pays for an extra request just to learn the finding's tool.

**Performance**

No added query cost. `FindingViewSet.get_queryset` already `prefetch_related(… "test", "test__test_type" …)` in both the `V3_FEATURE_LOCATIONS` and legacy branches, so the field reads from the prefetch cache — no per-finding query and no N+1 on the list endpoint.

**Test results**

Additive, read-only field with no change to any existing field or behavior. Null-safe via DRF's attribute traversal plus `allow_null`, so a finding whose test/test_type is somehow absent serializes as `null` rather than raising. Ruff clean, Python 3.13 compliant.

**Documentation**

None required — no settings, model, or migration changes; this exposes an existing related value as a flat convenience field.

[sc-14426]

**Checklist**

- [x] Bugfix submitted against the `bugfix` branch.
- [x] Meaningful PR name.
- [x] Ruff compliant.
- [x] No model changes, so no migration.
