### PR TITLE
fix(dedupe): stop Xeol finding identity depending on the wall clock

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1430,6 +1430,13 @@ HASHCODE_FIELDS_PER_SCANNER = {
     "PyRIT Scan": ["title", "vuln_id_from_tool"],
     "debsecan Scan": ["vulnerability_ids", "component_name"],
     "PMapper Scan": ["vuln_id_from_tool", "component_name"],
+    # Deliberately without "severity", unlike most entries here. The Xeol parser derives
+    # severity from datetime.now() against the component's EOL date, so a stored finding
+    # would change identity on its own as the date passes each band boundary. The product
+    # name in the title plus the component name and version identify the finding; the
+    # description is excluded because it embeds every artifact attribute and moves whenever
+    # the parser's wording does.
+    "Xeol Parser": ["title", "component_name", "component_version"],
 }
 
 # Override the hardcoded settings here via the env var
@@ -1877,6 +1884,10 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     "PyRIT Scan": DEDUPE_ALGO_HASH_CODE,
     "debsecan Scan": DEDUPE_ALGO_HASH_CODE,
     "PMapper Scan": DEDUPE_ALGO_HASH_CODE,
+    # Without this entry Xeol falls through to DEDUPE_ALGO_LEGACY, whose reimport candidate
+    # key is (title.lower(), severity). Xeol's severity is a function of the wall clock, so
+    # that key rewrites itself as time passes even though the report never changed.
+    "Xeol Parser": DEDUPE_ALGO_HASH_CODE,
 }
 
 # Override the hardcoded settings here via the env var


### PR DESCRIPTION
`Xeol Parser` has no entry in `DEDUPLICATION_ALGORITHM_PER_PARSER`, so it falls through to `DEDUPE_ALGO_LEGACY`, whose reimport candidate key is `(title.lower(), severity)`.

Its severity is a function of the current time. `dojo/tools/xeol/parser.py` bands `datetime.now()` minus the component's EOL date into Low, Medium, High and Critical at two, four and six weeks:

```python
now = datetime.now()
if eol_date < now:
    delta = now - eol_date
    if delta <= timedelta(weeks=2):
        severity = "Low"
    ...
```

So the deduplication key rewrites itself as time passes, even though the report never changed. At each band boundary the incoming finding stops matching the stored one, reimport closes the stored finding as absent, and a duplicate is created at the new severity. Rehashing cannot repair it, because the stored row does not contain the new value either.

This is not theoretical. On 2026-08-13 a sample scan crossed its six-week boundary and began parsing as Critical instead of High with no code change anywhere in the repository.

### The change

Register the scan type so identity stops depending on severity:

```python
"Xeol Parser": DEDUPE_ALGO_HASH_CODE,
"Xeol Parser": ["title", "component_name", "component_version"],
```

All three values come straight from the report. The title carries the product name, and the component name and version identify which artifact is end of life, so two artifacts sharing a product stay two findings.

Two deliberate omissions:

* **`severity`**, even though most entries here include it. It is the field the clock moves, and it is the whole reason this parser drifts.
* **`description`**, because it embeds every artifact attribute, so it moves whenever the parser's wording moves. That is the same class of problem arriving by a different route.

**The severity ramp itself is untouched.** A user still sees urgency rise as an EOL date recedes. It simply no longer decides what the finding *is*.

### Blast radius

Stating this plainly rather than burying it: registering hash fields moves the stored `hash_code` for existing Xeol findings once, the same one-time cost as any change to a hash field list.

That is the price of ending a break which otherwise recurs at every band boundary, for every user, indefinitely. A one-time move is bounded and can be planned around; the current behaviour is not.

### Checks

* `dojo.checks.check_configuration_deduplication` reports no warnings with both halves registered. Registering only one half is what raises `dojo.W001`.
* All three fields are in `HASHCODE_ALLOWED_FIELDS`.
* `ruff check --config ruff.toml` clean with the pinned 0.16.0.

### How it surfaced

A test that parses the sample corpus under two different clocks and compares the identity-bearing output, then fails when a finding present under one clock is **absent** under the other. Xeol is that case: the same finding changes severity, so its old identity disappears.

Worth contrasting with a parser that is fine. `CyberArk Certificate Manager Scan` also reads `now()`, but once a certificate lapses it emits an *additional* violation with its own `unique_id_from_tool` while every existing finding keeps its identity exactly. Adding findings over time is correct behaviour for an expiry parser. Losing one is not.
