### PR TITLE
docs: fix the dedupe management command in three upgrade notes

### DIFF
--- a/docs/content/releases/os_upgrading/2.42.md
+++ b/docs/content/releases/os_upgrading/2.42.md
@@ -9,9 +9,9 @@ exclude_search: true
 **Hash Code changes**
 A few parsers have been updated to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code please execute the following command:
 
-    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Horusec Scan' --hash_code_only"
-    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Qualys Hacker Guardian Scan' --hash_code_only"
-    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Red Hat Satellite' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Horusec Scan' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Qualys Hacker Guardian Scan' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Red Hat Satellite' --hash_code_only"
 
 This command has various command line arguments to tweak its behaviour, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.

--- a/docs/content/releases/os_upgrading/2.43.md
+++ b/docs/content/releases/os_upgrading/2.43.md
@@ -33,11 +33,11 @@ In the past, when DefectDojo supported different database and message brokers, `
 
 The Rusty Hog parser has been [updated](https://github.com/DefectDojo/django-DefectDojo/pull/11433) to populate more fields. Some of these fields are part of the hash code calculation. To recalculate the hash code and deduplicate existing Rusty Hog findings, please execute the following command:
 
-    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Rusty Hog Scan)' --hash_code_only"
-    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Choctaw Hog)' --hash_code_only"
-    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Duroc Hog)' --hash_code_only"
-    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Gottingen Hog)' --hash_code_only"
-    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Essex Hog Scan (Essex Hog)' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Essex Hog Scan (Rusty Hog Scan)' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Essex Hog Scan (Choctaw Hog)' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Essex Hog Scan (Duroc Hog)' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Essex Hog Scan (Gottingen Hog)' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Essex Hog Scan (Essex Hog)' --hash_code_only"
 
 This command has various command line arguments to tweak its behaviour, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.

--- a/docs/content/releases/os_upgrading/2.44.md
+++ b/docs/content/releases/os_upgrading/2.44.md
@@ -9,7 +9,7 @@ description: No special instructions.
 
 The Burp parser now has a custom deduplication configuration to make deduplication more accurate. To recalculate the hash code and deduplicate existing Burp findings, please execute the following command:
 
-    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Burp Scan' --hash_code_only"
+    docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Burp Scan' --hash_code_only"
 
 This command has various command line arguments to tweak its behavior, for example to trigger a run of the deduplication process.
 See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py) for more information.


### PR DESCRIPTION
The upgrade notes for 2.42, 2.43 and 2.44 tell users to run:

```
docker compose exec uwsgi /bin/bash -c "python manage.py dedupe.py --parser 'Burp Scan' --hash_code_only"
```

Django management commands are invoked by command name, not by filename, so that exits with `Unknown command: 'dedupe.py'`. The command is `dedupe`, defined in `dojo/management/commands/dedupe.py`.

Nine occurrences across the three files: three in 2.42, five in 2.43, one in 2.44.

### Why it is worth fixing rather than leaving

These are the notes a user follows precisely when a release has changed a hash configuration and their existing findings need rehashing to keep matching. So the one command that repairs identity drift is the one command in the page that does not run, at the moment it is needed.

The correct form already appears elsewhere in the same docs tree, including `OS__deduplication_tuning.md` and the 1.13, 1.15, 2.0 and 3.2 upgrade notes, so this is three pages drifting from the convention rather than a change of convention.

### Deliberately not changed

Each of those files also links the source file:

```markdown
See [dedupe.py](https://github.com/DefectDojo/django-DefectDojo/blob/master/dojo/management/commands/dedupe.py)
```

That reference is correct, because the file really is named `dedupe.py`. Only the command invocations were wrong, and only those are touched.

Docs only. No code, no tests, no migrations.
