### PR TITLE
docs(sensei): CSPM is gated on the Sensei license, not a feature flag

### DIFF
--- a/docs/content/sensei/cloud_posture.md
+++ b/docs/content/sensei/cloud_posture.md
@@ -23,7 +23,7 @@ Sensei has two capabilities that share one hub. **AppSec** scans and fixes sourc
 ## Requirements
 
 - A **DefectDojo Pro** license that includes the **Sensei** feature, with a **cloud-account quota** (`sensei_cloud_account_limit`).
-- The **Cloud Posture** feature flag enabled, and the **Locations** feature enabled — a cloud finding is identified by the cloud *resource* it concerns rather than a file and line, and Locations is what records that. Without Locations, cloud onboarding is not offered (see [Troubleshooting](#troubleshooting)).
+- The **Locations** feature enabled — a cloud finding is identified by the cloud *resource* it concerns rather than a file and line, and Locations is what records that. Without Locations, cloud onboarding is not offered (see [Troubleshooting](#troubleshooting)). CSPM itself needs no feature flag: it is part of Sensei, so the Sensei license unlocks it.
 - A **read-only scan credential** for each provider (details below).
 - To **onboard** accounts and **manage connections**: a global **Maintainer** or **Owner** role. To **run a direct fix or revert one**: at least **Writer** access to the finding's Asset — a direct fix mutates live cloud state, so it is an edit of the finding.
 
@@ -128,7 +128,7 @@ CSPM meters against two quotas, both shown as cards at the top of the hub:
 
 ## Troubleshooting
 
-- **Cloud onboarding is not offered / the CSPM capability is missing.** CSPM requires both the **Cloud Posture** feature flag and the **Locations** feature. A cloud finding has no identity without a resource location, so with Locations off, onboarding is refused. Ask a DefectDojo administrator to enable them.
+- **Cloud onboarding is not offered.** CSPM requires the **Locations** feature. A cloud finding has no identity without a resource location, so with Locations off, onboarding is refused (the CSPM capability itself still appears). Enable Locations on the **Settings > Feature Flags** page — the Sensei hub links there from the prompt — then onboard a cloud account.
 - **"No cloud-account quota is available."** Your license carries no `sensei_cloud_account_limit`, or it is used up. Contact your DefectDojo administrator to raise it.
 - **The fix button shows "Fix" or "Configure Asset" on a cloud finding, not "Fix in Cloud."** The finding is not directly remediable — either the account has no write credential / remediation is not enabled, or the finding's check has no v1 direct action. It can still be fixed by an IaC pull request.
 - **A revert failed with a drift error.** The live resource changed out-of-band since the fix was applied, so the recorded prior state no longer matches. Reconcile the resource manually; Sensei refuses to overwrite an unexpected state.

--- a/docs/content/sensei/sensei_reference.md
+++ b/docs/content/sensei/sensei_reference.md
@@ -52,7 +52,7 @@ Sensei is metered against your DefectDojo Pro license, shown as meters at the to
 
 - **Fixes:** remediations applied against your prepaid limit. Approving a candidate or triggering a fix consumes from this quota; when it is exhausted, further fixes are blocked (a warning banner appears) until the limit is raised.
 - **Onboarded Repositories:** repositories onboarded against your repository limit. When it is reached, onboarding new repositories is blocked.
-- **Onboarded Cloud Accounts:** cloud accounts onboarded against your cloud-account limit (`sensei_cloud_account_limit`), shown when CSPM is enabled. When it is reached, onboarding new accounts is blocked. The Fixes quota is **shared** — an AppSec fix and a cloud remediation both spend `sensei_fix_limit` — and the Fixes card breaks its total down by capability. See [CSPM → Quotas](/sensei/cloud_posture/#quotas).
+- **Onboarded Cloud Accounts:** cloud accounts onboarded against your cloud-account limit (`sensei_cloud_account_limit`), shown when Sensei is licensed (CSPM has no feature flag of its own). When it is reached, onboarding new accounts is blocked. The Fixes quota is **shared** — an AppSec fix and a cloud remediation both spend `sensei_fix_limit` — and the Fixes card breaks its total down by capability. See [CSPM → Quotas](/sensei/cloud_posture/#quotas).
 
 To raise a limit, contact your DefectDojo account team.
 


### PR DESCRIPTION
## Description

Documentation update for the Pro-side change that removes the `cloud_posture` feature flag: Cloud Security Posture (CSPM) is part of Sensei and is now gated on the **Sensei license** alone, like AppSec. There is no longer a "Cloud Posture" feature flag to enable.

Changes:
- **`docs/content/sensei/cloud_posture.md`** — Requirements no longer lists the Cloud Posture feature flag; CSPM needs the Sensei license (+ cloud-account quota) plus the **Locations** feature. Troubleshooting reframed so the only onboarding prerequisite is Locations, with a pointer to enabling it on **Settings > Feature Flags** (the Sensei hub links there from the prompt).
- **`docs/content/sensei/sensei_reference.md`** — the Onboarded Cloud Accounts note now reads "shown when Sensei is licensed" instead of "shown when CSPM is enabled".

Pairs with the Pro PR on the same release line (`bugfix`).

Note: `cloud_posture.md` remains English-only; the de/es/fr/ja translations are a pre-existing gap, not introduced here.
