### PR TITLE
docs: publish the four docs changes stranded on dev

### DIFF
--- a/docs/content/asset_modelling/engagements_tests/PRO__assets.md
+++ b/docs/content/asset_modelling/engagements_tests/PRO__assets.md
@@ -174,6 +174,55 @@ Because Findings inherit risk, priority, and ownership from their parent Asset, 
 
 Importantly, Assets are also the primary determining factor in a Finding’s SLA characteristics. Therefore, the SLA of a Findings depends on the SLA configuration of its parent Asset. More information about SLA configurations can be found [here](/asset_modelling/pro_hierarchy/priority_sla/#working-with-slas).
 
+## Asset Kinds
+
+An Asset can declare what kind of thing it is: a repository, a service, a host, a domain, a
+container image, a package, a cloud account, a device, or a branch. The kind is optional —
+an Asset without one behaves exactly as it always has — and it is descriptive rather than
+functional: it does not change permissions, deduplication, SLAs, or reporting scope. What it
+does is make a long Asset list readable, by giving each Asset an icon and a label that says
+what you are looking at.
+
+The list of kinds is data, not a fixed set. The kinds DefectDojo ships are marked as system
+kinds and cannot be deleted, but their wording and icons can be changed, and you can add your
+own kinds for anything your inventory contains that the shipped list does not cover.
+
+Kinds are available on the Asset itself and through the API at `/api/v2/asset_kinds/`
+(read-only) and as the `kind` field on `/api/v2/assets/`.
+
+## Asset Identity: Aliases
+
+The same Asset is usually known by different names in different places: a repository id in
+GitHub, a project key in your scanner, a hostname in DNS, an image digest in a registry. An
+**alias** records one of those identifiers against the Asset it refers to, so DefectDojo can
+recognise the Asset from whichever name a source happens to use.
+
+Each alias has three parts:
+
+- a **namespace**, naming the system that issued the identifier — `dns`, `oci`, `purl`, `git`,
+or a specific Connector configuration;
+- a **type**, saying what kind of identifier it is — `external_id`, `hostname`, `image_digest`,
+and so on;
+- the **value** itself.
+
+An identifier resolves to exactly one Asset. Two Assets cannot both claim `api.example.com` in
+the `dns` namespace, which is what makes an alias a reliable answer to "which Asset is this?"
+
+Aliases record where they came from. Ones you add yourself are marked as user-asserted and are
+never rewritten by automation; Connector sync maintains its own. That means you can correct a
+Connector's idea of what an identifier means without the next sync undoing it.
+
+Aliases are asserted or withdrawn, never edited: there is no update action on the API, because
+changing an identifier in place would silently re-point identity with no record of what it used
+to mean. To correct one, remove it and add the right one.
+
+Connector-issued aliases are written by Connector sync rather than by hand, so the API refuses
+writes to a `connector:` namespace. Everything else is yours to declare, through
+`/api/v2/asset_aliases/`.
+
+Aliases require `DD_V3_ASSET_ALIASES` to be enabled before they can be created; existing ones
+stay readable whether it is on or off.
+
 ## Asset Nesting
 
 DefectDojo supports parent-child relationship between two Assets within the same Organization. This can be configured during Asset creation or in the Asset’s settings. 

--- a/docs/content/asset_modelling/engagements_tests/PRO__organizations.md
+++ b/docs/content/asset_modelling/engagements_tests/PRO__organizations.md
@@ -58,6 +58,91 @@ Additionally, the following is an illustrative guide as to whether a something i
 
 As noted, your structure may differ depending on your unique security needs. 
 
+## Organization Types
+
+Organizations carry a **type** that records what kind of boundary they represent:
+
+- **Team** — the people who own or work on the Assets
+- **Business Application** — a business-level application made up of several Assets
+- **Compliance Scope** — a regulated boundary such as PCI or FedRAMP
+- **Portfolio** — a roll-up grouping for executive or portfolio-level reporting
+- **Custom** — anything else (the default)
+
+Types are orthogonal ways of looking at the same inventory: with non-exclusive
+membership enabled (below), one Asset can sit in a Team, a Compliance Scope, and a
+Portfolio at the same time, and each of those Organizations answers a different
+question about it.
+
+The type is set when creating or editing an Organization, is shown as a badge on the
+Organization's view, and is filterable on the API (`org_type` on
+`/api/v2/organizations/`).
+
+### Nesting within a type
+
+Organizations of the **same type** can be nested with a **parent Organization** for
+drill-down navigation and reporting — for example, a "Payments" Portfolio inside a
+"Company" Portfolio. Nesting is deliberately limited:
+
+- A parent must have the same type as its child, and cycles are rejected.
+- Nesting is for reporting and navigation **only** — it does not grant access. A
+  user with a role on a parent Organization does not gain access to its children.
+
+## Non-Exclusive Membership
+
+By default, every Asset belongs to exactly one Organization. Deployments that opt in
+to **non-exclusive membership** can additionally place an Asset in any number of
+further Organizations, so the same Asset can be visible through its Team, its
+Compliance Scope, and its Portfolio without duplicating it.
+
+This behavior is managed by deployment configuration: set
+`DD_V3_ORGANIZATION_NONEXCLUSIVE=True` (self-hosted) or contact support (cloud). It
+is off by default.
+
+### Primary and additional memberships
+
+- Each Asset always has exactly one **primary** membership: the Organization shown
+  on the Asset itself. The primary membership is the access and billing anchor and
+  cannot be removed — change the Asset's Organization to move it.
+- Any further memberships are **additional** and carry a record of where they came
+  from:
+    - **User Pin** — added by hand from the Organization or Asset view
+    - **Connector** — kept in sync from a connector's grouping attributes (for
+      example, the Backstage connector maps a service's **Domain** to a
+      Portfolio-type Organization and its **Owner Group** to a Team-type
+      Organization)
+    - **Rule** — granted by a membership rule ("Assets tagged `pci` belong to the
+      PCI Organization"); when the tag no longer matches, the membership dissolves
+- Automation only ever reconciles memberships it created itself. User pins are never
+  removed by a connector sync or a rule.
+
+### Membership and access
+
+Access follows **every** membership, not just the primary one: a user with a role on
+any of an Asset's Organizations can see the Asset (and its Engagements, Tests, and
+Findings) with the permissions that role grants. Pinning an Asset into an
+Organization therefore extends visibility, which is why creating a pin requires edit
+permission on **both** the Organization and the Asset.
+
+### Managing memberships
+
+- The Organization view gains a **Member Assets** table listing every member with
+  its provenance, plus a **Pin Asset** action.
+- The Organization view's Asset list — and the `organization` filter on the Asset
+  and Finding lists — covers **every** member Asset, whether it lives here or is a
+  member through a pin, rule, or connector. (Filtering by the classic organization
+  field alone still matches only Assets whose home is that Organization.)
+- The Asset view gains an **Organization Memberships** panel listing the Asset's memberships —
+  each Organization with its type and provenance — plus a **Pin to Organization**
+  action.
+- Additional memberships can be removed from either surface. Removing a
+  connector- or rule-created membership works the same way, but the next sync or
+  tag match may recreate it; disable the rule or adjust the connector mapping to
+  make it permanent.
+- On the API, memberships live at `/api/v2/organization_memberships/`
+  (filterable by `product`, `organization`, `origin`, and `is_primary`); the
+  Organization type and parent are readable and writable on
+  `/api/v2/organizations/` as `org_type` and `parent_organization`.
+
 ## Accessing Organizations
 
 Organizations are accessible via the sidebar. The submenu provides access to All Organizations as well as the option to create a new Organization.
@@ -76,6 +161,11 @@ An Organization’s view contains a variety of tables and charts to interpret it
 - **Assigned User Groups** 
     - User groups that have been assigned to the Organization for permission control. More information about user groups can be found [here](/admin/user_management/create_user_group/). 
 - **List of Assets within the Organization**
+
+With non-exclusive membership enabled, the view also shows the Organization's type
+badge and parent next to its name, and a **Member Assets** table listing every
+member Asset with the provenance of its membership (see
+[Non-Exclusive Membership](#non-exclusive-membership)).
 
 ## Working with Organizations 
 

--- a/docs/content/asset_modelling/locations/PRO__exporting_sboms_and_vex.md
+++ b/docs/content/asset_modelling/locations/PRO__exporting_sboms_and_vex.md
@@ -19,13 +19,27 @@ GET /api/v2/sbom/{asset_id}/?spec=spdx
 | Parameter | Values | Default |
 | --- | --- | --- |
 | `spec` | `cyclonedx` (CycloneDX 1.6 JSON), `spdx` (SPDX 2.3 JSON) | `cyclonedx` |
+| `version` | An Asset version name, e.g. `5.2.0` | *(none — the current inventory)* |
 
 The response is a downloadable JSON document (`Content-Disposition: attachment`). Components carry their Package URL, group/namespace, version, artifact hashes (algorithms each specification supports), and — when the SBOM import recorded one — the license expression for this Asset's use of the component.
 
-Two current-state boundaries to be aware of:
+Without a `version`, the export describes the Asset's **current** inventory, and its `dependencies` section declares root → component edges only: the aggregate inventory is a set of libraries, not a graph.
 
-- The export describes the Asset's **current** inventory. Version-pinned snapshots (the SBOM of release 5.2 specifically) are on the roadmap alongside Asset versions.
-- Imports flatten the dependency graph today, so the exported `dependencies` section declares root → component edges only.
+### Exporting one release
+
+Deployments with [Asset Versions](../pro__working_with_sboms/#asset-versions-and-bom-snapshots) enabled can export a specific release instead of the current aggregate:
+
+```
+GET /api/v2/sbom/{asset_id}/?version=5.2.0
+```
+
+The document is then built from the BOM snapshot recorded for that version, which changes three things:
+
+- **Components** are the ones that version's SBOM declared, with the licenses recorded for it — not everything the Asset has accumulated since.
+- **`dependencies`** reproduces the structure the imported document declared — root → direct components, then component → component — instead of the flat root → everything fan.
+- **The version** appears on `metadata.component` (SPDX: the root package's `versionInfo`), so the document says which release it describes.
+
+A version the Asset does not have returns 404 rather than quietly exporting the aggregate inventory under a version label — a document labelled 5.2.0 that does not describe 5.2.0 is the wrong thing to hand a downstream consumer or a regulator. A version that exists but has no SBOM uploaded yet exports an empty inventory, correctly labelled with that version.
 
 ## Exporting a VEX document
 
@@ -50,3 +64,16 @@ The status of each **finding ↔ location edge** (where per-location triage live
 | Mitigated | `resolved` | |
 
 When the same vulnerability × component pair carries conflicting statuses across findings, the **least-resolved status wins** — exporting `resolved` while any observation is still active would be the dangerous direction to be wrong in.
+
+### VEX for one release
+
+```
+GET /api/v2/sbom/{asset_id}/vex/?version=5.2.0
+```
+
+With Asset Versions enabled, a VEX document can answer for a single release. A Finding carrying a `fixed_in` record for the requested version is reported `resolved` there, while the same Finding stays exploitable at the versions where it was found and on the Asset overall. That is the point of the model: one Finding row, per-version answers, rather than a copy of every Finding in every release.
+
+Two deliberate conservatisms:
+
+- A Finding mitigated on the Asset, but with no `fixed_in` record for the requested version, **keeps its status** for that version. Claiming a fix in a release requires evidence for that release.
+- Nothing is inferred across versions. A Finding found in 5.0 and fixed in 5.2 says nothing here about 5.1, because version strings carry no ordering (see [Asset Versions](../pro__working_with_sboms/#asset-versions-and-bom-snapshots)).

--- a/docs/content/asset_modelling/locations/PRO__exporting_sboms_and_vex.md
+++ b/docs/content/asset_modelling/locations/PRO__exporting_sboms_and_vex.md
@@ -1,0 +1,52 @@
+---
+title: "Exporting SBOMs and VEX"
+description: "Export an Asset's dependency inventory as CycloneDX or SPDX, and its finding statuses as a CycloneDX VEX document"
+audience: pro
+weight: 7
+---
+
+DefectDojo Pro can serialize an Asset's current dependency inventory back out as a standards-compliant SBOM, and its vulnerability triage decisions as a machine-readable VEX document. Both are produced from the same [Dependency Locations](../pro__working_with_sboms/) that SBOM imports and scan findings populate, so whatever your scanners and uploads have accumulated is what the export describes — the documents are consumed by downstream tooling, compliance pipelines, and AI agents, not just humans.
+
+Both endpoints require **V3 Locations** to be enabled, and respect Asset-level permissions: an Asset the requesting user cannot view returns a 404.
+
+## Exporting an SBOM
+
+```
+GET /api/v2/sbom/{asset_id}/
+GET /api/v2/sbom/{asset_id}/?spec=spdx
+```
+
+| Parameter | Values | Default |
+| --- | --- | --- |
+| `spec` | `cyclonedx` (CycloneDX 1.6 JSON), `spdx` (SPDX 2.3 JSON) | `cyclonedx` |
+
+The response is a downloadable JSON document (`Content-Disposition: attachment`). Components carry their Package URL, group/namespace, version, artifact hashes (algorithms each specification supports), and — when the SBOM import recorded one — the license expression for this Asset's use of the component.
+
+Two current-state boundaries to be aware of:
+
+- The export describes the Asset's **current** inventory. Version-pinned snapshots (the SBOM of release 5.2 specifically) are on the roadmap alongside Asset versions.
+- Imports flatten the dependency graph today, so the exported `dependencies` section declares root → component edges only.
+
+## Exporting a VEX document
+
+```
+GET /api/v2/sbom/{asset_id}/vex/
+```
+
+The VEX export is a standalone CycloneDX 1.6 document built from the statuses of findings attached to the Asset's dependencies. Component references are Package URLs — the same identifiers the SBOM export uses — so the pair can be consumed together without any reference translation. SPDX has no VEX profile, so this endpoint is CycloneDX-only.
+
+Statement grouping: one vulnerability entry per (vulnerability ID × analysis state), with every affected component listed under `affects`. Findings without a vulnerability ID are omitted — VEX statements are keyed by vulnerability identifier.
+
+### How DefectDojo statuses map to VEX analysis
+
+The status of each **finding ↔ location edge** (where per-location triage lives) drives the analysis:
+
+| DefectDojo status | VEX `analysis.state` | Notes |
+| --- | --- | --- |
+| Active | `exploitable` | |
+| Risk Accepted | `exploitable` | with `response: ["will_not_fix"]` |
+| Out of Scope | `not_affected` | |
+| False Positive | `false_positive` | |
+| Mitigated | `resolved` | |
+
+When the same vulnerability × component pair carries conflicting statuses across findings, the **least-resolved status wins** — exporting `resolved` while any observation is still active would be the dangerous direction to be wrong in.

--- a/docs/content/asset_modelling/locations/PRO__working_with_sboms.md
+++ b/docs/content/asset_modelling/locations/PRO__working_with_sboms.md
@@ -49,7 +49,8 @@ POST /api/v2/sbom-import/
 | `product` | The target Product (Asset) ID |
 | `file` | The SBOM file |
 | `scan_type` | The SBOM format — see supported formats below |
-| `replace` *(optional)* | If `true`, stale Product associations not backed by an existing Finding reference are removed. Default: `false` (cumulative) |
+| `replace_dependencies` *(optional)* | If `true`, stale Product associations not backed by an existing Finding reference are removed. Default: `false` (cumulative) |
+| `version` *(optional)* | The Asset version this SBOM describes, e.g. `5.2.0`. Requires Asset Versions — see [below](#asset-versions-and-bom-snapshots) |
 
 The importer parses the file, extracts `Dependency` records, deduplicates them against existing Locations (creating new ones as needed), and creates Asset References linking each Dependency to the Product. The Pro UI exposes the same upload flow — see the **Upload SBOM** action on a Product's Locations tab.
 
@@ -66,7 +67,44 @@ SWID Tag format is not yet supported.
 
 By default, repeated uploads are **additive**: dependencies that already exist on the Asset are kept, new ones are added, and nothing is removed. This matches the typical workflow of incremental SBOM updates.
 
-Set `replace=true` to prune. When replace mode is on, after a successful import the importer removes Product associations that were not present in the new SBOM **and** are not currently referenced by an active Finding. References tied to active Findings are preserved even in replace mode, so you do not lose vulnerability context just because a new SBOM omits a package.
+Set `replace_dependencies=true` to prune. When replace mode is on, after a successful import the importer removes Product associations that were not present in the new SBOM **and** are not currently referenced by an active Finding. References tied to active Findings are preserved even in replace mode, so you do not lose vulnerability context just because a new SBOM omits a package.
+
+## Asset Versions and BOM Snapshots
+
+An SBOM describes an Asset at a point in its release history — *the dependencies of Payments API 5.2.0* — but by default DefectDojo records only the Asset's current inventory. Re-uploading either accumulates forever or prunes, and *what shipped in 5.1?* is not a question the data can answer.
+
+Deployments that opt in to **Asset Versions** can bind each upload to a version. This behavior is managed by deployment configuration: set `DD_V3_ASSET_VERSIONS=True` (self-hosted) or contact support (cloud). It is off by default, and while it is off nothing described in this section is recorded — uploads behave exactly as above.
+
+A version is **metadata about an Asset, not another Asset**, and that distinction is the whole point. Modelling releases as child Assets copies every Finding into every release; one customer's 30,000 Findings became 360,000 that way. A Finding stays a single row on its Asset no matter how many versions mention it.
+
+### Binding an upload to a version
+
+Pass `version` to `POST /api/v2/sbom-import/`. The version is created on first sight, so there is no setup step.
+
+If you omit it, the document's own subject version is used — `metadata.component.version` in CycloneDX, the root package's version in SPDX. Most producers stamp it, so uploads usually bind correctly without you passing anything. Omitting `version` *and* uploading a document that declares none leaves the import on the unversioned stream, which is today's behavior.
+
+Versions carry **no ordering**. DefectDojo does not parse or compare version strings — package ecosystems disagree about what "newer" means — so nothing infers that 5.1 sits between 5.0 and 5.2. `released_at` on a version is an optional display and reporting hint.
+
+### Snapshots supersede rather than merge
+
+Each upload records a **BOM snapshot**: the components the document declared, the dependency relationships between them, and the document's own identity (specification, serial number, timestamp, and declared subject).
+
+Uploading again for the same version and format **supersedes** the previous snapshot — the newest one is what per-version reads return — and the superseded snapshots remain queryable as history. Nothing is deleted. Snapshots are scoped per format, so a CycloneDX document and an SPDX document for the same release supersede independently instead of clobbering each other.
+
+This is a separate axis from `replace_dependencies`, which still governs the Asset's aggregate dependency list. A snapshot answers *what did this document say*; the aggregate answers *what is on this Asset now*.
+
+Snapshots also preserve the BOM's **structure**. Each component records whether the document listed it as a direct dependency of its subject, and component → component relationships are recorded as declared, so a per-version export reproduces the graph instead of flattening it (see [Exporting SBOMs and VEX](../pro__exporting_sboms_and_vex/#exporting-one-release)). CycloneDX JSON and XML and SPDX 2 JSON carry full structure; SPDX XML, tag-value, and v3 record components only.
+
+### `found_in` and `fixed_in`
+
+Scan imports contribute the other half of the version story. When an import or reimport carries a `version` — the field `/api/v2/import-scan/` and `/api/v2/reimport-scan/` already accept — and Asset Versions is enabled:
+
+- Findings the import processes are recorded as **found_in** that version.
+- Findings the import mitigates because the scan no longer reports them are recorded as **fixed_in** that version. Previously that version reached the record only as prose inside the auto-close note.
+
+These claims are **additive and never withdrawn automatically**: an import that stops seeing a Finding does not un-say that an earlier version contained it. Because a Finding's mitigation timestamp is write-once while claims are per-version, a reopen-and-refix cycle appends a second `fixed_in` instead of rewriting the first. Re-importing the same version is a no-op.
+
+The claims are what makes [per-version VEX](../pro__exporting_sboms_and_vex/#vex-for-one-release) possible: they let one Finding report *resolved in 5.2* and *exploitable in 5.1* without existing twice.
 
 ## Findings That Reference Libraries
 
@@ -88,8 +126,12 @@ Because Findings and SBOM uploads share the same underlying Dependency objects, 
 | List Dependency Locations | `GET /api/v2/location/?location_type=dependency` |
 | Link a Dependency to a Finding | `POST /api/v2/location_findings/` |
 | Link a Dependency to a Product (with `owned_by` / `used_by`) | `POST /api/v2/location_products/` |
+| List or create Asset versions | `GET` / `POST /api/v2/asset_versions/` |
+| Record a `found_in` / `fixed_in` claim by hand | `POST /api/v2/finding_version_affects/` |
 
 Filters on `/api/v2/dependencies/` include the pURL component fields, tags, and ordering on `name`, `version`, and active-finding count.
+
+The two version endpoints follow the same rule as the rest of the Asset surface: reading is open to anyone who can already see the Asset, while writing requires edit permission on it plus `DD_V3_ASSET_VERSIONS`. Neither offers an update action, deliberately — a version is a name that exported documents and claims already point at, so renaming one would silently rewrite the meaning of every document exported under it, and a claim is stated or withdrawn rather than edited into a different claim. Hand-recorded claims are marked as such, so they stay distinguishable from the ones imports write.
 
 ## In the Pro UI
 

--- a/docs/content/asset_modelling/locations/PRO__working_with_sboms.md
+++ b/docs/content/asset_modelling/locations/PRO__working_with_sboms.md
@@ -100,6 +100,10 @@ When Locations is enabled, the navigation exposes:
 - **New Dependency** — Form to create a single library by entering its pURL components manually.
 - **Findings detail** — A Finding that touches a library shows its Dependency Locations alongside any URL Locations, so you can see *"this CVE affects `log4j-core@2.14.1` on Asset 6 and Asset 9"* in one place.
 
+## Exporting
+
+The inventory flows back out as well: an Asset's dependencies can be exported as a CycloneDX 1.6 or SPDX 2.3 SBOM, and its finding statuses as a CycloneDX VEX document. See [Exporting SBOMs and VEX](../pro__exporting_sboms_and_vex/).
+
 ## What's Not in the MVP
 
 - **SWID Tag SBOM format** — Not parsed. CycloneDX or SPDX is required.

--- a/docs/content/connectors/upstream/manage_records.md
+++ b/docs/content/connectors/upstream/manage_records.md
@@ -37,6 +37,32 @@ If you have **Auto-Mapping** enabled, new Records will be Mapped to Products aut
 
 If you don't have Auto-Mapping enabled, you can make your own decisions about where you want data to flow. Each time the Connector finds a new Vendor-Equivalent Product (via **Discover**), it will add a new Record to your **Unmapped Records** list, and you can then manually assign that Record to a new or existing Product in DefectDojo.
 
+#### How Auto-Mapping chooses the Product
+
+Auto-Mapping resolves each Record in a fixed order, and stops at the first answer:
+
+1. **The tool's own identifier.** Every Record stores the identifier the tool uses for the
+Vendor-Equivalent Product. Once a Connector has mapped that identifier once, it recognises it
+on every later Discover — so renaming the project in the tool, or in DefectDojo, no longer
+loses the Mapping or creates a duplicate Product.
+2. **The name.** If the Connector has not seen the identifier before, it looks for a Product
+whose name matches. When one is found, the Record is mapped to it and the identifier is
+recorded, so step 1 answers from then on.
+3. **A new Product.** If neither matches, DefectDojo creates one.
+
+Step 1 requires the identity feature to be enabled (`DD_V3_ASSET_ALIASES`); until then,
+Auto-Mapping resolves by name alone, which is the historical behaviour. Enabling it changes
+nothing about existing Mappings: the first Discover after it is turned on records identifiers
+for the Records you already have, and later runs use them.
+
+Because names are matched globally, two tools that each report something called `payments` map
+to the same Product on first sight. Recording each tool's identifier separately is what stops
+that coincidence from becoming permanent — after the first mapping, each Connector follows its
+own identifier rather than the shared name.
+
+Remapping a Record by hand always wins. When you change a Record's Mapping yourself, the
+tool's identifier moves with it, and the next sync follows your decision.
+
 #### Mapping - Example Workflow:
 
 David has just finished setting up a connector for his BurpSuite tool, and runs a Discover operation. David has Burp set up to scan 4 different 'Sites', and DefectDojo creates a new Record for each of those Sites.


### PR DESCRIPTION
Four documentation changes were merged into `dev` and are therefore not on the live docs site. `gh-pages.yml` builds docs.defectdojo.com only on pushes to `master` and `bugfix`, so anything merged to `dev` stays unpublished until the next minor. This brings them to `bugfix` so they publish on the next patch.

Cherry-picked in their original `dev` order, `-x` so each commit records its source:

| Commit | Origin |
|---|---|
| `e97be18ab0` | #15584 — Exporting SBOMs and VEX (Pro) |
| `8c418687ab` | #15619 — organization types + non-exclusive membership |
| `71807ded61` | #15629 — asset versions, BOM snapshots, per-version SBOM/VEX export |
| `a32ac15629` | #15633 — asset kinds and per-source asset aliases |

All four applied without conflict, and the five resulting files are byte-identical to their current state on `dev`. No content was rewritten in the move.

The order matters: #15629 edits the SBOM pages that #15584 created, and #15633 edits the asset pages ahead of further work. Cherry-picking any one of them alone conflicts, which is why they travel together.

Docs only. No code changes.
