### PR TITLE
ci: skip the heavy unit-tests suite for docs-only pull requests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,6 +9,18 @@ on:
       - bugfix
       - release/**
       - hotfix/**
+    # Skip the heavy suite for docs-only pull requests. paths-ignore only skips a
+    # PR whose changes are ENTIRELY under docs/ -- touch any code alongside the
+    # docs and the full matrix runs, so this never under-tests real changes.
+    #
+    # This filter deliberately lives on pull_request only. The merge_group trigger
+    # below stays unfiltered because GitHub ignores paths/paths-ignore for
+    # merge_group events: a docs-only PR is still built and tested in full when it
+    # reaches the queue, and `Unit Tests Complete` is still produced there -- so
+    # the required check never hangs pending. (Same merge_group + required-check
+    # reasoning is documented in ruff.yml.)
+    paths-ignore:
+      - 'docs/**'
   # Run the suite against the speculative merge commit a merge queue builds, which
   # is the only thing that tests what will actually land: two pull requests can
   # each be green on their own and broken in combination, and nothing before this


### PR DESCRIPTION
[sc-14594]

## Problem

A pull request that changes only `docs/` still triggers the entire `unit-tests` matrix — docker image builds, REST framework tests, the full UI/integration suite, k8s deployment, and performance tests — and re-runs it on every push. That is a large amount of runner time spent on changes that cannot affect any of those tests.

## Fix

Add `paths-ignore: ['docs/**']` to the `pull_request` trigger of `unit-tests.yml`. Because `paths-ignore` only skips a PR whose changes are *entirely* under `docs/`, a PR that touches any code alongside docs still runs the full suite — this never under-tests real changes.

## Why this is safe (required checks)

- The filter is on the `pull_request` trigger only. The `merge_group` trigger is left unfiltered, and GitHub **ignores `paths`/`paths-ignore` for `merge_group` events**, so a docs-only PR is still built and tested in full when it enters the merge queue, and the required **`Unit Tests Complete`** check is still produced there. No "skipped but required" check hangs the PR.
- The PR-level required check **`ruff-linting`** runs from its own workflow (`ruff.yml`), unaffected by this change.

Net effect: docs-only PRs skip redundant per-push runs during review, and are still fully tested at merge time via the queue. No test coverage is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
