### PR TITLE
ci(k8s): cap k8s deployment job runtime to stop multi-hour hangs

### DIFF
--- a/.github/workflows/k8s-tests.yml
+++ b/.github/workflows/k8s-tests.yml
@@ -9,6 +9,13 @@ jobs:
   setting_minikube_cluster:
     name: Kubernetes Deployment
     runs-on: ubuntu-latest
+    # Hard ceiling for the whole job. Without it a hang in any step falls through
+    # to GitHub's 360-minute (6-hour) default, which is how this job has run for
+    # hours. The individual steps below are timed, but the two slowest-to-stall
+    # ones -- minikube bring-up and the download-artifact/helm-dependency steps --
+    # were not, so this cap is the backstop that covers every step regardless.
+    # A healthy run finishes in well under 20 minutes; 30 leaves headroom.
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -25,6 +32,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Minikube
+        timeout-minutes: 10
         uses: manusa/actions-setup-minikube@b65276017fdec6f1e6498129fb740e34e260dc55 # v2.18.0
         with:
           minikube version: 'v1.38.1' # renovate: datasource=github-releases depName=kubernetes/minikube
@@ -55,6 +63,7 @@ jobs:
              docker images
 
       - name: Configure HELM repos
+        timeout-minutes: 5
         run: |-
              helm dependency list ./helm/defectdojo
              helm dependency update ./helm/defectdojo


### PR DESCRIPTION
[sc-14593]

## Problem

The `test-k8s` job (`k8s-tests.yml`) can run for hours. It had **no job-level `timeout-minutes`**, and several hang-prone steps were left untimed: `Setup Minikube` (cluster bring-up), the `download-artifact` step, and `Configure HELM repos` (`helm dependency update`). When any of those stalls, there is nothing to stop it, so the job falls through to GitHub's **360-minute (6-hour) default** job timeout and burns runner time.

## Fix

- **Job-level `timeout-minutes: 30`** as a hard backstop that catches a hang in *any* step, including the `uses:` steps that can't be caught by the existing per-step timeouts. A healthy run finishes well under 20 minutes, so 30 leaves comfortable headroom.
- **Per-step timeouts** on the two untimed shell steps most likely to stall: `Setup Minikube` (10 min) and `Configure HELM repos` (5 min), so a failure attributes to the right step rather than only tripping the job cap.

Both k8s-version matrix cells are capped independently.

No behavior change for a healthy run; this only bounds the failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
