### PR TITLE
fix(docs): handle failed release-notes fetch in home.html Hugo build

### DIFF
--- a/docs/layouts/home.html
+++ b/docs/layouts/home.html
@@ -1,19 +1,24 @@
 {{ define "main" }}
 {{ $url := "https://api.github.com/repos/DefectDojo/django-DefectDojo/releases/latest" }}
-{{ $resource := resources.GetRemote $url }}
 {{ $releaseName := "" }}
-{{ if $resource }}
-  {{ $release := $resource | transform.Unmarshal | default dict }}
-  {{ if $release.name }}
-    {{ $releaseName = $release.name }}
+{{/* Best-effort: the release chip depends on an unauthenticated GitHub API
+     call, which is rate-limited (403 Forbidden) on shared CI runners.
+     Wrap the fetch in `try` so a failed request degrades to "no chip"
+     instead of failing the whole build (Resource.Err was removed in
+     Hugo v0.141.0 in favor of the `try` keyword). */}}
+{{ with try (resources.GetRemote $url) }}
+  {{ with .Err }}
+    {{ warnf "Release notes fetch failed from %s: %s" $url . }}
+  {{ else with .Value }}
+    {{ $release := . | transform.Unmarshal | default dict }}
+    {{ with $release.name }}
+      {{ $releaseName = . }}
+    {{ else }}
+      {{ warnf "Could not parse release name from %s (not valid JSON or missing field)" $url }}
+    {{ end }}
   {{ else }}
-    {{ printf "⚠️ Could not parse release name (not valid JSON or missing field)\n" | warnf }}
-    {{ printf "Media Type: %s\n" $resource.MediaType | warnf }}
-    {{ $contentPreview := substr $resource.Content 0 500 }}
-    {{ printf "Content Preview (first 500 chars):\n%s\n" $contentPreview | warnf }}
+    {{ warnf "Release notes fetch returned no resource from %s" $url }}
   {{ end }}
-{{ else }}
-  {{ printf "❌ Release Notes Fetch failed from: %s\n" $url | warnf }}
 {{ end }}
 <section class="hero-section">
   <div class="container">


### PR DESCRIPTION
[sc-14595]

## Problem

The `deploy` job in `.github/workflows/validate_docs_build.yml` (and the `github-pages` deploy) intermittently fails because Hugo's `resources.GetRemote` fetches the latest GitHub release at build time and gets a **403 Forbidden** (unauthenticated GitHub API rate limit on shared Actions runners).

`docs/layouts/home.html` called `resources.GetRemote` **without** wrapping it in `try`, so a non-200 response aborted the entire site build:

```
ERROR error building site: ... GetRemote: failed to fetch remote resource from
'https://api.github.com/.../releases/latest': Forbidden
```

## Fix

Wrap the fetch in `try` and fall back to an empty release name (the changelog chip is simply omitted) with a `warnf`, mirroring the resilient handling already in `docs/layouts/_partials/header/header.html`.

Grepped every `resources.GetRemote` caller under `docs/`:

- `layouts/home.html` — was unguarded → **fixed here**
- `layouts/_partials/header/header.html` — already wrapped in `try`, no change
- `layouts/_markup/render-image.html` — already wrapped in `try`, no change

`home.html` was the only caller that could fail the build.

## Verification

Local build with the production config (`hugo --minify --gc --config config/production/hugo.toml`):

- Normal fetch: builds clean, exit 0.
- Simulated failure (temporarily pointed the URL at a non-existent endpoint): build emits `WARN Release notes fetch returned no resource ...` and completes with **exit 0** instead of erroring. URL restored afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
