### PR TITLE
fix: retry async cascade delete on foreign-key violation race

### DIFF
--- a/dojo/db_utils.py
+++ b/dojo/db_utils.py
@@ -7,16 +7,40 @@
 # category and repeating it only repeats the problem.
 TRANSIENT_DB_CONFLICT_SQLSTATES = frozenset({"40P01", "40001"})
 
+# 23503 foreign_key_violation. Retryable ONLY in the cascade-delete context: it means a
+# row referencing what we are deleting appeared after the cascade step had already
+# cleared the children -- an import committing a new child (e.g. a Test_Import row for a
+# Test being deleted) between the cascade step and the top-level delete. The reference is
+# real but transient: on a re-run the cascade step clears the newly-created child and the
+# delete succeeds. Outside a delete an FK violation is a genuine bug, so this is exposed as
+# its own predicate and never folded into is_transient_db_conflict.
+FK_VIOLATION_SQLSTATE = "23503"
+
+
+def _iter_sqlstates(exc):
+    """
+    Yield the SQLSTATE of exc and of its driver ``__cause__``.
+
+    Django re-raises the driver error as its own OperationalError/IntegrityError and keeps
+    the driver exception -- the one carrying the SQLSTATE -- as ``__cause__``, so check
+    both rather than matching on the message text, which is localized and version-dependent.
+    """
+    for err in (exc, getattr(exc, "__cause__", None)):
+        state = getattr(err, "sqlstate", None)
+        if state is not None:
+            yield state
+
 
 def is_transient_db_conflict(exc):
-    """
-    Whether exc is a deadlock or serialization failure, and so safe to retry.
+    """Whether exc is a deadlock or serialization failure, and so safe to retry."""
+    return any(state in TRANSIENT_DB_CONFLICT_SQLSTATES for state in _iter_sqlstates(exc))
 
-    Django re-raises the driver error as its own OperationalError and keeps the driver
-    exception -- the one carrying the SQLSTATE -- as ``__cause__``, so check both rather
-    than matching on the message text, which is localized and version-dependent.
+
+def is_foreign_key_conflict(exc):
     """
-    return any(
-        getattr(err, "sqlstate", None) in TRANSIENT_DB_CONFLICT_SQLSTATES
-        for err in (exc, exc.__cause__)
-    )
+    Whether exc is a foreign-key violation (SQLSTATE 23503).
+
+    See ``FK_VIOLATION_SQLSTATE`` -- retryable only while cascade-deleting, where it is the
+    delete-vs-import race, not a generic transient conflict.
+    """
+    return any(state == FK_VIOLATION_SQLSTATE for state in _iter_sqlstates(exc))

--- a/dojo/utils.py
+++ b/dojo/utils.py
@@ -42,7 +42,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.signals import user_logged_in, user_logged_out, user_login_failed
 from django.core.paginator import Paginator
-from django.db import OperationalError, transaction
+from django.db import IntegrityError, OperationalError, transaction
 from django.db.models import Case, Count, F, IntegerField, Q, Sum, Value, When
 from django.db.models.query import QuerySet
 from django.db.models.signals import post_save
@@ -57,7 +57,7 @@ from django.utils.translation import gettext as _
 from kombu import Connection
 
 from dojo.celery import app
-from dojo.db_utils import is_transient_db_conflict
+from dojo.db_utils import is_foreign_key_conflict, is_transient_db_conflict
 from dojo.finding.queries import get_authorized_findings
 from dojo.github.services import (
     add_external_issue_github,
@@ -1927,6 +1927,24 @@ ASYNC_DELETE_RETRY_DELAY = 5
 ASYNC_DELETE_MAX_CONFLICT_RETRIES = 3
 
 
+def _is_retryable_delete_conflict(exc):
+    """
+    Whether a delete failure is a lost concurrency race worth retrying.
+
+    Two shapes, both caused by another transaction touching the same rows while the
+    cascade delete runs, and both cleared by re-running the resumable body:
+
+    * a deadlock or serialization failure raised mid-cascade (``OperationalError``); and
+    * a foreign-key violation from an import committing a new child row -- e.g. a
+      ``Test_Import`` for a ``Test`` being deleted -- between the cascade step (which
+      cleared the old children) and the top-level ``obj.delete()`` (``IntegrityError``).
+
+    Any other DB error (a statement timeout, a unique violation, a dropped connection) is
+    not a lost race, so it is surfaced rather than retried.
+    """
+    return is_transient_db_conflict(exc) or is_foreign_key_conflict(exc)
+
+
 @app.task(bind=True)
 def async_delete_task(self, model_label, pk, **kwargs):
     """
@@ -1937,7 +1955,9 @@ def async_delete_task(self, model_label, pk, **kwargs):
     against each other. This retry is the backstop for the conflicts that ordering
     cannot rule out -- a delete overlapping an import, say -- because the aborted
     transaction's work is not wrong, only rolled back, and failing here would leave the
-    object partly deleted.
+    object partly deleted. That overlap has two shapes: a deadlock/serialization failure,
+    and a foreign-key violation when the import commits a new child row referencing a row
+    being deleted (see ``_is_retryable_delete_conflict``); both are retried the same way.
 
     Only applies to background execution: under eager execution Celery re-runs the body
     inline and ignores ``countdown``, which would retry into an unfinished conflicting
@@ -1949,8 +1969,8 @@ def async_delete_task(self, model_label, pk, **kwargs):
     retries = self.request.retries
     try:
         _async_delete_object(model_label, pk, is_retry=retries > 0)
-    except OperationalError as exc:
-        if not is_transient_db_conflict(exc):
+    except (OperationalError, IntegrityError) as exc:
+        if not _is_retryable_delete_conflict(exc):
             raise
         if self.request.is_eager:
             # Verified against celery 5.6.3: under apply() retry re-invokes the body

--- a/unittests/test_async_delete.py
+++ b/unittests/test_async_delete.py
@@ -13,13 +13,13 @@ from unittest.mock import patch
 from celery.exceptions import Retry
 from crum import impersonate
 from django.contrib.auth.models import User
-from django.db import OperationalError
+from django.db import IntegrityError, OperationalError
 from django.test import override_settings
 from django.utils import timezone
 from parameterized import parameterized
-from psycopg.errors import DeadlockDetected, QueryCanceled, SerializationFailure
+from psycopg.errors import DeadlockDetected, ForeignKeyViolation, QueryCanceled, SerializationFailure, UniqueViolation
 
-from dojo.db_utils import is_transient_db_conflict
+from dojo.db_utils import is_foreign_key_conflict, is_transient_db_conflict
 from dojo.models import Engagement, Finding, Product, Product_Type, Test, Test_Type, UserContactInfo
 from dojo.utils import ASYNC_DELETE_MAX_CONFLICT_RETRIES, async_delete, async_delete_task
 
@@ -357,6 +357,142 @@ class TestAsyncDeleteTransientConflictRetry(DojoTestCase):
             is_transient_db_conflict(OperationalError("connection closed")),
             msg="an OperationalError without a SQLSTATE must not be treated as retryable",
         )
+
+    @staticmethod
+    def _wrapped_integrity_error(driver_error_class, message="integrity error"):
+        """
+        Build the IntegrityError shape the cloud reports show.
+
+        Django re-raises the driver error as its own IntegrityError and keeps the
+        psycopg exception -- the one carrying the SQLSTATE -- as ``__cause__``.
+        """
+        cause = driver_error_class(message)
+        exc = IntegrityError(str(cause))
+        exc.__cause__ = cause
+        return exc
+
+    def test_is_foreign_key_conflict(self):
+        """
+        An FK violation (23503) is the delete-vs-import race; other errors are not.
+
+        The two predicates stay separate: a foreign-key violation is only retryable in
+        the delete context, so it must NOT be reported as a generic transient conflict,
+        and a deadlock must NOT be reported as a foreign-key conflict.
+        """
+        fk_exc = self._wrapped_integrity_error(
+            ForeignKeyViolation,
+            'update or delete on table "dojo_test" violates foreign key constraint '
+            '"dojo_test_import_test_id_e8dc3f37_fk_dojo_test_id" on table "dojo_test_import"',
+        )
+        self.assertTrue(
+            is_foreign_key_conflict(fk_exc),
+            msg="a foreign-key violation raised while deleting a referenced row must be retryable",
+        )
+        self.assertFalse(
+            is_transient_db_conflict(fk_exc),
+            msg="a foreign-key violation is not a deadlock/serialization conflict",
+        )
+        deadlock = self._wrapped_db_error(DeadlockDetected)
+        self.assertFalse(
+            is_foreign_key_conflict(deadlock),
+            msg="a deadlock is not a foreign-key conflict",
+        )
+
+    def test_is_foreign_key_conflict_rejects_other_integrity_errors(self):
+        """Control: a unique violation (23505) is a real bug, not the delete-vs-import race."""
+        unique_exc = self._wrapped_integrity_error(UniqueViolation, "duplicate key value")
+        self.assertFalse(
+            is_foreign_key_conflict(unique_exc),
+            msg="only foreign-key violations (23503) are the transient delete race",
+        )
+
+    def test_foreign_key_conflict_is_retried_rather_than_failing(self):
+        """
+        The reported failure: an import committed a new Test_Import row referencing a
+        Test between the cascade step and the top-level delete, so the delete hit an FK
+        violation. On a re-run the cascade step clears the new child and the delete
+        completes, so the task must retry rather than surface the error.
+        """
+        product = self._create_product()
+        exc = self._wrapped_integrity_error(
+            ForeignKeyViolation,
+            'update or delete on table "dojo_test" violates foreign key constraint',
+        )
+
+        with patch.object(async_delete_task, "retry", side_effect=Retry()) as mock_retry:
+            async_delete_task.push_request(retries=0, is_eager=False)
+            try:
+                with patch(
+                    "dojo.utils_cascade_delete.cascade_delete_related_objects", side_effect=exc,
+                ), self.assertRaises(Retry):
+                    async_delete_task("dojo.product", product.pk)
+            finally:
+                async_delete_task.pop_request()
+
+        mock_retry.assert_called_once()
+        countdown = mock_retry.call_args.kwargs["countdown"]
+        self.assertGreater(
+            countdown, 0,
+            msg="the retry must be delayed so the racing import's transaction commits "
+                f"first, got countdown={countdown}",
+        )
+
+    def test_non_fk_integrity_error_is_not_retried(self):
+        """Control: an integrity error that is not the delete-vs-import race fails loudly."""
+        product = self._create_product()
+        exc = self._wrapped_integrity_error(UniqueViolation, "duplicate key value")
+
+        with patch.object(async_delete_task, "retry", side_effect=Retry()) as mock_retry:
+            async_delete_task.push_request(retries=0, is_eager=False)
+            try:
+                with patch(
+                    "dojo.utils_cascade_delete.cascade_delete_related_objects", side_effect=exc,
+                ), self.assertRaises(IntegrityError):
+                    async_delete_task("dojo.product", product.pk)
+            finally:
+                async_delete_task.pop_request()
+
+        mock_retry.assert_not_called()
+
+    @override_settings(ASYNC_OBJECT_DELETE=True)
+    def test_eager_execution_does_not_retry_foreign_key_conflict(self):
+        """Eager callers get the FK violation instead of a retry, as with a deadlock."""
+        product = self._create_product()
+        exc = self._wrapped_integrity_error(
+            ForeignKeyViolation, "violates foreign key constraint",
+        )
+
+        with patch(
+            "dojo.utils_cascade_delete.cascade_delete_related_objects", side_effect=exc,
+        ), patch.object(async_delete_task, "retry", side_effect=Retry()) as mock_retry:
+            result = async_delete_task.apply(args=("dojo.product", product.pk))
+
+        mock_retry.assert_not_called()
+        self.assertTrue(
+            isinstance(result.result, IntegrityError),
+            msg=f"eager execution must surface the FK violation, got {result.result!r}",
+        )
+
+    def test_foreign_key_conflict_surfaces_once_retries_are_exhausted(self):
+        """An FK violation that keeps repeating must be reported rather than retried forever."""
+        product = self._create_product()
+        exc = self._wrapped_integrity_error(
+            ForeignKeyViolation, "violates foreign key constraint",
+        )
+
+        with patch.object(async_delete_task, "retry", side_effect=Retry()) as mock_retry:
+            async_delete_task.push_request(
+                retries=ASYNC_DELETE_MAX_CONFLICT_RETRIES, is_eager=False,
+            )
+            try:
+                with patch(
+                    "dojo.utils_cascade_delete.cascade_delete_related_objects", side_effect=exc,
+                ), self.assertRaises(IntegrityError):
+                    async_delete_task("dojo.product", product.pk)
+            finally:
+                async_delete_task.pop_request()
+
+        mock_retry.assert_not_called()
 
     @parameterized.expand([
         ("deadlock", DeadlockDetected),


### PR DESCRIPTION
**Description**

Async cascade delete of a `Test` (or a parent object that cascades down to one) could fail with an `IntegrityError` when the top-level object is deleted:

```
update or delete on table "dojo_test" violates foreign key constraint
"dojo_test_import_test_id_..._fk_dojo_test_id" on table "dojo_test_import"
DETAIL:  Key (id)=(...) is still referenced from table "dojo_test_import".
```

Root cause is a delete-vs-import race. `async_delete_task` deletes a `Test`'s children (including its `Test_Import` rows) in the cascade step, and then deletes the `Test` itself in a separate statement. If an import commits a **new** `Test_Import` row referencing that `Test` in the window between those two steps, the top-level delete hits a foreign-key violation. The reference is real but transient: the delete body is resumable, so re-running it repeats the cascade step (clearing the newly-created child) and then completes.

The task already retries the deadlock / serialization-failure form of exactly this race, but the retry only caught `OperationalError`. The foreign-key form is raised as an `IntegrityError` (SQLSTATE `23503`), so it fell through, surfaced to the operator, and left the object partly deleted instead of being retried.

**Fix**

- Add `is_foreign_key_conflict()` in `dojo/db_utils.py`, which recognises a `23503` foreign-key violation (checking both the exception and its driver `__cause__`, matching the existing SQLSTATE approach).
- Widen `async_delete_task` to catch `IntegrityError` alongside `OperationalError` and classify both through a new `_is_retryable_delete_conflict()` helper, so the FK-violation race flows through the same eager-execution guard, exponential backoff, and max-retries logic that the deadlock race already uses.
- The FK predicate is kept deliberately separate from `is_transient_db_conflict()` so a foreign-key violation is only ever treated as retryable inside the delete path. Everywhere else an FK violation is a genuine bug and must still surface.
- Non-race errors are unchanged: other integrity errors (e.g. unique-violation `23505`) and statement timeouts (`57014`) are still surfaced rather than retried, and eager execution still surfaces the error rather than retrying (retries ignore `countdown` under eager execution).

No schema change and **no migration** — this is purely a change to the task's exception handling.

**Test results**

Extended `unittests/test_async_delete.py`:

- `is_foreign_key_conflict()` classification: FK violation → retryable; deadlock and unique-violation → not an FK conflict; FK violation is not reported as a generic transient conflict.
- FK-violation conflict is retried with a positive backoff `countdown`.
- A non-FK integrity error (unique violation) fails loudly and is not retried.
- Eager execution surfaces the FK violation instead of retrying.
- The FK violation is surfaced once the retry budget is exhausted.

The new tests mirror the structure of the existing (passing) deadlock/serialization retry tests in the same class. The pure classification logic in `dojo/db_utils.py` was validated directly against real `psycopg` error SQLSTATEs (23503 / 40P01 / 40001 / 23505 / 57014); the full Django suite runs in CI.

**Documentation**

No user-facing behavior change (background-task resilience only), so no docs update is needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_013FnVnyZUhZpt2ZnXVfzLgN)_