### PR TITLE
docs: Restrict Layout Customization and the UI Defaults settings group

### DIFF
--- a/docs/content/metrics_reports/dashboards/PRO__custom_dashboards.md
+++ b/docs/content/metrics_reports/dashboards/PRO__custom_dashboards.md
@@ -65,6 +65,11 @@ Widgets are placed on a **12-column grid**. In edit mode you drag widgets to mov
 - **Clone** — copy any layout (one of yours, or a shared template) into your own space as a fresh, independent starting point. Cloning gives the copy its own widgets, so editing the clone never touches the original.
 - **Share** — publish one of your layouts to the whole team as a **shared layout**. Other users can see it and clone it, but only a team **Maintainer** can publish, edit, or unshare a shared layout. Sharing a layout shares only its *design* — every viewer still sees only the data their own permissions allow.
 - **Starter & shared templates** — DefectDojo ships a set of curated **shared templates** you can clone as a head start (see [Shared templates](#shared-templates) below). The **Default Dashboard** is the special "starter" template that new users are given automatically.
+- **Organization default**: a user who can share dashboards can mark a shared layout as the **organization default** from **Manage Layouts** (**Set Org Default**, cleared with **Clear Org Default**). It carries an "Org Default" badge, and it is the dashboard everyone is shown when dashboard customization is restricted (see below).
+
+### Restricting customization
+
+An administrator can enable **Restrict Layout Customization** (Settings, then UI Defaults, then Layout Defaults) to limit dashboard changes to superusers. Everyone else is shown the organization default dashboard, or the built-in starter dashboard when none is designated, with no toolbar options to create, switch, edit, or manage layouts. Personal dashboards saved earlier are kept and reappear if the setting is turned back off.
 
 ## Building a dashboard in the UI
 

--- a/docs/content/metrics_reports/dashboards/PRO__custom_dashboards.md
+++ b/docs/content/metrics_reports/dashboards/PRO__custom_dashboards.md
@@ -65,11 +65,11 @@ Widgets are placed on a **12-column grid**. In edit mode you drag widgets to mov
 - **Clone** — copy any layout (one of yours, or a shared template) into your own space as a fresh, independent starting point. Cloning gives the copy its own widgets, so editing the clone never touches the original.
 - **Share** — publish one of your layouts to the whole team as a **shared layout**. Other users can see it and clone it, but only a team **Maintainer** can publish, edit, or unshare a shared layout. Sharing a layout shares only its *design* — every viewer still sees only the data their own permissions allow.
 - **Starter & shared templates** — DefectDojo ships a set of curated **shared templates** you can clone as a head start (see [Shared templates](#shared-templates) below). The **Default Dashboard** is the special "starter" template that new users are given automatically.
-- **Organization default**: a user who can share dashboards can mark a shared layout as the **organization default** from **Manage Layouts** (**Set Org Default**, cleared with **Clear Org Default**). It carries an "Org Default" badge, and it is the dashboard everyone is shown when dashboard customization is restricted (see below).
+- **Global default**: a user who can share dashboards can mark a shared layout as the **global default** from **Manage Layouts** (**Set as Global Default**, cleared with **Clear Global Default**). It carries a "Global Default" badge, and it is the dashboard everyone is shown when dashboard customization is restricted (see below). It can also be chosen from a dropdown on the Layout Defaults settings page (Settings, then UI Defaults, then Layout Defaults).
 
 ### Restricting customization
 
-An administrator can enable **Restrict Layout Customization** (Settings, then UI Defaults, then Layout Defaults) to limit dashboard changes to superusers. Everyone else is shown the organization default dashboard, or the built-in starter dashboard when none is designated, with no toolbar options to create, switch, edit, or manage layouts. Personal dashboards saved earlier are kept and reappear if the setting is turned back off.
+An administrator can enable **Restrict Layout Customization** (Settings, then UI Defaults, then Layout Defaults) to limit dashboard changes to superusers. Everyone else is shown the global default dashboard, or the built-in starter dashboard when none is designated, with no toolbar options to create, switch, edit, or manage layouts. Personal dashboards saved earlier are kept and reappear if the setting is turned back off.
 
 ## Building a dashboard in the UI
 

--- a/docs/content/navigation/PRO__settings_menu.md
+++ b/docs/content/navigation/PRO__settings_menu.md
@@ -47,7 +47,7 @@ The last category, **Elsewhere in the app**, lists pages that configure DefectDo
 The **UI Defaults** group collects the settings that control how much of the interface each person can tailor:
 
 - **Form Configuration**: choose which fields the create and edit forms show and require, and whether the Optional Fields panel starts expanded.
-- **Layout Defaults**: the **Restrict Layout Customization** switch, plus an overview of the organization-wide defaults designated for dashboards, page layouts, and table views. With the switch on, only superusers can create or change dashboards, page layouts, and table views; everyone else is shown the designated defaults, or the built-in defaults when none are chosen. Personal layouts saved earlier are kept and reappear if the switch is turned back off. You designate a default in context (a shared dashboard's Manage dialog, a view page's layout menu, or a table's Views menu); the Layout Defaults page shows what is currently set and lets an administrator clear it.
+- **Layout Defaults**: the **Restrict Layout Customization** switch, plus the global defaults designated for dashboards, page layouts, and table views. With the switch on, only superusers can create or change dashboards, page layouts, and table views; everyone else is shown the designated defaults, or the built-in defaults when none are chosen. Personal layouts saved earlier are kept and reappear if the switch is turned back off. You choose each default from a dropdown of the layouts an administrator has shared, or designate one in context (a shared dashboard's Manage dialog, a view page's layout menu, or a table's Views menu).
 
 ## What moved
 

--- a/docs/content/navigation/PRO__settings_menu.md
+++ b/docs/content/navigation/PRO__settings_menu.md
@@ -14,11 +14,12 @@ Either way, **every settings page keeps the same URL**. Bookmarks, saved links a
 
 ## The reorganized layout
 
-Settings is divided into seven groups, named for what you are trying to do rather than for the part of the system involved.
+Settings is divided into eight groups, named for what you are trying to do rather than for the part of the system involved.
 
 | Group | What it holds |
 | --- | --- |
 | **System** | System Settings, Appearance, Announcement Banner, Login Banner, E-mail |
+| **UI Defaults** | Form Configuration, Layout Defaults |
 | **Users & Permissions** | Users, Groups, Roles |
 | **Finding Workflow** | The three Deduplication pages, Finding Enrichment, Service Level Agreements, Prioritization Engines, Mitigation Policies |
 | **Configuration** | Environments, Regulations, Note Types, Test Types, CI/CD Infrastructure, Tool Types, Tool Configurations |
@@ -40,6 +41,13 @@ Two conventions are worth knowing:
 The first entry in the section, **All Settings**, opens a directory of every settings page your account can reach, arranged in the same groups as the menu and searchable by name or by what the page does. Searching `deduplication` finds the three deduplication pages *and* System Settings, because System Settings holds deduplication options too.
 
 The last category, **Elsewhere in the app**, lists pages that configure DefectDojo but live in other sidebar sections — the authorization providers, Login and MFA settings, Jira instances, the Upstream and Downstream connectors, and the Universal Parser. Each tile is chipped with the section it belongs to.
+
+## UI Defaults
+
+The **UI Defaults** group collects the settings that control how much of the interface each person can tailor:
+
+- **Form Configuration**: choose which fields the create and edit forms show and require, and whether the Optional Fields panel starts expanded.
+- **Layout Defaults**: the **Restrict Layout Customization** switch, plus an overview of the organization-wide defaults designated for dashboards, page layouts, and table views. With the switch on, only superusers can create or change dashboards, page layouts, and table views; everyone else is shown the designated defaults, or the built-in defaults when none are chosen. Personal layouts saved earlier are kept and reappear if the switch is turned back off. You designate a default in context (a shared dashboard's Manage dialog, a view page's layout menu, or a table's Views menu); the Layout Defaults page shows what is currently set and lets an administrator clear it.
 
 ## What moved
 

--- a/docs/content/navigation/PRO__table_customization.md
+++ b/docs/content/navigation/PRO__table_customization.md
@@ -43,3 +43,12 @@ Column visibility, column order, column widths, page size, filters, and sort ord
 To switch between preferences, pick one from the list in the preferences menu. Selecting **Default** returns the table to its built-in columns and widths without deleting any of your saved preferences.
 
 Shared preferences created by other users appear under the **Shared Preferences** tab of the menu. You can load or set a shared preference as your default, but only its creator can change or delete it.
+
+## Organization defaults and restricted customization
+
+An administrator can pin everyone to a shared table view instead of letting each person keep their own.
+
+- **Set as Organization Default**: on a shared preference, the preferences menu offers **Set as Organization Default** to users who can share preferences. The designated preference becomes the one every user is shown for that table while customization is restricted.
+- **Restrict Layout Customization**: a system setting (Settings, then UI Defaults, then Layout Defaults) that, when enabled, limits table customization to superusers. Everyone else is shown the designated organization default for each table, or the table's built-in columns when none is designated, and the **Views** and **Columns** buttons are hidden. Sorting, filtering, and searching still work.
+
+Personal preferences saved before the setting was enabled are not deleted. They are ignored while it is on, and they reappear if an administrator turns it back off.

--- a/docs/content/navigation/PRO__table_customization.md
+++ b/docs/content/navigation/PRO__table_customization.md
@@ -44,11 +44,11 @@ To switch between preferences, pick one from the list in the preferences menu. S
 
 Shared preferences created by other users appear under the **Shared Preferences** tab of the menu. You can load or set a shared preference as your default, but only its creator can change or delete it.
 
-## Organization defaults and restricted customization
+## Global defaults and restricted customization
 
 An administrator can pin everyone to a shared table view instead of letting each person keep their own.
 
-- **Set as Organization Default**: on a shared preference, the preferences menu offers **Set as Organization Default** to users who can share preferences. The designated preference becomes the one every user is shown for that table while customization is restricted.
-- **Restrict Layout Customization**: a system setting (Settings, then UI Defaults, then Layout Defaults) that, when enabled, limits table customization to superusers. Everyone else is shown the designated organization default for each table, or the table's built-in columns when none is designated, and the **Views** and **Columns** buttons are hidden. Sorting, filtering, and searching still work.
+- **Set as Global Default**: on a shared preference, the preferences menu offers **Set as Global Default** to users who can share preferences. The designated preference becomes the one every user is shown for that table while customization is restricted. You can also choose it on the Layout Defaults settings page (Settings, then UI Defaults, then Layout Defaults), which offers a dropdown of the shared preferences for each table.
+- **Restrict Layout Customization**: a system setting (Settings, then UI Defaults, then Layout Defaults) that, when enabled, limits table customization to superusers. Everyone else is shown the designated global default for each table, or the table's built-in columns when none is designated, and the **Views** and **Columns** buttons are hidden. Sorting, filtering, and searching still work.
 
 Personal preferences saved before the setting was enabled are not deleted. They are ignored while it is on, and they reappear if an administrator turns it back off.


### PR DESCRIPTION
## What

Documents the **Restrict Layout Customization** setting and the organization-wide layout defaults it pins users to.

- **Customizing Tables**: a new section on designating a shared table view as the organization default, and on the Restrict Layout Customization setting: what changes for non-superusers, and that personal preferences are kept and restored when it is turned back off.
- **Customizable Dashboards**: the organization default dashboard (Set Org Default in Manage Layouts) and how the restriction behaves.
- **The Settings Menu**: the new **UI Defaults** group (Form Configuration and Layout Defaults) and a section describing the Layout Defaults page.

## Notes

Documentation only. The behavior is described in words; no screenshots.
