### PR TITLE
fix(dedupe): hash Checkmarx One on the vendor id it already matches on

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1437,6 +1437,10 @@ HASHCODE_FIELDS_PER_SCANNER = {
     # description is excluded because it embeds every artifact attribute and moves whenever
     # the parser's wording does.
     "Xeol Parser": ["title", "component_name", "component_version"],
+    # Checkmarx One already deduplicates on the vendor id; this makes the STORED hash_code
+    # agree with that instead of falling through to the legacy field set, whose "description"
+    # is what every result family assigns to "title" as well.
+    "Checkmarx One Scan": ["unique_id_from_tool"],
 }
 
 # Override the hardcoded settings here via the env var


### PR DESCRIPTION
`Checkmarx One Scan` is registered `DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL` but has no `HASHCODE_FIELDS_PER_SCANNER` entry. Candidates are therefore looked up by the vendor id, while the **stored** `hash_code` falls through to the legacy field set:

```
title + cwe + line + file_path + description
```

For this parser that is close to description twice, because every result family assigns the description to the title as well:

```python
get_results_sast: title=description, description=description
get_results_kics: title=description, description=description
get_results_sca:  title=description, description=description
```

So the stored hash moves whenever Checkmarx rephrases a finding, even though matching does not. `hash_code` is what false positive history, risk acceptance copying and similar findings key on, so those quietly stop tracking the finding they were attached to, while deduplication itself looks healthy.

### The change

```python
"Checkmarx One Scan": ["unique_id_from_tool"],
```

Every family sets it from `vulnerability.get("id", vulnerability.get("similarityId"))`, which is the value the parser **already deduplicates on**. Hashing it makes the stored identity agree with the matching identity instead of contradicting it.

Eight scan types already use exactly this list, including the `Tartufo Scan` file parser.

### Two lists that were considered and rejected

* **`["cwe", "severity", "file_path"]`**, mirroring `Checkmarx Scan`. `get_results_sca` sets no `cwe`, no `file_path` and no `line`, so this would hash SCA findings on severity alone and collapse distinct findings onto one `hash_code`. That is worse than the legacy behaviour it would replace.
* **Anything title or description based.** `title` *is* the description here, so such a list would keep exactly the volatility this is meant to remove.

### Blast radius

This moves the stored `hash_code` once for existing Checkmarx One findings.

Matching is unaffected. `unique_id_from_tool` is not a hash matched algorithm, so this changes what is stored without changing how candidates are found. The one-time move is the cost of ending an ongoing drift in which the stored identity disagrees with the matching identity on every rewording.

Narrow case worth naming: a result carrying neither `id` nor `similarityId` would hash a null vendor id. Such findings are already undedupable under the current algorithm, so matching does not regress, but their `hash_code` would no longer be distinct.

### Checks

* `check_configuration_deduplication` reports no warnings.
* `unique_id_from_tool` is in `HASHCODE_ALLOWED_FIELDS`.
* `ruff check --config ruff.toml` clean with the pinned 0.16.0.
