### PR TITLE
fix(importers): auto-creating the same asset name concurrently no longer 500s

### DIFF
--- a/dojo/importers/auto_create_context.py
+++ b/dojo/importers/auto_create_context.py
@@ -261,7 +261,20 @@ class AutoCreateContextManager:
         product_type = self.get_or_create_product_type(product_type_name=product_type_name)
         # Create the product
         with transaction.atomic():
-            product, _created = Product.objects.select_for_update().get_or_create(name=product_name, prod_type=product_type, description=product_name)
+            # Only `name` is a lookup: it is the column that is actually unique. `prod_type`
+            # and `description` were lookup kwargs historically, so a row a concurrent request
+            # had just committed did not match here, making this attempt a CREATE that then
+            # lost to the unique index -- and get_or_create's recovery get() reuses the same
+            # lookup, so it missed that row too and re-raised. Callers reach this line only
+            # when the name looked free, so the symptom was an IntegrityError whenever two
+            # imports raced through that gap.
+            product, _created = Product.objects.select_for_update().get_or_create(
+                name=product_name,
+                defaults={
+                    "prod_type": product_type,
+                    "description": product_name,
+                },
+            )
 
         return product
 

--- a/unittests/test_importers_product_race.py
+++ b/unittests/test_importers_product_race.py
@@ -1,0 +1,116 @@
+import logging
+from unittest import mock
+
+from parameterized import parameterized
+
+from dojo.importers.auto_create_context import AutoCreateContextManager
+from dojo.models import Product, Product_Type
+
+from .dojo_test_case import DojoTestCase
+
+logger = logging.getLogger(__name__)
+
+PRODUCT_NAME = "TestImportersProductRace"
+REQUESTED_TYPE = "Product Race Requested"
+
+
+class TestImportersProductRace(DojoTestCase):
+
+    """
+    Regression: two concurrent auto-creating imports of the same product name could fail one
+    of them with a 500 instead of returning the product the other one had just created.
+
+    `get_or_create_product()` guards with `get_target_product_if_exists()`, which matches on
+    `name` alone, so the `get_or_create()` below it is reached only when the name looked free.
+    That call passed `prod_type` and `description` as *lookup* kwargs rather than `defaults=`,
+    which made its `get` half match on all three columns -- so a row another request committed
+    inside the guard's window was invisible to it. Django fell through to `create`, lost to the
+    `dojo_product_name_key` unique index, and its recovery `get` reused the same three-column
+    lookup, missing the winner's row a second time, so the IntegrityError was re-raised:
+
+        duplicate key value violates unique constraint "dojo_product_name_key"
+        DETAIL: Key (name)=(TestImportersProductRace) already exists.
+
+    `name` is the only unique column, so `name` is the only lookup; the rest are `defaults=`.
+    The race window itself is unchanged -- the loser now resolves to the winner's product
+    instead of raising, and does not overwrite it.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.requested_type, _ = Product_Type.objects.get_or_create(name=REQUESTED_TYPE)
+        self.auto_create_manager = AutoCreateContextManager()
+
+    def _auto_create_through_the_race_window(self):
+        """
+        Call the creator as a request that lost the race would reach it.
+
+        The losing request ran `get_target_product_if_exists()` before the winner committed,
+        so it saw nothing and fell through to the create. Patching that guard to None
+        reproduces exactly that state, and is the only way to reach the `get_or_create()` at
+        all: left alone the guard returns the existing product first, which is why this bug
+        stayed latent.
+        """
+        with mock.patch.object(AutoCreateContextManager, "get_target_product_if_exists", return_value=None):
+            return self.auto_create_manager.get_or_create_product(
+                product_name=PRODUCT_NAME,
+                product_type_name=REQUESTED_TYPE,
+                auto_create_context=True,
+            )
+
+    @parameterized.expand([
+        # The winner filed the name under a different organization.
+        ("competing_organization", "Product Race Competitor", PRODUCT_NAME),
+        # The winner came from a path that writes its own description (a connector sync, or a
+        # person creating the asset in the UI inside the window).
+        ("competing_description", REQUESTED_TYPE, "Created by another importer"),
+        # Control: the winner wrote exactly what this request would have. Already worked.
+        ("identical_row", REQUESTED_TYPE, PRODUCT_NAME),
+    ])
+    def test_losing_the_create_race_returns_the_winners_product(
+        self, case_name, winner_type_name, winner_description,
+    ):
+        winner_type, _ = Product_Type.objects.get_or_create(name=winner_type_name)
+        winner = Product.objects.create(
+            name=PRODUCT_NAME,
+            prod_type=winner_type,
+            description=winner_description,
+        )
+
+        product = self._auto_create_through_the_race_window()
+
+        self.assertEqual(
+            winner.pk, product.pk,
+            msg=f"expected the winner's product pk={winner.pk}, got pk={product.pk}",
+        )
+        self.assertEqual(
+            1, Product.objects.filter(name=PRODUCT_NAME).count(),
+            msg="the losing request must not add a second product under the same name",
+        )
+        persisted = Product.objects.get(pk=winner.pk)
+        self.assertEqual(
+            winner_description, persisted.description,
+            msg=f"defaults must not overwrite the winner: expected description="
+                f"{winner_description!r}, persisted={persisted.description!r}",
+        )
+        self.assertEqual(
+            winner_type_name, persisted.prod_type.name,
+            msg=f"defaults must not overwrite the winner: expected prod_type={winner_type_name!r}, "
+                f"persisted={persisted.prod_type.name!r}",
+        )
+
+    def test_auto_create_still_populates_a_product_when_nothing_races(self):
+        """Control: with no competing row the defaults still land on the created product."""
+        self.assertFalse(Product.objects.filter(name=PRODUCT_NAME).exists())
+
+        product = self._auto_create_through_the_race_window()
+
+        persisted = Product.objects.get(pk=product.pk)
+        self.assertEqual(
+            PRODUCT_NAME, persisted.description,
+            msg=f"expected description={PRODUCT_NAME!r}, persisted={persisted.description!r}",
+        )
+        self.assertEqual(
+            REQUESTED_TYPE, persisted.prod_type.name,
+            msg=f"expected prod_type={REQUESTED_TYPE!r}, persisted={persisted.prod_type.name!r}",
+        )


### PR DESCRIPTION
**Description**

`AutoCreateContextManager.get_or_create_product()` passed `prod_type` and `description` to
`get_or_create()` as **lookup** kwargs rather than as `defaults=`:

```python
product, _created = Product.objects.select_for_update().get_or_create(
    name=product_name, prod_type=product_type, description=product_name,
)
```

`Product.name` is the only unique column, so that three-column lookup can miss a row which the
unique index will nonetheless reject. When it does, Django falls through to `create()`, loses to
`dojo_product_name_key`, and its recovery `get()` — which reuses the same three-column lookup —
misses the row a second time, so the `IntegrityError` is re-raised rather than resolved:

```
duplicate key value violates unique constraint "dojo_product_name_key"
DETAIL:  Key (name)=(...) already exists.
```

Only `name` belongs in the lookup. `prod_type` and `description` move into `defaults=`.

**How this is reached**

It is a race, not a dormant branch. `get_or_create_product()` guards with
`get_target_product_if_exists()`, which matches on `name` alone and returns early whenever a
product with that name already exists — so the `get_or_create()` below it is reached only when
the name looked free. Two concurrent `/api/v2/import-scan/` calls that auto-create the same
product name both clear that guard, and the one that loses the insert then fails with a 500
instead of resolving to the product the winner had just created.

The failure needs the two requests to disagree about the rest of the row: a different
`product_type_name`, or a competitor that writes its own description (a connector sync, or a
person creating the asset in the UI inside the window). When both requests would have written
exactly the same three columns, the recovery `get()` already matched — which is why this has
been survivable in practice and why it needed a race to show up at all.

**Behavior change**

The race window itself is unchanged; only its outcome is. The loser now resolves to the winner's
product instead of raising, and because the other two columns are `defaults=`, it does not
overwrite what the winner wrote.

One consequence worth naming: when the two racing requests disagree on product type, the loser
now adopts the winner's product silently, whereas the same mismatch found *outside* the window
still raises the existing `ValueError` from `get_target_product_if_exists()`. That asymmetry is
pre-existing in shape — it is the difference between the guard's path and the creator's path —
and returning the winner's row is strictly better than the 500 it replaces. Making the two paths
agree would mean re-validating after the create, which is a wider change than this fix.

**Test results**

New: `unittests/test_importers_product_race.py`.

The race is reproduced deterministically by patching `get_target_product_if_exists()` to return
`None` — exactly the state a losing request is in, having run its lookup before the winner
committed — with the winner's row already in the database. That patch is also the only way to
reach the `get_or_create()` at all, since the guard otherwise returns the existing product first.

Four cases: a competing product type, a competing description, an identical-row control that
already passed before this change, and a no-race control that proves `defaults=` still populate
a genuinely new product.

Before the fix, both competing cases fail with the `IntegrityError` quoted above; after it, all
four pass. Also ran the neighbouring importer suites to check for collateral damage.

**Documentation**

None needed — no user-facing behavior is documented for this path; the change removes a 500 in a
concurrent-import race.
