### PR TITLE
fix(dedupe): retry post_process_findings_batch on transient DB deadlock

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -463,6 +463,17 @@ def post_process_finding_save_internal(finding, dedupe_option=True, rules_option
             jira_services.push(finding.finding_group)
 
 
+# post_process_findings_batch runs the status-changing dedup / false-positive-history
+# writes for a batch of findings. Two of these tasks racing on overlapping dojo_finding
+# rows -- concurrent imports or connector syncs into the same product -- can deadlock
+# (Postgres SQLSTATE 40P01 deadlock_detected): each holds a row the other needs and
+# Postgres aborts one participant. The aborted batch is not wrong, only rolled back, so
+# re-running it is safe. This mirrors bulk_delete_findings' backstop for the same class
+# of transient conflict on the same table.
+POST_PROCESS_BATCH_RETRY_DELAY = 0.5  # seconds before the first retry; doubled each attempt
+POST_PROCESS_BATCH_MAX_CONFLICT_RETRIES = 3
+
+
 @app.task
 def post_process_findings_batch(
     finding_ids,
@@ -503,25 +514,48 @@ def post_process_findings_batch(
 
     system_settings = System_Settings.objects.get()
 
-    # use list() to force a complete query execution and related objects to be loaded once
-    logger.debug(f"getting finding models for batch deduplication with: {len(finding_ids)} findings")
-    findings = get_finding_models_for_deduplication(finding_ids)
-    logger.debug(f"found {len(findings)} findings for batch deduplication")
+    # The status-changing dedup / false-positive-history writes below update dojo_finding
+    # rows and can deadlock against a concurrent batch touching the same rows (see the
+    # POST_PROCESS_BATCH_* notes above). Retry the whole write unit on a transient DB
+    # conflict; the findings are reloaded on each attempt so a retry acts on the state the
+    # winning transaction just committed. Only transient conflicts (deadlock /
+    # serialization failure) are retried -- anything else re-raises at once, as does a
+    # conflict that survives every attempt. The non-status-changing follow-ups (issue
+    # updater, product grading, JIRA push) run once, after this loop succeeds, so a retry
+    # never re-fires them.
+    findings = []
+    for attempt in range(POST_PROCESS_BATCH_MAX_CONFLICT_RETRIES + 1):
+        try:
+            # use list() to force a complete query execution and related objects to be loaded once
+            logger.debug(f"getting finding models for batch deduplication with: {len(finding_ids)} findings")
+            findings = get_finding_models_for_deduplication(finding_ids)
+            logger.debug(f"found {len(findings)} findings for batch deduplication")
 
-    if not findings:
-        logger.debug(f"no findings found for batch deduplication with IDs: {finding_ids}")
-        return
+            if not findings:
+                logger.debug(f"no findings found for batch deduplication with IDs: {finding_ids}")
+                return
 
-    # Batch dedupe with single queries per algorithm; fallback to per-finding for anything else
-    if dedupe_option and system_settings.enable_deduplication:
-        dedupe_batch_of_findings(findings)
+            # Batch dedupe with single queries per algorithm; fallback to per-finding for anything else
+            if dedupe_option and system_settings.enable_deduplication:
+                dedupe_batch_of_findings(findings)
 
-    if system_settings.false_positive_history:
-        # Only perform false positive history if deduplication is disabled
-        if system_settings.enable_deduplication:
-            deduplicationLogger.warning("skipping false positive history because deduplication is also enabled")
+            if system_settings.false_positive_history:
+                # Only perform false positive history if deduplication is disabled
+                if system_settings.enable_deduplication:
+                    deduplicationLogger.warning("skipping false positive history because deduplication is also enabled")
+                else:
+                    do_false_positive_history_batch(findings)
+        except OperationalError as exc:
+            if not is_transient_db_conflict(exc) or attempt == POST_PROCESS_BATCH_MAX_CONFLICT_RETRIES:
+                raise
+            backoff = POST_PROCESS_BATCH_RETRY_DELAY * (2 ** attempt)
+            logger.warning(
+                "post_process_findings_batch: transient DB conflict on %d finding(s), retry %d/%d in %.1fs: %s",
+                len(finding_ids), attempt + 1, POST_PROCESS_BATCH_MAX_CONFLICT_RETRIES, backoff, exc,
+            )
+            sleep(backoff)
         else:
-            do_false_positive_history_batch(findings)
+            break
 
     # Non-status changing tasks
     if issue_updater_option:

--- a/unittests/test_finding_helper.py
+++ b/unittests/test_finding_helper.py
@@ -5,11 +5,17 @@ from unittest.mock import patch
 
 from crum import impersonate
 from django.contrib.auth.models import User
+from django.db import OperationalError
 from django.utils import timezone
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
-from dojo.finding.helper import save_vulnerability_ids, save_vulnerability_ids_template
+from dojo.finding.helper import (
+    POST_PROCESS_BATCH_MAX_CONFLICT_RETRIES,
+    post_process_findings_batch,
+    save_vulnerability_ids,
+    save_vulnerability_ids_template,
+)
 from dojo.models import Finding, Finding_Template, Test
 from unittests.dojo_test_case import DojoAPITestCase, DojoTestCase, versioned_fixtures
 
@@ -329,3 +335,99 @@ class TestFindingVulnerabilityIdsAPI(DojoAPITestCase):
         # CVE is not in the response, so get it fromt the database
         # current behaviour is that the cve is taken from the first vulnerability_id...
         self.assertEqual("RHSA-000000", Finding.objects.get(id=finding_id).cve)
+
+
+class TestPostProcessFindingsBatchDeadlockRetry(DojoTestCase):
+    """
+    post_process_findings_batch runs the batch dedup / false-positive-history writes that
+    update dojo_finding rows. Two of these tasks racing on overlapping rows (concurrent
+    imports or connector syncs into the same product) can deadlock -- Postgres aborts one
+    with SQLSTATE 40P01. The aborted batch is only rolled back, not wrong, so it must be
+    retried rather than surfaced as a failed task. These tests exercise that retry with a
+    simulated deadlock so they need no real concurrency.
+    """
+
+    def _transient_conflict(self):
+        # Mimic how psycopg surfaces a deadlock: Django re-raises the driver error as its
+        # own OperationalError and keeps the driver exception -- the one carrying the
+        # SQLSTATE -- as __cause__. is_transient_db_conflict inspects both.
+        cause = Exception("deadlock detected")
+        cause.sqlstate = "40P01"  # deadlock_detected
+        exc = OperationalError("deadlock detected")
+        exc.__cause__ = cause
+        return exc
+
+    def _dedup_enabled_settings(self):
+        return mock.Mock(
+            enable_deduplication=True,
+            false_positive_history=False,
+            enable_product_grade=False,
+        )
+
+    @patch("dojo.finding.helper.sleep", return_value=None)
+    @patch("dojo.finding.helper.dedupe_batch_of_findings")
+    @patch("dojo.finding.helper.get_finding_models_for_deduplication")
+    @patch("dojo.finding.helper.System_Settings")
+    def test_retries_batch_dedupe_on_transient_deadlock(self, mock_ss, mock_get, mock_dedupe, mock_sleep):
+        mock_ss.objects.get.return_value = self._dedup_enabled_settings()
+        mock_get.return_value = [mock.Mock(id=1)]
+        # First two attempts deadlock, the third succeeds.
+        mock_dedupe.side_effect = [self._transient_conflict(), self._transient_conflict(), None]
+
+        # Must NOT raise: the batch retries until dedupe succeeds.
+        post_process_findings_batch(
+            [1],
+            dedupe_option=True,
+            issue_updater_option=False,
+            product_grading_option=False,
+            push_to_jira=False,
+        )
+
+        self.assertEqual(mock_dedupe.call_count, 3)
+        # Findings are reloaded on each attempt so a retry acts on freshly committed state.
+        self.assertEqual(mock_get.call_count, 3)
+
+    @patch("dojo.finding.helper.sleep", return_value=None)
+    @patch("dojo.finding.helper.dedupe_batch_of_findings")
+    @patch("dojo.finding.helper.get_finding_models_for_deduplication")
+    @patch("dojo.finding.helper.System_Settings")
+    def test_reraises_after_exhausting_retries(self, mock_ss, mock_get, mock_dedupe, mock_sleep):
+        mock_ss.objects.get.return_value = self._dedup_enabled_settings()
+        mock_get.return_value = [mock.Mock(id=1)]
+        # Every attempt deadlocks -> the conflict must surface after retries are exhausted.
+        mock_dedupe.side_effect = self._transient_conflict()
+
+        with self.assertRaises(OperationalError):
+            post_process_findings_batch(
+                [1],
+                dedupe_option=True,
+                issue_updater_option=False,
+                product_grading_option=False,
+                push_to_jira=False,
+            )
+
+        # Initial try + POST_PROCESS_BATCH_MAX_CONFLICT_RETRIES retries.
+        self.assertEqual(mock_dedupe.call_count, POST_PROCESS_BATCH_MAX_CONFLICT_RETRIES + 1)
+
+    @patch("dojo.finding.helper.sleep", return_value=None)
+    @patch("dojo.finding.helper.dedupe_batch_of_findings")
+    @patch("dojo.finding.helper.get_finding_models_for_deduplication")
+    @patch("dojo.finding.helper.System_Settings")
+    def test_non_transient_operational_error_not_retried(self, mock_ss, mock_get, mock_dedupe, mock_sleep):
+        mock_ss.objects.get.return_value = self._dedup_enabled_settings()
+        mock_get.return_value = [mock.Mock(id=1)]
+        # A non-deadlock OperationalError (no transient SQLSTATE) is a genuine failure and
+        # must propagate immediately, without wasting retries.
+        mock_dedupe.side_effect = OperationalError("statement timeout")
+
+        with self.assertRaises(OperationalError):
+            post_process_findings_batch(
+                [1],
+                dedupe_option=True,
+                issue_updater_option=False,
+                product_grading_option=False,
+                push_to_jira=False,
+            )
+
+        self.assertEqual(mock_dedupe.call_count, 1)
+        mock_sleep.assert_not_called()

--- a/unittests/test_finding_helper.py
+++ b/unittests/test_finding_helper.py
@@ -338,6 +338,7 @@ class TestFindingVulnerabilityIdsAPI(DojoAPITestCase):
 
 
 class TestPostProcessFindingsBatchDeadlockRetry(DojoTestCase):
+
     """
     post_process_findings_batch runs the batch dedup / false-positive-history writes that
     update dojo_finding rows. Two of these tasks racing on overlapping rows (concurrent


### PR DESCRIPTION
**Description**

Fixes a `DeadlockDetected` (Postgres SQLSTATE `40P01`) failure of the
`dojo.finding.helper.post_process_findings_batch` Celery task, observed in production as
a background task crash:

```
psycopg.errors.DeadlockDetected: deadlock detected
DETAIL:  Process A waits for ShareLock on transaction ...; blocked by process B.
         Process B waits for ShareLock on transaction ...; blocked by process A.
CONTEXT:  while updating tuple (...) in relation "dojo_finding"
```

When two `post_process_findings_batch` tasks run concurrently — parallel imports or
connector syncs into the same product — their batch deduplication / false-positive-history
writes update overlapping `dojo_finding` rows. Postgres detects the lock cycle and aborts
one participant. The aborted batch was only rolled back, not computed incorrectly, so the
correct response is to re-run it; instead the task surfaced as a hard failure and the whole
batch lost its deduplication.

**The fix** (`dojo/finding/helper.py`)

The status-changing dedup / false-positive-history write unit is now wrapped in a
transient-conflict retry with exponential backoff, reusing the existing
`is_transient_db_conflict` predicate (SQLSTATE `40P01` deadlock / `40001` serialization
failure). This mirrors the backstop `bulk_delete_findings` already uses for the same class
of conflict on the same table.

- Findings are reloaded on each attempt, so a retry acts on the state the winning
  transaction just committed.
- The non-status-changing follow-ups (issue updater, product grading, JIRA push) run once,
  *after* the retry loop succeeds, so a retry never double-fires them (no duplicate JIRA
  pushes).
- Only transient conflicts are retried. Any other `OperationalError` (e.g. a statement
  timeout) re-raises immediately, as does a conflict that survives every attempt.

**Why retry rather than row locks**

Serializing the batch writes with `select_for_update` on the candidate rows would trade an
occasional aborted batch for routine deadlocks on this hot path (an import's dedup write
and the excess-duplicate delete task would form a lock-ordering cycle). Retry-on-conflict
is the pattern already established in this module for exactly this reason.

**No migration**

This is a pure control-flow change to a background task — no schema change, no data
migration. The only avenue considered and rejected was lock-based serialization, above.

**Pro impact**

Pro overrides deduplication via the `FINDING_DEDUPE_BATCH_METHOD` hook, which is invoked
*inside* `dedupe_batch_of_findings`, i.e. inside the retried block — so the Pro dedup path
is covered by this retry with no companion change. Pro does not override
`post_process_findings_batch` itself, and the JIRA/issue-updater follow-ups it relies on
remain outside the retry, so they still run exactly once.

**Test results**

Added `unittests/test_finding_helper.py::TestPostProcessFindingsBatchDeadlockRetry` with a
simulated deadlock (no real concurrency needed):

- retry-then-succeed: two simulated deadlocks then success completes without raising and
  reloads findings each attempt;
- re-raise after exhausting retries: a persistent deadlock surfaces after
  `initial + MAX_CONFLICT_RETRIES` attempts;
- a non-transient `OperationalError` propagates immediately with no retry/backoff.

The retry-then-succeed test fails on the unfixed code (the first deadlock propagates).

**Documentation**

No user-facing behavior change — this removes a failure mode from a background task. No
docs update needed.

**Checklist**

- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR.
- [x] Your code is Ruff compliant.
- [x] Your code is python 3.13 compliant.
- [x] Add applicable tests to the unit tests.
- [x] No model changes / migrations.
- [x] Add the proper label to categorize your PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159aVEfX5R8uJtkn6eTxsf7)_