### PR TITLE
perf(finding): drop two dojo_finding indexes a wider index already covers

### DIFF
--- a/dojo/db_migrations/0295_drop_redundant_finding_fk_indexes.py
+++ b/dojo/db_migrations/0295_drop_redundant_finding_fk_indexes.py
@@ -1,0 +1,88 @@
+"""Drop two `dojo_finding` indexes that a wider index already covers.
+
+Django creates a single-column index for every ForeignKey. On `Finding` two of those are
+redundant, because another index already begins with the same column:
+
+    (test_id)               -> covered by nine composites that lead with test_id, e.g.
+                               (test_id, active, verified), (test_id, hash_code, duplicate)
+    (duplicate_finding_id)  -> covered by (duplicate_finding_id, id)
+
+A btree whose columns are a strict prefix of another btree, with the same (here, absent)
+partial predicate, can be answered from the longer index, so the shorter one returns
+nothing for the write cost it adds to every finding insert. `dojo_finding` is the busiest
+table in the schema and carries close to fifty indexes, so each one removed is a real
+saving on import.
+
+Dropping the referencing-side index does not weaken the foreign keys. PostgreSQL requires
+an index on the REFERENCED (unique) side of a foreign key, not on the referencing side; the
+referencing-side index only accelerates cascade deletes and parent-row deletion checks, and
+in both cases a covering composite remains.
+
+Built with DROP INDEX CONCURRENTLY (non-atomic migration, following 0280) so it does not
+take an exclusive lock on a large `dojo_finding`. IF EXISTS makes it idempotent, and the
+reverse rebuilds concurrently too, so a downgrade does not lock the table either.
+
+The index names are Django's deterministic auto-generated names for these two foreign keys
+(table + column + a hash of both), so they are identical on every install.
+"""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("dojo", "0294_usercontactinfo_language"),
+    ]
+
+    operations = [
+        # RunSQL does the concurrent DB work; state_operations keeps Django's model state in
+        # step with db_index=False on the fields, so a later makemigrations stays a no-op.
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="DROP INDEX CONCURRENTLY IF EXISTS dojo_finding_test_id_ef8ec5fc",
+                    reverse_sql=(
+                        "CREATE INDEX CONCURRENTLY IF NOT EXISTS dojo_finding_test_id_ef8ec5fc "
+                        "ON dojo_finding (test_id)"
+                    ),
+                ),
+                migrations.RunSQL(
+                    sql="DROP INDEX CONCURRENTLY IF EXISTS dojo_finding_duplicate_finding_id_9ff391c5",
+                    reverse_sql=(
+                        "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                        "dojo_finding_duplicate_finding_id_9ff391c5 ON dojo_finding (duplicate_finding_id)"
+                    ),
+                ),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="finding",
+                    name="test",
+                    field=models.ForeignKey(
+                        db_index=False,
+                        editable=False,
+                        help_text="The test that is associated with this flaw.",
+                        on_delete=models.CASCADE,
+                        to="dojo.test",
+                        verbose_name="Test",
+                    ),
+                ),
+                migrations.AlterField(
+                    model_name="finding",
+                    name="duplicate_finding",
+                    field=models.ForeignKey(
+                        blank=True,
+                        db_index=False,
+                        editable=False,
+                        help_text="Link to the original finding if this finding is a duplicate.",
+                        null=True,
+                        on_delete=models.DO_NOTHING,
+                        related_name="original_finding",
+                        to="dojo.finding",
+                        verbose_name="Duplicate Finding",
+                    ),
+                ),
+            ],
+        ),
+    ]

--- a/dojo/finding/models.py
+++ b/dojo/finding/models.py
@@ -205,6 +205,10 @@ class Finding(BaseModel):
     test = models.ForeignKey("dojo.Test",
                              editable=False,
                              on_delete=models.CASCADE,
+                             # No standalone index: nine composite indexes below already lead with
+                             # `test`, so a query filtering on it alone is served by one of those.
+                             # The single-column copy only added write cost on every finding insert.
+                             db_index=False,
                              verbose_name=_("Test"),
                              help_text=_("The test that is associated with this flaw."))
     active = models.BooleanField(default=True,
@@ -226,6 +230,9 @@ class Finding(BaseModel):
                                           null=True,
                                           related_name="original_finding",
                                           blank=True, on_delete=models.DO_NOTHING,
+                                          # No standalone index: the ("duplicate_finding", "id")
+                                          # composite below covers every lookup this one did.
+                                          db_index=False,
                                           verbose_name=_("Duplicate Finding"),
                                           help_text=_("Link to the original finding if this finding is a duplicate."))
     out_of_scope = models.BooleanField(default=False,


### PR DESCRIPTION
## What

Django creates a single-column index for every `ForeignKey`. Two of those on `Finding` are redundant, because another index already begins with the same column:

| Redundant index | Already covered by |
|---|---|
| `(test_id)` | nine composites leading with `test_id`, among them `(test_id, active, verified)` and `(test_id, hash_code, duplicate)` |
| `(duplicate_finding_id)` | `(duplicate_finding_id, id)` |

A btree whose columns are a strict prefix of another btree, with the same (here absent) partial predicate, can be answered from the longer index. The shorter one returns nothing for the write cost it adds to every finding insert.

## Why it's worth doing

`dojo_finding` is the busiest table in the schema and currently carries **49 indexes**, every one of which is maintained on each row written. Import is where that is felt — a scan that creates thousands of findings pays all 49 per row.

This PR removes only what is *provably* covered, so there is no judgement call about query patterns involved.

## Why it doesn't weaken the foreign keys

PostgreSQL requires an index on the **referenced** (unique) side of a foreign key, not on the referencing side. The referencing-side index only accelerates cascade deletes and parent-row deletion checks — and for both fields a covering composite remains, so those paths keep an index to use.

## Migration safety

Built with `DROP INDEX CONCURRENTLY` in a non-atomic migration, following the pattern already established by `0280_vulnerability_id_upper_index`, so it takes no exclusive lock on a large `dojo_finding`. `IF EXISTS` makes it idempotent, and the reverse rebuilds concurrently as well, so a downgrade doesn't lock the table either.

The index names in the SQL are Django's deterministic auto-generated names for these two foreign keys (table + column + a hash of both), so they are identical on every install.

## Verification

- `makemigrations dojo --check --dry-run` reports **"No changes detected"** — the migration's state operations match the model, so a later `makemigrations` stays a no-op.
- Applied against a migrated database: `dojo_finding` goes from **49 indexes to 47**, and both named indexes are gone.
- Reversed: both indexes come back.
- `ruff` (repo config) clean.

## Scope

Deliberately narrow. Several single-column **boolean** indexes on the same table look like stronger candidates still — six of them are already covered by `(test_id, …)` composites — but whether an index is actually used is a property of the queries an instance runs, not of the schema. Settling those needs `pg_stat_user_indexes` from a long-running instance, so they are left alone here.
