### PR TITLE
Trivy Scan parser crash: Prevent resource_name from being appended to whilst uninitialised

### DIFF
--- a/dojo/tools/trivy/parser.py
+++ b/dojo/tools/trivy/parser.py
@@ -218,6 +218,7 @@ class TrivyParser:
                 namespace = resource.get("Namespace")
                 kind = resource.get("Kind")
                 name = resource.get("Name")
+                resource_name = ""
                 if namespace:
                     resource_name = f"{namespace} / "
                 if kind:


### PR DESCRIPTION
Fixes #15653