### PR TITLE
fix(locations): report distinct locations and per-endpoint failures from the endpoints backfill

### DIFF
--- a/docs/content/asset_modelling/locations/PRO__migrating_from_endpoints.md
+++ b/docs/content/asset_modelling/locations/PRO__migrating_from_endpoints.md
@@ -13,6 +13,8 @@ Note that migration is **one-way**. There is no automated rollback path that re-
 
 Enabling Locations only changes behaviour for *new* imports; your existing history is carried forward by a **data-migration suite** that appears under the Locations row on the **Settings > Feature Flags** page once the feature is on. Each item is run on demand by a superuser, shows live progress and an ETA, and is safe to re-run (every step is idempotent).
 
+When a backfill finishes it reports how many source objects it processed and how many distinct **Locations** those objects resolved to. The two numbers differ by design: several source objects can share one Location (many Endpoints normalising to the same URL, or many Findings sharing one component), so the Location count is normally lower than the object count. If any individual object could not be migrated it is skipped rather than aborting the run, and the number skipped is shown alongside the result.
+
 The suite has four items, because a Finding can carry three independent kinds of location:
 
 1. **Endpoints to Locations backfill** — turns existing `Endpoint` rows into **URL Locations** (detailed below).

--- a/dojo/management/commands/migrate_endpoints_to_locations.py
+++ b/dojo/management/commands/migrate_endpoints_to_locations.py
@@ -177,10 +177,12 @@ class Command(BaseCommand):
 
     help = "Usage: manage.py migrate_endpoints_to_locations"
 
-    # `progress_callback` is accepted by handle() but not exposed on the parser:
-    # it is a programmatic hook for in-process callers (Pro's migration suite
-    # passes it via call_command) and cannot be supplied on the command line.
-    stealth_options = ("progress_callback",)
+    # `progress_callback` and `summary_callback` are accepted by handle() but not
+    # exposed on the parser: they are programmatic hooks for in-process callers (Pro's
+    # migration suite passes them via call_command) and cannot be supplied on the
+    # command line. progress_callback(processed, total) drives a live bar;
+    # summary_callback(dict) reports the final {processed, total, locations, failures}.
+    stealth_options = ("progress_callback", "summary_callback")
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -605,7 +607,9 @@ class Command(BaseCommand):
             product_ref_rows, product_ref_endpoint_ids,
         )
 
-        self._reconcile_product_statuses(list({location.id for _, location in resolved}))
+        chunk_location_ids = {location.id for _, location in resolved}
+        self.migrated_location_ids.update(chunk_location_ids)
+        self._reconcile_product_statuses(list(chunk_location_ids))
 
     def _collect_references(
         self,
@@ -720,6 +724,23 @@ class Command(BaseCommand):
         except Exception:
             logger.warning("progress_callback raised; continuing migration", exc_info=True)
 
+    def _emit_summary(self, summary: dict) -> None:
+        """
+        Publish the final run summary to an optional programmatic callback.
+
+        Pro's migration suite passes ``summary_callback`` (a stealth option) to persist
+        the distinct-location count and the per-endpoint failures. Carried separately
+        from progress because handle() cannot return it: BaseCommand.execute writes any
+        truthy return to stdout and a dict has no ``.endswith``. Swallowed like progress.
+        """
+        callback = self.summary_callback
+        if callback is None:
+            return
+        try:
+            callback(summary)
+        except Exception:
+            logger.warning("summary_callback raised; continuing migration", exc_info=True)
+
     def _log_progress(
         self,
         i: int,
@@ -816,8 +837,9 @@ class Command(BaseCommand):
         self.query_count = bool(options.get("query_count"))
         self.batch_size = int(options["batch_size"])
         self.progress_every = int(options["progress_every"])
-        # Optional programmatic progress hook (see stealth_options). None for CLI runs.
+        # Optional programmatic hooks (see stealth_options). None for CLI runs.
         self.progress_callback = options.get("progress_callback")
+        self.summary_callback = options.get("summary_callback")
 
         # Per-phase wall-clock accumulators.
         self.timings = dict.fromkeys(PHASES, 0.0)
@@ -843,6 +865,10 @@ class Command(BaseCommand):
         # a multi-hour migration. Each entry is (endpoint_id, exception_str).
         self.failed_endpoints: list[tuple[int | None, str]] = []
         self.failed_endpoint_ids: set[int | None] = set()
+
+        # Distinct Location ids this run resolved, so the caller can report how many
+        # Locations the endpoints collapsed onto (many endpoints can share one URL).
+        self.migrated_location_ids: set[int] = set()
 
         if self.query_count:
             connection.force_debug_cursor = True
@@ -974,3 +1000,16 @@ class Command(BaseCommand):
 
         if self.query_count:
             connection.force_debug_cursor = False
+
+        # Summary for programmatic callers (the Pro Locations migration suite). CLI runs
+        # pass no summary_callback and are unaffected. ``locations`` is the distinct-
+        # Location count the endpoints collapsed onto (<= processed); ``failures`` are the
+        # per-endpoint errors isolated during the run so the suite can surface "N skipped".
+        self._emit_summary(
+            {
+                "processed": i,
+                "total": endpoint_count,
+                "locations": len(self.migrated_location_ids),
+                "failures": [{"id": endpoint_id, "error": error} for endpoint_id, error in self.failed_endpoints],
+            },
+        )

--- a/unittests/test_migrate_endpoints_to_locations.py
+++ b/unittests/test_migrate_endpoints_to_locations.py
@@ -455,6 +455,38 @@ class MigrateEndpointsToLocationsTest(TestCase):
             ["good-one.example.com", "good-two.example.com"],
         )
 
+    def test_summary_callback_reports_locations_and_failures(self):
+        # The Pro Locations migration suite passes summary_callback to learn the
+        # distinct-Location count (endpoints collapse onto shared URLs) and the
+        # per-endpoint failures, neither of which the (processed, total) progress
+        # hook can carry. Two endpoints share a host (one Location), one is unique
+        # (a second Location), and one is broken (fails, no Location).
+        self._make_endpoint("dup.example.com", [])
+        self._make_endpoint("dup.example.com", [])
+        self._make_endpoint("uniq.example.com", [])
+        broken = self._make_endpoint("broken.example.com", [])
+        Endpoint.objects.filter(pk=broken.pk).update(host="")
+
+        summaries = []
+        with self.assertLogs(
+            "dojo.management.commands.migrate_endpoints_to_locations",
+            level="ERROR",
+        ):
+            call_command(
+                "migrate_endpoints_to_locations",
+                batch_size=10,
+                progress_every=100,
+                summary_callback=summaries.append,
+                stdout=StringIO(),
+            )
+
+        self.assertEqual(len(summaries), 1, msg=f"summary_callback fired {len(summaries)} times")
+        summary = summaries[0]
+        self.assertEqual(summary["processed"], 4, msg=summary)
+        self.assertEqual(summary["total"], 4, msg=summary)
+        self.assertEqual(summary["locations"], 2, msg=f"expected 2 distinct locations: {summary}")
+        self.assertEqual([f["id"] for f in summary["failures"]], [broken.id], msg=summary)
+
     def test_failed_bulk_location_write_falls_back_per_endpoint(self):
         self._make_endpoint("first-bulk.example.com", [])
         self._make_endpoint("second-bulk.example.com", [])


### PR DESCRIPTION
### Description

`migrate_endpoints_to_locations` already isolated per-endpoint failures (so one bad endpoint can't abort a long run) and resolved many endpoints onto shared URL Locations via `identity_hash`. Neither fact was reported to programmatic callers, so an in-process driver could only see the raw count of endpoints processed — it could not tell how many distinct Locations resulted, nor which endpoints were skipped.

This adds a `summary_callback` stealth option, symmetric with the existing `progress_callback`. When the command finishes it reports:

```
{"processed": <endpoints iterated>,
 "total": <endpoint count>,
 "locations": <distinct Locations resolved>,
 "failures": [{"id": <endpoint id>, "error": <message>}, ...]}
```

`progress_callback(processed, total)` still drives a live progress bar; the summary carries the two things a per-chunk tick cannot.

The summary is delivered via a callback rather than a `handle()` return value on purpose: `BaseCommand.execute()` writes any truthy `handle()` return to stdout, and `OutputWrapper.write` calls `msg.endswith(...)`, which raises on a dict. A callback sidesteps that entirely.

CLI runs pass no `summary_callback` and are unaffected. The command's counts and behavior are otherwise unchanged.

### Test results

`unittests/test_migrate_endpoints_to_locations.py` gains a test asserting the summary reports the deduped Location count and the per-endpoint failure (two endpoints share a host → one Location; one invalid endpoint is skipped). Full file: 11 tests pass.

### Documentation

`docs/content/asset_modelling/locations/PRO__migrating_from_endpoints.md` now describes the completed-run summary: source objects processed vs. distinct Locations they resolved to, and the skipped count.
