### PR TITLE
update regulations form

### DIFF
--- a/dojo/templates/dojo/edit_product.html
+++ b/dojo/templates/dojo/edit_product.html
@@ -32,6 +32,10 @@
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
+          $('#id_regulations').select2({
+              placeholder: 'Select applicable regulations',
+              width: '100%'
+          });
           $("textarea").each(function (index, elem) {
               if (elem.hasAttribute("required")) {
                   elem.removeAttribute("required");

--- a/dojo/templates/dojo/new_product.html
+++ b/dojo/templates/dojo/new_product.html
@@ -32,6 +32,10 @@
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
+            $('#id_regulations').select2({
+                placeholder: 'Select applicable regulations',
+                width: '100%'
+            });
             $("textarea").each(function (index, elem) {
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");

--- a/dojo/templates_classic/dojo/edit_product.html
+++ b/dojo/templates_classic/dojo/edit_product.html
@@ -44,6 +44,12 @@
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
+          // base.html turns every <select> into a bootstrap-select; swap this
+          // one for select2 so multi-selection shows as removable pills
+          $('#id_regulations').selectpicker('destroy').select2({
+              placeholder: 'Select applicable regulations',
+              width: '70%'
+          });
           $("textarea").each(function (index, elem) {
               if (elem.hasAttribute("required")) {
                   elem.removeAttribute("required");

--- a/dojo/templates_classic/dojo/new_product.html
+++ b/dojo/templates_classic/dojo/new_product.html
@@ -41,6 +41,12 @@
     <script type="application/javascript" src="{% static "easymde/dist/easymde.min.js" %}"></script>
     <script type="application/javascript">
         $(function () {
+            // base.html turns every <select> into a bootstrap-select; swap this
+            // one for select2 so multi-selection shows as removable pills
+            $('#id_regulations').selectpicker('destroy').select2({
+                placeholder: 'Select applicable regulations',
+                width: '70%'
+            });
             $("textarea").each(function (index, elem) {
                 if (elem.hasAttribute("required")) {
                     elem.removeAttribute("required");


### PR DESCRIPTION
<img width="833" height="78" alt="Screenshot 2026-08-17 at 4 02 37 PM" src="https://github.com/user-attachments/assets/2fc4124b-db08-4682-a18e-8d890d05e180" />

On the Add/Edit Asset form, the Regulations field is now a searchable multi-select: type to filter (e.g. "pci") and each chosen regulation appears as a removable tag with an ×, making it obvious you can pick several. 

Previously it was an unclear widget — a plain listbox or a "Nothing selected" dropdown depending on the UI, which gave no hint multiple selections were possible.