### PR TITLE
docs(locations): note the Endpoints deprecation timeline

### DIFF
--- a/docs/content/asset_modelling/locations/PRO__migrating_from_endpoints.md
+++ b/docs/content/asset_modelling/locations/PRO__migrating_from_endpoints.md
@@ -9,6 +9,8 @@ When you enable Locations on an existing DefectDojo Pro instance, the data alrea
 
 Note that migration is **one-way**. There is no automated rollback path that re-creates Endpoints from Locations.
 
+> **Endpoints are deprecated.** As of **3.2.201**, Endpoints are deprecated in favour of Locations and are scheduled for **removal in 3.4.0**. Until then the Endpoints UI and the read-only Endpoint API stay available, and the **DEPRECATED** badges shown on the Endpoints menu, the Endpoint list pages, and a Finding's endpoint tables link here. Enable Locations and run the migration below before 3.4.0.
+
 ## Running the migration from the Feature Flags page
 
 Enabling Locations only changes behaviour for *new* imports; your existing history is carried forward by a **data-migration suite** that appears under the Locations row on the **Settings > Feature Flags** page once the feature is on. Each item is run on demand by a superuser, shows live progress and an ETA, and is safe to re-run (every step is idempotent).


### PR DESCRIPTION
[sc-14599]

## Description

Records the Endpoints deprecation timeline at the top of the "Migrating from Endpoints" guide: Endpoints are deprecated in favour of Locations as of **3.2.201** and are scheduled for **removal in 3.4.0**. Until then the Endpoints UI and the read-only Endpoint API remain available.

This is the documentation companion to the Pro change that adds **DEPRECATED** badges to the Endpoint surfaces (the Endpoints menu, the Endpoint list pages, and a Finding's endpoint tables). Those badges link to the Feature Flags page where a user enables Locations and runs the migration this guide describes, so the guide is where the timeline belongs.

Docs-only change; no code or behavior is affected.
