### PR TITLE
docs(changelog): add Pro changelog entry for 3.2.200

### DIFF
--- a/docs/content/releases/pro/changelog.md
+++ b/docs/content/releases/pro/changelog.md
@@ -14,8 +14,42 @@ For Open Source release notes, please see the [Releases page on GitHub](https://
 
 ### August 17, 2026: v3.2.200
 
+New features:
+* **(CSPM)** Added Cloud Security Posture Management: connect AWS, Azure, and GCP cloud accounts, run posture scans against them, and apply reversible direct remediation to the misconfigurations that are found.
+* **(Asset Exposure)** Added asset exposure reporting from Wiz, Shodan, and Censys, and from CrowdStrike Spotlight (which reports only the exposure it can prove).
+* **(Connectors)** Registered the Aikido Security, Jit, and Cycode connectors.
+* **(Finding Templates)** You can now apply a finding template to a Finding, and turn a Finding into a template, directly from the Vue UI.
+* **(Form Configuration)** Added admin-controlled Form Configuration for the Vue create and edit forms, so an administrator can decide which fields appear.
+* **(Locations)** Added a DB-backed Locations toggle, with a data-migration suite to move existing data over.
+* **(Assets)** You can now export the asset and organization inventory as CSV.
+* **(Reporting)** Quick Export now names its output from the current context, and you can apply a report template to an export.
+* **(Findings)** Added a filterable Review Claimant column to the findings list.
+* **(Rules Engine)** Rules Engine permissions now split into View / Add / Edit / Delete for finer RBAC.
+* **(Feature Flags)** Promoted nine feature flags off the menu, turned five more on by default, and moved Feature Flags out of System into its own settings location.
+* **(Layouts)** Layout customization can now be restricted to admin-designated defaults.
+
 Enhancements:
 * **(Qualys)** The Qualys connector now accepts a **Host Tags** filter that scopes discovery to hosts carrying the Qualys asset tags you name. The filter is sent to Qualys, so out-of-scope hosts are never downloaded. It applies to the detection download as well as the host listing, so a narrowed scope also shortens each Sync. Tag names are matched exactly, because Qualys supports no wildcards on tag names. Leave the field blank to keep discovering every host.
+* **(JFrog)** The JFrog connector now surfaces a pending status.
+* **(Jira)** The Jira connector now accepts service accounts.
+* **(Findings)** The count of Findings a tool submitted is now recorded before deduplication runs.
+* **(API)** The finding serializer now exposes a flat `test_type_name` field.
+* **(MCP)** Finding and asset Location retrieval is now consolidated into single REST calls.
+
+Bug fixes:
+* **(Authorization)** Location data, DojoMeta visibility, and the `/api/v2/location/` endpoint are now scoped to the requesting user's products and RBAC rather than superusers only; every routed connector endpoint is named in the permission allow-list; the user edit form authorization was hardened; Tool Configuration credentials are kept out of the edit form; and the private-note visibility rule is now applied in the note UI views.
+* **(Export)** Spreadsheet formulas can no longer execute out of an exported file (CSV/formula injection).
+* **(SSO)** SAML2 routes now answer 404 when SAML is disabled.
+* **(Findings)** The Priority filter and override inputs now accept decimal values.
+* **(Assets)** A PATCH without a `parent` field no longer orphans the asset, and auto-creating the same asset name concurrently no longer returns a 500.
+* **(Importers)** Bulk finding deletes, tag-count updates, and async cascade deletes now retry on transient DB conflicts and are ordered so concurrent imports and deletes cannot deadlock.
+* **(Connectors)** The Action1 connector tolerates non-numeric sentinels in quoted numeric fields, and the Microsoft Defender connector retries a transient 5xx/429 on a single export page instead of failing the whole export.
+* **(Parsers)** Fixed a Trivy Scan crash from an uninitialized `resource_name`, and reset Scout Suite parser state so a report parses to the same findings twice.
+* **(Notes)** A partial note PATCH now keeps the note body and no longer writes a null NoteHistory entry.
+* **(Reporting)** Reports no longer fetch unrenderable columns, report cells are now bounded, and a block's Order By is applied through the filterset.
+* **(Tables & UI)** Clipped table cell text now wraps, the empty band below short pages is gone, the viewport row cap no longer oscillates and stalls a table, and the severity bar chart is positioned correctly in the open findings chart.
+* **(Page Grid)** A widget's Title and Icon now follow its Records choice.
+* **(Jira)** Fixed the Jira migration.
 
 ### August 10, 2026: v3.2.100
 


### PR DESCRIPTION
[sc-14586]

Adds a DefectDojo Pro changelog entry for release **3.2.200**, summarizing the user-facing features, enhancements, and bug fixes drawn from the release PR list. Grouped into New features / Enhancements / Bug fixes; dependency bumps, CI, tests, and internal chores are omitted.

Highlights:
- **CSPM** — Cloud Security Posture Management (AWS/Azure/GCP posture scanning + reversible direct remediation)
- Asset exposure reporting (Wiz, Shodan, Censys, CrowdStrike Spotlight)
- New connectors (Aikido Security, Jit, Cycode) and Qualys Host Tags scoping
- Finding Templates in the Vue UI, admin Form Configuration, DB-backed Locations, CSV asset export
- A batch of authorization-scoping and concurrency/deadlock bug fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)