### PR TITLE
fix(scout suite): reset parser state so a report parses to the same findings twice

### DIFF
--- a/dojo/tools/scout_suite/parser.py
+++ b/dojo/tools/scout_suite/parser.py
@@ -88,6 +88,17 @@ class ScoutSuiteParser:
         return self.__get_items(data)
 
     def __get_items(self, data):
+        # ``item_data`` and ``pdepth`` are class attributes that ``recursive_print``
+        # accumulates into, and the parser instance is reused for every import in the
+        # process. ``recursive_print`` emits a newline based on ``self.pdepth != depth``,
+        # so without this reset the first finding of a report is rendered against the
+        # depth left behind by whatever was parsed before it: the same file parsed twice
+        # produces different descriptions, and one report's text depends on the previous
+        # one. Reset restores the values a fresh instance would have, so a parse is a
+        # function of its input alone.
+        self.item_data = ""
+        self.pdepth = 0
+
         findings = []
         # get the date of the run
         last_run_date = None


### PR DESCRIPTION
`ScoutSuiteParser` keeps `item_data` and `pdepth` as **class attributes**, and `recursive_print` accumulates into them. The parser instance is reused for every import in the process, and neither value is reset between calls.

`recursive_print` decides whether to emit a separating newline from `self.pdepth != depth`, so the first finding of a report is rendered against the depth left behind by whatever was parsed before it.

### Reproduction

Parsing the same file three times in one process, on `bugfix`:

```
parse 1: findings=356 description_digest=76a8199ae2f2 pdepth_after=1
parse 2: findings=356 description_digest=44ff844ef8e2 pdepth_after=1
parse 3: findings=356 description_digest=44ff844ef8e2 pdepth_after=1
```

The finding count is stable, but the descriptions are not. Parse 1 differs from every later parse, because it is the only one that starts from the initial `pdepth = 0`.

Two consequences:

* The same report imported twice produces different finding descriptions.
* In a worker that imports several reports, one report's description text depends on the previous one, which is the more surprising half.

### Fix

Reset both values at the start of `__get_items`, so a parse is a function of its input alone.

After the change all three parses agree, and they agree on **`76a8199ae2f2`, the original first-parse value**:

```
parse 1: findings=356 description_digest=76a8199ae2f2
parse 2: findings=356 description_digest=76a8199ae2f2
parse 3: findings=356 description_digest=76a8199ae2f2
```

That is the important property for review: the fix restores what a freshly constructed parser already produced, so **no existing recorded output changes**. It removes a divergence rather than introducing one.

### Deduplication impact: none

`Scout Suite Scan` deduplicates on `hash_code` over `["file_path", "vuln_id_from_tool"]`, so `description` is not part of its hash and finding identity never moved with this. The bug affected the text a user reads, not what matches what.

### How it surfaced

Found by a test that parses the sample corpus twice and compares the identity-bearing output. Scout Suite was the one scan type that differed between two parses at a **fixed** point in time, which ruled out anything date related and pointed at retained state.

`ruff check --config ruff.toml` clean with the pinned 0.16.0.
