### PR TITLE
Apply the tool-configuration permission check in the shared serializer guard

### DIFF
--- a/dojo/asset/api/serializers.py
+++ b/dojo/asset/api/serializers.py
@@ -1,7 +1,10 @@
 from rest_framework import serializers
 
 from dojo.api_v2.serializers import ProductMetaSerializer, TagListSerializerField
-from dojo.authorization.serializer_guards import AuthorizedUsersMemberGuardMixin
+from dojo.authorization.serializer_guards import (
+    AuthorizedUsersMemberGuardMixin,
+    ToolConfigurationUseGuardMixin,
+)
 from dojo.models import (
     Dojo_User,
     Product,
@@ -16,7 +19,7 @@ class RelatedAssetField(serializers.PrimaryKeyRelatedField):
         return get_authorized_products("view")
 
 
-class AssetAPIScanConfigurationSerializer(serializers.ModelSerializer):
+class AssetAPIScanConfigurationSerializer(ToolConfigurationUseGuardMixin, serializers.ModelSerializer):
     asset = RelatedAssetField(source="product")
 
     class Meta:

--- a/dojo/authorization/serializer_guards.py
+++ b/dojo/authorization/serializer_guards.py
@@ -76,3 +76,50 @@ class AuthorizedUsersMemberGuardMixin:
         if not (request_user and user_has_permission(request_user, self.instance, permission)):
             msg = f"You do not have permission to manage authorized users for this {label}."
             raise PermissionDenied(msg)
+
+
+class ToolConfigurationUseGuardMixin:
+
+    """
+    Enforce ``view_tool_configuration`` on ``tool_configuration`` writes.
+
+    Selecting a ``tool_configuration`` lets an import run authenticated requests
+    with the credential stored on it, so it is gated by the same
+    ``view_tool_configuration`` permission that guards the tool-configuration
+    views, not just the object permission these endpoints already check.
+
+    Mix this into *every* serializer exposing the field, including alias
+    serializers over the same model, so the rule holds wherever the field is
+    reachable.
+
+    The check hangs off ``run_validation`` rather than ``validate`` on purpose: a
+    subclass that defines its own ``validate`` would otherwise shadow the mixin's
+    and silently drop the guard.
+
+    No-ops when the field is absent (replay-safe on PATCH), mirroring
+    dojo.authorization.api_permissions.check_update_permission.
+    """
+
+    def run_validation(self, data=serializers.empty):
+        value = super().run_validation(data)
+        self._validate_tool_configuration_use(value)
+        return value
+
+    def _validate_tool_configuration_use(self, data):
+        if "tool_configuration" not in data:
+            return
+
+        from dojo.tool_config.queries import (  # noqa: PLC0415 -- lazy import, avoids circular dependency
+            get_authorized_tool_configurations,
+        )
+
+        # Field-level validation has already resolved the payload to a
+        # Tool_Configuration instance at this point.
+        tool_configuration = data.get("tool_configuration")
+        if tool_configuration is None:
+            return
+        request = self.context.get("request")
+        request_user = getattr(request, "user", None)
+        if not get_authorized_tool_configurations(request_user).filter(pk=tool_configuration.pk).exists():
+            msg = "You do not have permission to use this tool configuration."
+            raise PermissionDenied(msg)

--- a/dojo/product/api/serializer.py
+++ b/dojo/product/api/serializer.py
@@ -1,9 +1,10 @@
 from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied
 
-from dojo.authorization.serializer_guards import AuthorizedUsersMemberGuardMixin
+from dojo.authorization.serializer_guards import (
+    AuthorizedUsersMemberGuardMixin,
+    ToolConfigurationUseGuardMixin,
+)
 from dojo.models import DojoMeta, Product, Product_API_Scan_Configuration
-from dojo.tool_config.queries import get_authorized_tool_configurations
 
 
 class ProductMetaSerializer(serializers.ModelSerializer):
@@ -12,33 +13,10 @@ class ProductMetaSerializer(serializers.ModelSerializer):
         fields = ("name", "value")
 
 
-class ProductAPIScanConfigurationSerializer(serializers.ModelSerializer):
+class ProductAPIScanConfigurationSerializer(ToolConfigurationUseGuardMixin, serializers.ModelSerializer):
     class Meta:
         model = Product_API_Scan_Configuration
         fields = "__all__"
-
-    def validate(self, data):
-        self._validate_tool_configuration_use(data)
-        return data
-
-    def _validate_tool_configuration_use(self, data):
-        """
-        Selecting a ``tool_configuration`` lets an import run authenticated
-        requests with the credential stored on it, so it is gated by the same
-        ``view_tool_configuration`` permission that guards the tool-configuration
-        views -- not just the product permission this endpoint already checks.
-
-        No-ops when the field is absent (replay-safe on PATCH), mirroring
-        dojo.authorization.api_permissions.check_update_permission.
-        """
-        if "tool_configuration" not in data:
-            return
-        tool_configuration = data.get("tool_configuration")
-        request = self.context.get("request")
-        request_user = getattr(request, "user", None)
-        if tool_configuration is not None and not get_authorized_tool_configurations(request_user).filter(pk=tool_configuration.pk).exists():
-            msg = "You do not have permission to use this tool configuration."
-            raise PermissionDenied(msg)
 
 
 class ProductSerializer(AuthorizedUsersMemberGuardMixin, serializers.ModelSerializer):

--- a/dojo/tool_product/api/serializer.py
+++ b/dojo/tool_product/api/serializer.py
@@ -1,10 +1,11 @@
 from rest_framework import serializers
 
+from dojo.authorization.serializer_guards import ToolConfigurationUseGuardMixin
 from dojo.models import Product
 from dojo.tool_product.models import Tool_Product_Settings
 
 
-class ToolProductSettingsSerializer(serializers.ModelSerializer):
+class ToolProductSettingsSerializer(ToolConfigurationUseGuardMixin, serializers.ModelSerializer):
     setting_url = serializers.CharField(source="url")
     product = serializers.PrimaryKeyRelatedField(
         queryset=Product.objects.all(), required=True,

--- a/dojo/tool_product/ui/forms.py
+++ b/dojo/tool_product/ui/forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.core.validators import URLValidator
 
 from dojo.tool_config.models import Tool_Configuration
+from dojo.tool_config.queries import get_authorized_tool_configurations
 from dojo.tool_product.models import Tool_Product_Settings
 
 
@@ -15,7 +16,11 @@ class DeleteToolProductSettingsForm(forms.ModelForm):
 
 
 class ToolProductSettingsForm(forms.ModelForm):
-    tool_configuration = forms.ModelChoiceField(queryset=Tool_Configuration.objects.all(), label="Tool Configuration")
+    tool_configuration = forms.ModelChoiceField(queryset=Tool_Configuration.objects.none(), label="Tool Configuration")
+
+    def __init__(self, *args, user=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["tool_configuration"].queryset = get_authorized_tool_configurations(user)
 
     class Meta:
         model = Tool_Product_Settings

--- a/dojo/tool_product/ui/views.py
+++ b/dojo/tool_product/ui/views.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def new_tool_product(request, pid):
     prod = get_object_or_404(Product, id=pid)
     if request.method == "POST":
-        tform = ToolProductSettingsForm(request.POST)
+        tform = ToolProductSettingsForm(request.POST, user=request.user)
         if tform.is_valid():
             # form.tool_type = tool_type
             new_prod = tform.save(commit=False)
@@ -34,7 +34,7 @@ def new_tool_product(request, pid):
             return HttpResponseRedirect(
                 reverse("all_tool_product", args=(pid, )))
     else:
-        tform = ToolProductSettingsForm()
+        tform = ToolProductSettingsForm(user=request.user)
     product_tab = Product_Tab(prod, title=_("Tool Configurations"), tab="settings")
     return render(request, "dojo/new_tool_product.html", {
         "tform": tform,
@@ -61,7 +61,7 @@ def edit_tool_product(request, pid, ttid):
         raise PermissionDenied
 
     if request.method == "POST":
-        tform = ToolProductSettingsForm(request.POST, instance=tool_product)
+        tform = ToolProductSettingsForm(request.POST, instance=tool_product, user=request.user)
         if tform.is_valid():
             tform.save()
             messages.add_message(
@@ -71,7 +71,7 @@ def edit_tool_product(request, pid, ttid):
                 extra_tags="alert-success")
             return HttpResponseRedirect(reverse("all_tool_product", args=(pid, )))
     else:
-        tform = ToolProductSettingsForm(instance=tool_product)
+        tform = ToolProductSettingsForm(instance=tool_product, user=request.user)
 
     product_tab = Product_Tab(product, title=_("Edit Product Tool Configuration"), tab="settings")
     return render(request, "dojo/edit_tool_product.html", {
@@ -95,7 +95,7 @@ def delete_tool_product(request, pid, ttid):
             _("Tool Product Successfully Deleted."),
             extra_tags="alert-success")
         return HttpResponseRedirect(reverse("all_tool_product", args=(pid, )))
-    tform = ToolProductSettingsForm(instance=tool_product)
+    tform = ToolProductSettingsForm(instance=tool_product, user=request.user)
 
     product_tab = Product_Tab(product, title=_("Delete Product Tool Configuration"), tab="settings")
 

--- a/unittests/test_api_scan_configuration_tool_authz.py
+++ b/unittests/test_api_scan_configuration_tool_authz.py
@@ -24,6 +24,8 @@ from dojo.asset.api.serializers import AssetAPIScanConfigurationSerializer
 from dojo.models import Dojo_User, Product_API_Scan_Configuration, Tool_Configuration, Tool_Type
 from dojo.product.api.serializer import ProductAPIScanConfigurationSerializer
 from dojo.product.ui.forms import Product_API_Scan_ConfigurationForm
+from dojo.tool_product.api.serializer import ToolProductSettingsSerializer
+from dojo.tool_product.ui.forms import ToolProductSettingsForm
 
 from .dojo_test_case import DojoTestCase
 
@@ -115,3 +117,42 @@ class ApiScanConfigurationToolAuthzTest(DojoTestCase):
         with impersonate(self.staff):
             serializer = self._alias_serializer(self.staff, product)
             self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def _tool_product_serializer(self, user, product):
+        return ToolProductSettingsSerializer(
+            data={
+                "name": "tps", "setting_url": "http://example.invalid",
+                "product": product.pk, "tool_configuration": self.tool_config.pk,
+            },
+            context={"request": SimpleNamespace(user=user)},
+        )
+
+    def test_tool_product_rest_rejects_unauthorized_tool_configuration(self):
+        product = self._asset_for(self.unprivileged, "scanconf-tps-unprivileged")
+        with self.assertRaises(PermissionDenied):
+            self._tool_product_serializer(self.unprivileged, product).is_valid(raise_exception=True)
+
+    def test_tool_product_rest_allows_authorized_tool_configuration(self):
+        product = self._asset_for(self.staff, "scanconf-tps-staff")
+        serializer = self._tool_product_serializer(self.staff, product)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def _tool_product_form(self, user):
+        return ToolProductSettingsForm(
+            {"name": "tps", "url": "http://example.invalid", "tool_configuration": self.tool_config.pk},
+            user=user,
+        )
+
+    def test_tool_product_form_offers_unprivileged_user_no_tool_configurations(self):
+        form = ToolProductSettingsForm(user=self.unprivileged)
+        self.assertNotIn(self.tool_config, form.fields["tool_configuration"].queryset)
+
+    def test_tool_product_form_rejects_unauthorized_tool_configuration(self):
+        form = self._tool_product_form(self.unprivileged)
+        self.assertFalse(form.is_valid())
+        self.assertIn("tool_configuration", form.errors)
+
+    def test_tool_product_form_allows_authorized_tool_configuration(self):
+        form = self._tool_product_form(self.staff)
+        self.assertIn(self.tool_config, form.fields["tool_configuration"].queryset)
+        self.assertNotIn("tool_configuration", form.errors)

--- a/unittests/test_api_scan_configuration_tool_authz.py
+++ b/unittests/test_api_scan_configuration_tool_authz.py
@@ -10,12 +10,18 @@ tool-configuration views. A user without that permission gets an empty choice
 set, and a submitted pk is rejected, so narrowing the rendered <select> alone
 cannot be bypassed by POSTing the id directly, and the REST endpoint cannot be
 used to attach an unauthorized configuration either.
+
+The V3 asset alias is a second serializer over the same model, so it is covered
+here too: a member of the asset who lacks the permission cannot attach an
+unauthorized configuration through the alias, on create or on update.
 """
 from types import SimpleNamespace
 
+from crum import impersonate
 from rest_framework.exceptions import PermissionDenied
 
-from dojo.models import Dojo_User, Tool_Configuration, Tool_Type
+from dojo.asset.api.serializers import AssetAPIScanConfigurationSerializer
+from dojo.models import Dojo_User, Product_API_Scan_Configuration, Tool_Configuration, Tool_Type
 from dojo.product.api.serializer import ProductAPIScanConfigurationSerializer
 from dojo.product.ui.forms import Product_API_Scan_ConfigurationForm
 
@@ -28,6 +34,10 @@ class ApiScanConfigurationToolAuthzTest(DojoTestCase):
         self.tool_config = Tool_Configuration.objects.create(
             name="prod-sonarqube", tool_type=tool_type, authentication_type="API",
             url="http://example.invalid/api", api_key="ADMIN-TOKEN",
+        )
+        self.other_tool_config = Tool_Configuration.objects.create(
+            name="prod-sonarqube-secondary", tool_type=tool_type, authentication_type="API",
+            url="http://example.invalid/api2", api_key="ADMIN-TOKEN-2",
         )
         self.unprivileged = Dojo_User.objects.create(
             username="scanconf_unprivileged", is_staff=False, is_superuser=False,
@@ -72,3 +82,36 @@ class ApiScanConfigurationToolAuthzTest(DojoTestCase):
     def test_rest_allows_authorized_tool_configuration(self):
         serializer = self._serializer(self.staff)
         self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def _asset_for(self, user, name):
+        product = self.create_product(name, prod_type=self.product_type)
+        product.authorized_users.add(user)
+        return product
+
+    def _alias_serializer(self, user, product, **kwargs):
+        return AssetAPIScanConfigurationSerializer(
+            data={"asset": product.pk, "tool_configuration": self.tool_config.pk, "service_key_1": "k1"},
+            context={"request": SimpleNamespace(user=user)},
+            **kwargs,
+        )
+
+    def test_alias_rest_rejects_unauthorized_tool_configuration(self):
+        product = self._asset_for(self.unprivileged, "scanconf-alias-unprivileged")
+        with impersonate(self.unprivileged), self.assertRaises(PermissionDenied):
+            self._alias_serializer(self.unprivileged, product).is_valid(raise_exception=True)
+
+    def test_alias_rest_rejects_unauthorized_tool_configuration_on_update(self):
+        product = self._asset_for(self.unprivileged, "scanconf-alias-unprivileged-update")
+        existing = Product_API_Scan_Configuration.objects.create(
+            product=product, tool_configuration=self.other_tool_config, service_key_1="k0",
+        )
+        with impersonate(self.unprivileged), self.assertRaises(PermissionDenied):
+            self._alias_serializer(
+                self.unprivileged, product, instance=existing, partial=True,
+            ).is_valid(raise_exception=True)
+
+    def test_alias_rest_allows_authorized_tool_configuration(self):
+        product = self._asset_for(self.staff, "scanconf-alias-staff")
+        with impersonate(self.staff):
+            serializer = self._alias_serializer(self.staff, product)
+            self.assertTrue(serializer.is_valid(), serializer.errors)


### PR DESCRIPTION
Hardening / consistency improvement to API object permission checks. Moves an existing
authorization check out of a single serializer and into the shared serializer-guard module, so
every serializer that writes the field gets it instead of one of them, and narrows the matching
form's choices the same way. Adds regression tests.

No functional change for correctly-permissioned users.
