### PR TITLE
docs(notifications): document the Connector Health Warning notification

### DIFF
--- a/docs/content/admin/notifications/about_notifications.md
+++ b/docs/content/admin/notifications/about_notifications.md
@@ -85,6 +85,19 @@ When Findings are assigned to you, the **Work Assigned** notification tells you 
 
 It is aggregated per person rather than per Finding: assigning a hundred Findings sends one message, not a hundred. As with review requests, the assignment is visible in your queue whether or not the notification reaches you.
 
+## Connector Health Notifications (Pro)
+
+A Connector that stops working is quiet about it. Nothing in DefectDojo fails, and the only sign is on the **Upstream Connectors** page, which nobody is watching. The **Connector Health Warning** notification is the message that finds you instead.
+
+It covers the two ways a Connector goes quiet:
+
+* **Its runs start failing.** A Discover or Sync ends in error or times out against your tool. The message names the Connector and carries the tool's own error, which is usually an expired or narrowed credential.
+* **Its tool stops returning data.** A run succeeds, but every record the Connector holds is now **Missing**. The run reports success, so this state raises no error anywhere. See [Managing Operations](/connectors/upstream/manage_operations/) for what that state means and how it clears.
+
+Both messages arrive once, not once per run. A Connector with a dead credential on an hourly schedule sends one message when it starts failing, then stays quiet until its runs succeed again. A Connector that lost visibility sends one message per day while it stays blind, and re-arms once the records come back.
+
+The notification is on **🔔 Alerts** by default. Set it to Email, Slack or Teams on your notification settings page, under **Connections**. A Connector that is set up correctly but has never seen any data is a separate case, and it warns you when you save it rather than later.
+
 ## Open-Source Considerations
 
 ### Specific overrides

--- a/docs/content/connectors/upstream/manage_operations.md
+++ b/docs/content/connectors/upstream/manage_operations.md
@@ -79,3 +79,9 @@ To have DefectDojo run a Sync operation off\-schedule:
 2. From this page, click the **Sync** button. This button is located next to the **Mapped Records** header.
 
 ![image](images/operations_sync.png)
+
+## Getting told when a Connector stops working
+
+The Operations Page is a record, not an alarm. If you do not want to check it, turn on the **Connector Health Warning** notification, which messages you when a Connector's runs start failing and when its tool stops returning the records it used to return.
+
+Set it on your notification settings page, under **Connections**. See [Connector Health Notifications](/admin/notifications/about_notifications/#connector-health-notifications-pro) for what each message covers and how often it arrives.


### PR DESCRIPTION
## Description

Documents the Connector Health Warning notification, which is new in Pro.

A connector that stops working is silent. Its runs fail against the vendor, or its tool stops returning the records it used to return, and nothing in DefectDojo raises an error. The only sign is on the Upstream Connectors page. The new notification is the message that reaches a user who is not looking at that page.

Two files change:

- `admin/notifications/about_notifications.md` gets a **Connector Health Notifications (Pro)** section, matching the pattern the review-request and work-assignment sections already use. It says what the two messages cover, how often they arrive, and where to set the channel.
- `connectors/upstream/manage_operations.md` gets a short pointer at the end of the page, because that is where a user reads about failed operations.

No screenshots. The section describes the behavior in text.

Note for whoever merges: PR #15634 adds a "When a Connector runs but imports nothing" section to `manage_operations.md`. It edits the top of that file and this one appends to the bottom, so the two do not conflict. Both belong to the same release.
