### PR TITLE
docs(navigation): note the classic sidebar is retired in 3.3.0

### DIFF
--- a/docs/content/navigation/PRO__settings_menu.md
+++ b/docs/content/navigation/PRO__settings_menu.md
@@ -87,3 +87,5 @@ The group that was named after your license package — **Pro Settings** on a Pr
 New installations start with it on. Existing installations start with it off, so an upgrade never rearranges the menu under a team mid-flight — turn it on when your administrators are ready.
 
 While it is off, the **All Settings** page is unavailable and its URL returns Not Found.
+
+> **Menu 2.0 becomes the standard in the 3.3.0 release (September 8, 2026).** That release removes the classic sidebar and this toggle, so every instance moves to Menu 2.0. An instance still on the classic layout switches automatically on upgrade; turn Menu 2.0 on beforehand if you would rather move on your own schedule. In the patch releases leading up to 3.3.0, a banner in the app reminds anyone still on the classic layout.


### PR DESCRIPTION
[sc-14611]

## Description

The 3.3.0 release retires the classic sidebar and removes the Menu 2.0 toggle, so every instance moves to Menu 2.0. This adds a short note to the **Switching layouts** section of the Settings Menu page so anyone still on the classic layout knows the switch is coming and can turn Menu 2.0 on ahead of time if they prefer to move on their own schedule.

Documentation-only change (`docs/content/navigation/PRO__settings_menu.md`); no code or behavior changes.

## Test Commands
- None — docs-only.

