### PR TITLE
docs(sbom): document the Asset-page export and the version it produces

### DIFF
--- a/docs/content/asset_modelling/locations/PRO__exporting_sboms_and_vex.md
+++ b/docs/content/asset_modelling/locations/PRO__exporting_sboms_and_vex.md
@@ -9,6 +9,20 @@ DefectDojo Pro can serialize an Asset's current dependency inventory back out as
 
 Both endpoints require **V3 Locations** to be enabled, and respect Asset-level permissions: an Asset the requesting user cannot view returns a 404.
 
+## Exporting from the Asset page
+
+The Asset page carries an **Export** panel offering the same data without going through the API, in one of three shapes:
+
+| Export type | What the document contains |
+| --- | --- |
+| **SBOM** | The component inventory only. |
+| **VEX** | The vulnerability analysis only — a standalone document describing the exploitability of this Asset's findings. |
+| **SBOM with vulnerabilities (VDR)** | Both — the inventory with an embedded `vulnerabilities` block carrying the VEX analysis. |
+
+Each choice names the format and specification version it produces, for example *SBOM — component inventory only (CycloneDX 1.6)*. Those labels are read from the server as the panel renders rather than written into the page, so they describe the document you will actually receive: when the exporters adopt a newer specification, the labels follow rather than going stale.
+
+The Asset page and the API endpoints below emit the same specification version, so a document exported from either path is interchangeable with the other.
+
 ## Exporting an SBOM
 
 ```


### PR DESCRIPTION
[sc-14491]

## Description

The **Exporting SBOMs and VEX** page documented only the token-auth API endpoints. The Asset page's own **Export** panel — SBOM, VEX, and SBOM with vulnerabilities (VDR) — had no documentation at all, so the three choices, and what document each one produces, were discoverable only by exporting one and reading the result.

This adds a section covering that panel:

- A table of the three export types and what each document contains.
- A note that each choice now names the format and specification version it produces, and that those labels are read from the server as the panel renders rather than written into the page — so they follow the exporters rather than going stale when the specification is bumped.
- A statement that the Asset page and the API endpoints emit the same specification version, so a document exported from either path is interchangeable with the other.

Docs-only; no code changes in this repo.

Pairs with a DefectDojo Pro change on the same release line that adds the version to those labels and unifies the specification version across the two export paths.
