### PR TITLE
docs: features that became standard, and Feature Flags moving up the settings menu

### DIFF
--- a/docs/content/admin/feature_flags/PRO__feature_flags.md
+++ b/docs/content/admin/feature_flags/PRO__feature_flags.md
@@ -118,7 +118,7 @@ Most features are available on both installation types. The exceptions are:
 
 | Feature | Availability | How it is controlled |
 | --- | --- | --- |
-| Request a New Connector | [DefectDojo Pro (Cloud)](/get_started/pro/cloud/) only | Feature Flags page. Shown as **Unavailable on This Deployment** on-premise. |
+| Request a New Connector | [DefectDojo Pro (Cloud)](/get_started/pro/cloud/) only | Always on for Cloud instances, and not offered on-premise. No longer listed on the Feature Flags page. |
 | Locations | Both | Feature Flags page for the Pro UI and import pipeline; the Classic UI and `/api/v2` route wiring follow the `DD_V3_FEATURE_LOCATIONS` deployment setting. Enabling is self-service and one-way — once on, it cannot be turned back off. See [above](#locations) and [Locations Overview](/asset_modelling/locations/pro__locations_overview/). |
 | Organization / Asset Relabeling | Both | Feature Flags page for the Pro UI; the Classic UI, its URLs and generated reports follow the `DD_ENABLE_V3_ORGANIZATION_ASSET_RELABEL` deployment setting. See [above](#organization--asset-relabeling). |
 
@@ -143,10 +143,13 @@ This endpoint is **read-only**. Turning a feature on or off is still done from t
 ## Frequently asked questions
 
 **A feature I want is not in the list.**
-The list shows optional features only. Capabilities that are always on do not appear. If you expected a feature that is missing, confirm your license includes it, then contact [DefectDojo Support](mailto:support@defectdojo.com).
+The list shows optional features only. Capabilities that are always on do not appear. A feature also leaves the list once it becomes standard — it is then on for every instance and there is nothing to switch. If you expected a feature that is missing, confirm your license includes it, then contact [DefectDojo Support](mailto:support@defectdojo.com).
+
+**A feature I had turned off is on again after an upgrade.**
+A feature that becomes standard is turned on everywhere, and the setting you had chosen for it while it was optional is cleared as part of that release — otherwise an instance that had opted out would stay off with no toggle left to change it back. This only happens to features that leave the list; everything still shown keeps your setting. If a standard feature causes you a problem, contact [DefectDojo Support](mailto:support@defectdojo.com), who can turn it off for your instance.
 
 **I turned a feature on but I do not see it.**
 Reload the page — menu entries and routes are evaluated when the page loads, so a newly enabled feature appears on the next load rather than instantly in the current view.
 
 **Will upgrading change my settings?**
-No. Upgrading preserves the features you have turned on and the ones you have turned off.
+For every feature on this page, yes — upgrading preserves the ones you have turned on and the ones you have turned off. The exception is a feature that becomes standard in that release and leaves the page; see the question above.

--- a/docs/content/navigation/PRO__settings_menu.md
+++ b/docs/content/navigation/PRO__settings_menu.md
@@ -18,7 +18,7 @@ Settings is divided into seven groups, named for what you are trying to do rathe
 
 | Group | What it holds |
 | --- | --- |
-| **System** | System Settings, Appearance, Announcement Banner, Login Banner, E-mail, Feature Flags |
+| **System** | System Settings, Appearance, Announcement Banner, Login Banner, E-mail |
 | **Users & Permissions** | Users, Groups, Roles |
 | **Finding Workflow** | The three Deduplication pages, Finding Enrichment, Service Level Agreements, Prioritization Engines, Mitigation Policies |
 | **Configuration** | Environments, Regulations, Note Types, Test Types, CI/CD Infrastructure, Tool Types, Tool Configurations |
@@ -27,6 +27,8 @@ Settings is divided into seven groups, named for what you are trying to do rathe
 | **License & Support** | License Manager, Version Manager, Contact Support |
 
 You only ever see the entries your account has permission to open, and a group disappears entirely when none of its pages are available to you.
+
+**Feature Flags sits above the groups**, directly under All Settings, rather than inside any of them. It is the page administrators open most often, and it reads alongside All Settings: one lists what exists, the other controls what is switched on. It is still filed under System in the All Settings directory.
 
 Two conventions are worth knowing:
 
@@ -45,7 +47,7 @@ If you are used to the previous layout:
 
 | Previously | Now |
 | --- | --- |
-| Settings → *(top level)* → Feature Flags | Settings → System → Feature Flags |
+| Settings → *(top level)* → Feature Flags | Unchanged — still at the top level, below All Settings |
 | Settings → Pro Settings → System Settings | Settings → System → System Settings |
 | Settings → Pro Settings → Appearance | Settings → System → Appearance |
 | Settings → Pro Settings → Banner Settings → Announcement Banner Settings | Settings → System → Announcement Banner |

--- a/docs/content/sensei/threat_modeling.md
+++ b/docs/content/sensei/threat_modeling.md
@@ -11,13 +11,14 @@ weight: 4
 
 This is Sensei's **pre-code** capability. Where [scan-and-fix](/sensei/about_sensei/) works on a repository that already exists, threat modeling works on the design, before there is code to scan.
 
-> **🔎 BETA:** Threat Modeling is under active development and is labeled **BETA** throughout the UI. Behavior and screens may change between releases. During BETA it is enabled per instance by DefectDojo — contact your DefectDojo representative to have it turned on.
+> **🔎 BETA:** Threat Modeling is under active development and is labeled **BETA** throughout the UI. Behavior and screens may change between releases. It is on by default; a superuser can switch it off, or back on, from the [Feature Flags page](/admin/feature_flags/pro__feature_flags/) — no Support request is required.
 
 > **📍 Where to find it:** open **Threat Modeling** from the left-hand navigation, directly below Sensei.
 
 ## What you need
 
 - The **Sensei** licensed feature. Threat modeling ships under the same entitlement as scan-and-fix.
+- The **AI Threat Modeling** feature flag, which is on by default. If your instance turned it off, a superuser can turn it back on from the [Feature Flags page](/admin/feature_flags/pro__feature_flags/).
 - A global **Maintainer** or **Owner** role. Users without it do not see the page.
 - An Asset to attach the threat model to. Instances using V3 naming see Assets called **assets**; this page says *Asset* throughout, and the UI follows whichever naming your instance is set to.
 


### PR DESCRIPTION
## Description

Documentation for the feature-flag changes shipping in the same release: nine optional features become standard and leave the Feature Flags page, five more default on, and the Feature Flags entry moves up a level in the settings menu.

Three pages change.

**`admin/feature_flags/PRO__feature_flags.md`**

- The FAQ said upgrading never changes your settings. That is not true for a feature promoted to standard in the same release — its stored setting is cleared, because an instance that had opted out would otherwise stay off with no toggle left to change it back. Answered directly rather than left for a reader to discover, with a matching entry for "a feature I had turned off is on again after an upgrade".
- "A feature I want is not in the list" now covers the other reason a feature can be missing: it became standard.
- Connector Requests is no longer shown as **Unavailable on This Deployment** on-premise, because it is off the page entirely. Its availability row says that instead.

**`navigation/PRO__settings_menu.md`** — Feature Flags is no longer inside the **System** group. It sits above the groups, directly under All Settings, and is still filed under System in the All Settings directory. The group table and the "what moved" table both follow.

**`sensei/threat_modeling.md`** — threat modeling is on by default and a superuser can switch it off or back on from the Feature Flags page, rather than being enabled per instance on request during beta. It stays labeled BETA, and the Sensei entitlement is unchanged.

English only. The de/es/fr/ja translations are regenerated from the English source through the pipeline described in `docs/TRANSLATIONS.md` rather than hand-edited.
