### PR TITLE
docs(connectors): note that Location is pre-filled for single-host tools

### DIFF
--- a/docs/content/connectors/upstream/toolreference.de.md
+++ b/docs/content/connectors/upstream/toolreference.de.md
@@ -14,6 +14,8 @@ Beim Einrichten eines Connectors für ein unterstütztes Tool müssen Sie Defect
 * **Location** \-ein Feld, das im Allgemeinen auf die URL Ihres Tools in Ihrem Netzwerk verweist,
 * **Secret** \- in der Regel ein API-Schlüssel.
 
+Viele Tools stellen genau einen festen API\-Host bereit. Für diese füllt DefectDojo das Feld **Location** beim Anlegen des Connectors automatisch aus. Sie müssen die URL also nicht von dieser Seite kopieren. Behalten Sie den vorgegebenen Wert. Ändern Sie ihn nur, wenn Ihre Instanz einen anderen Host verwendet, zum Beispiel eine selbst gehostete Installation oder eine andere Region.
+
 Manche Tools benötigen über **Location** und **Secret** hinaus weitere API-bezogene Felder. Möglicherweise müssen Sie auch auf der Seite des Tools Änderungen vornehmen, um einen eingehenden Connector von DefectDojo zu ermöglichen.
 
 ![image](images/connectors_tool_reference.png)
@@ -274,7 +276,7 @@ Sie benötigen einen Bright-**API-Schlüssel**, der in der Bright-App unter **Us
 
 #### Connector-Zuordnungen
 
-1. Lassen Sie das Feld **Location** leer, um `https://app.brightsec.com` zu verwenden, oder geben Sie Ihren Bright-Host explizit an.
+1. Behalten Sie den vorgegebenen Wert im Feld **Location**, `https://app.brightsec.com`, oder geben Sie Ihren Bright-Host explizit an.
 2. Geben Sie den Bright-API-Schlüssel in das Feld **Secret** ein.
 3. Legen Sie optional einen **Minimum Severity**-Wert fest, um einzuschränken, welche Befunde importiert werden.
 
@@ -551,7 +553,7 @@ Sie benötigen einen Escape-**API-Schlüssel**, der in der Escape-App unter **Se
 
 #### Connector-Zuordnungen
 
-1. Lassen Sie das Feld **Location** leer, um `https://public.escape.tech/v2` zu verwenden, oder geben Sie Ihren Escape-API-Host explizit an.
+1. Behalten Sie den vorgegebenen Wert im Feld **Location**, `https://public.escape.tech/v2`, oder geben Sie Ihren Escape-API-Host explizit an.
 2. Geben Sie den Escape-API-Schlüssel in das Feld **Secret** ein.
 3. Legen Sie optional einen **Minimum Severity**-Wert fest, um einzuschränken, welche Befunde importiert werden.
 
@@ -569,7 +571,7 @@ Sie benötigen einen Fairwinds-Insights-**Organisationsnamen** und ein **API-Tok
 
 #### Connector-Zuordnungen
 
-1. Lassen Sie das Feld **Location** leer, um `https://insights.fairwinds.com` zu verwenden, oder geben Sie Ihren Insights-Host explizit an.
+1. Behalten Sie den vorgegebenen Wert im Feld **Location**, `https://insights.fairwinds.com`, oder geben Sie Ihren Insights-Host explizit an.
 2. Geben Sie Ihren Insights-**Organization**-Namen ein (den Slug, der in Ihrer Dashboard-URL angezeigt wird).
 3. Geben Sie das Insights-API-Token in das Feld **Secret** ein.
 4. Legen Sie optional einen **Minimum Severity**-Wert fest, um einzuschränken, welche Befunde importiert werden.
@@ -1349,7 +1351,7 @@ Sie benötigen ein Socket-**API-Token** — ein Organisations-Token, das im Sock
 
 #### Connector-Zuordnungen
 
-1. Lassen Sie das Feld **Location** leer, um `https://api.socket.dev/v0` zu verwenden, oder geben Sie es explizit an.
+1. Behalten Sie den vorgegebenen Wert im Feld **Location**, `https://api.socket.dev/v0`, oder geben Sie es explizit an.
 2. Geben Sie das Socket-API-Token in das Feld **Secret** ein.
 3. Legen Sie optional einen **Minimum Severity**-Wert fest, um einzuschränken, welche Befunde importiert werden.
 

--- a/docs/content/connectors/upstream/toolreference.es.md
+++ b/docs/content/connectors/upstream/toolreference.es.md
@@ -14,6 +14,8 @@ Al configurar un Conector para una herramienta compatible, deberá proporcionar 
 * **Location** \-un campo que generalmente hace referencia a la URL de su herramienta dentro de su red,
 * **Secret** \- generalmente, una clave de API.
 
+Muchas herramientas usan un único host de API fijo. Para esas, DefectDojo completa el campo **Location** cuando agrega el Conector, así que no necesita copiar la URL de esta página. Conserve el valor que aparece. Cámbielo solo si su instancia usa otro host, por ejemplo una instalación autoalojada o una región distinta.
+
 Algunas herramientas requerirán campos adicionales relacionados con la API además de **Location** y **Secret**. También pueden requerir que realice cambios de su lado para admitir un Conector entrante desde DefectDojo.
 
 ![imagen](images/connectors_tool_reference.png)
@@ -274,7 +276,7 @@ Necesitará una **API key** de Bright, creada en la aplicación Bright en **User
 
 #### Asignaciones del conector
 
-1. Deje el campo **Location** en blanco para usar `https://app.brightsec.com`, o ingrese explícitamente su host de Bright.
+1. Conserve el valor ya rellenado en **Location**, `https://app.brightsec.com`, o ingrese explícitamente su host de Bright.
 2. Ingrese la API key de Bright en el campo **Secret**.
 3. Opcionalmente, configure una **Minimum Severity** para limitar qué hallazgos se importan.
 
@@ -551,7 +553,7 @@ Necesitará una **API key** de Escape, creada en la aplicación de Escape en **S
 
 #### Asignaciones del conector
 
-1. Deje el campo **Location** en blanco para usar `https://public.escape.tech/v2`, o introduzca explícitamente el host de la API de Escape.
+1. Conserve el valor ya rellenado en **Location**, `https://public.escape.tech/v2`, o introduzca explícitamente el host de la API de Escape.
 2. Introduzca la clave de API de Escape en el campo **Secret**.
 3. De forma opcional, defina una **Minimum Severity** para limitar qué hallazgos se importan.
 
@@ -569,7 +571,7 @@ Necesitará un nombre de **organización** de Fairwinds Insights y un **API toke
 
 #### Asignaciones del conector
 
-1. Deje el campo **Location** en blanco para usar `https://insights.fairwinds.com`, o introduzca explícitamente el host de Insights.
+1. Conserve el valor ya rellenado en **Location**, `https://insights.fairwinds.com`, o introduzca explícitamente el host de Insights.
 2. Introduzca el nombre de **Organization** de Insights (el slug que aparece en la URL de su panel).
 3. Introduzca el token de API de Insights en el campo **Secret**.
 4. De forma opcional, defina una **Minimum Severity** para limitar qué hallazgos se importan.
@@ -1349,7 +1351,7 @@ Necesitará un **token de API** de Socket — un token de organización creado e
 
 #### Asignaciones del conector
 
-1. Deje el campo **Location** en blanco para usar `https://api.socket.dev/v0`, o introdúzcalo explícitamente.
+1. Conserve el valor ya rellenado en **Location**, `https://api.socket.dev/v0`, o introdúzcalo explícitamente.
 2. Introduzca el token de API de Socket en el campo **Secret**.
 3. Opcionalmente, establezca una **Minimum Severity** para limitar qué hallazgos se importan.
 

--- a/docs/content/connectors/upstream/toolreference.fr.md
+++ b/docs/content/connectors/upstream/toolreference.fr.md
@@ -14,6 +14,8 @@ Lors de la configuration d'un Connecteur pour un outil pris en charge, vous deve
 * **Location** \- un champ qui fait généralement référence à l'URL de votre outil sur votre réseau,
 * **Secret** \- généralement une clé API.
 
+De nombreux outils exposent un seul hôte d'API fixe. Pour ceux\-là, DefectDojo remplit le champ **Location** lorsque vous ajoutez le connecteur, vous n'avez donc pas à copier l'URL depuis cette page. Conservez la valeur proposée. Ne la modifiez que si votre instance utilise un autre hôte, par exemple une installation auto\-hébergée ou une autre région.
+
 Certains outils nécessiteront des champs supplémentaires liés à l'API, en plus de **Location** et **Secret**. Ils peuvent également nécessiter que vous effectuiez des modifications de leur côté pour prendre en charge un Connecteur entrant depuis DefectDojo.
 
 ![image](images/connectors_tool_reference.png)
@@ -274,7 +276,7 @@ Vous aurez besoin d'une **clé API** Bright, créée dans l'application Bright s
 
 #### Mappages du Connecteur
 
-1. Laissez le champ **Location** vide pour utiliser `https://app.brightsec.com`, ou saisissez explicitement votre hôte Bright.
+1. Conservez la valeur pré\-remplie du champ **Location**, `https://app.brightsec.com`, ou saisissez explicitement votre hôte Bright.
 2. Saisissez la clé API Bright dans le champ **Secret**.
 3. Facultativement, définissez une **Minimum Severity** pour limiter les constatations importées.
 
@@ -551,7 +553,7 @@ Vous aurez besoin d'une **API key** Escape, créée dans l'application Escape so
 
 #### Mappages du connecteur
 
-1. Laissez le champ **Location** vide pour utiliser `https://public.escape.tech/v2`, ou saisissez explicitement l'hôte de votre API Escape.
+1. Conservez la valeur pré\-remplie du champ **Location**, `https://public.escape.tech/v2`, ou saisissez explicitement l'hôte de votre API Escape.
 2. Saisissez la clé d'API Escape dans le champ **Secret**.
 3. Facultativement, définissez une **Minimum Severity** pour limiter les constatations importées.
 
@@ -569,7 +571,7 @@ Vous aurez besoin d'un nom d'**organisation** Fairwinds Insights et d'un **jeton
 
 #### Mappages du connecteur
 
-1. Laissez le champ **Location** vide pour utiliser `https://insights.fairwinds.com`, ou saisissez explicitement l'hôte de votre instance Insights.
+1. Conservez la valeur pré\-remplie du champ **Location**, `https://insights.fairwinds.com`, ou saisissez explicitement l'hôte de votre instance Insights.
 2. Saisissez votre nom d'**Organization** Insights (le slug affiché dans l'URL de votre tableau de bord).
 3. Saisissez le jeton d'API Insights dans le champ **Secret**.
 4. Facultativement, définissez une **Minimum Severity** pour limiter les constatations importées.
@@ -1349,7 +1351,7 @@ Vous aurez besoin d'un **jeton API** Socket — un jeton d'organisation créé d
 
 #### Mappages du connecteur
 
-1. Laissez le champ **Location** vide pour utiliser `https://api.socket.dev/v0`, ou saisissez-le explicitement.
+1. Conservez la valeur pré\-remplie du champ **Location**, `https://api.socket.dev/v0`, ou saisissez-le explicitement.
 2. Saisissez le jeton API Socket dans le champ **Secret**.
 3. Optionnellement, définissez une **Minimum Severity** pour limiter les constatations importées.
 

--- a/docs/content/connectors/upstream/toolreference.ja.md
+++ b/docs/content/connectors/upstream/toolreference.ja.md
@@ -13,6 +13,8 @@ aliases:
 * **Location** \- 通常、ネットワーク内のツールの URL を指すフィールド
 * **Secret** \- 通常は API キー
 
+多くのツールは固定の API ホストを 1 つだけ公開します。その場合、コネクタを追加した時点で DefectDojo が **Location** を自動入力するため、このページから URL をコピーする必要はありません。入力済みの値はそのまま使用してください。セルフホスト環境や別リージョンなど、お使いのインスタンスが異なるホストを使う場合にのみ変更してください。
+
 ツールによっては、**Location** と **Secret** 以外にも追加の API 関連フィールドが必要になる場合があります。また、DefectDojo からの Connector 接続を受け入れるために、ツール側での設定変更が必要になることもあります。
 
 ![image](images/connectors_tool_reference.png)
@@ -273,7 +275,7 @@ Bright アプリの **User settings → API keys** で作成した Bright の**A
 
 #### Connector Mappings
 
-1. **Location** フィールドを空欄のままにすると `https://app.brightsec.com` が使用されます。または Bright のホストを明示的に入力してください。
+1. **Location** フィールドには `https://app.brightsec.com` が自動入力されます。この値をそのまま使用するか、Bright のホストを明示的に入力してください。
 2. **Secret** フィールドに Bright の API キーを入力します。
 3. 必要に応じて、インポートする検出事項を制限するために **Minimum Severity** を設定します。
 
@@ -550,7 +552,7 @@ Escapeの**APIキー**が必要です。これはEscapeアプリの**Settings �
 
 #### Connector Mappings
 
-1. **Location**フィールドを空欄のままにすると`https://public.escape.tech/v2`が使用されます。あるいは、EscapeのAPIホストを明示的に入力することもできます。
+1. **Location**フィールドには`https://public.escape.tech/v2`が自動入力されます。この値をそのまま使用するか、EscapeのAPIホストを明示的に入力してください。
 2. **Secret**フィールドにEscapeのAPIキーを入力します。
 3. 必要に応じて、インポートする検出事項を制限するために**Minimum Severity**を設定します。
 
@@ -568,7 +570,7 @@ Fairwinds Insightsの**organization**名と**APIトークン**が必要です。
 
 #### Connector Mappings
 
-1. **Location**フィールドを空欄のままにすると`https://insights.fairwinds.com`が使用されます。あるいは、Insightsのホストを明示的に入力することもできます。
+1. **Location**フィールドには`https://insights.fairwinds.com`が自動入力されます。この値をそのまま使用するか、Insightsのホストを明示的に入力してください。
 2. Insightsの**Organization**名（ダッシュボードのURLに表示されるスラッグ）を入力します。
 3. **Secret**フィールドにInsightsのAPIトークンを入力します。
 4. 必要に応じて、インポートする検出事項を制限するために**Minimum Severity**を設定します。
@@ -1348,7 +1350,7 @@ Socket の **API トークン**（Socket ダッシュボードの **Settings →
 
 #### Connector Mappings
 
-1. **Location** フィールドを空欄のままにすると `https://api.socket.dev/v0` が使用されます。明示的に入力することもできます。
+1. **Location** フィールドには `https://api.socket.dev/v0` が自動入力されます。この値をそのまま使用するか、明示的に入力してください。
 2. **Secret** フィールドに Socket API トークンを入力します。
 3. 必要に応じて、**Minimum Severity** を設定してインポートする検出事項を絞り込みます。
 

--- a/docs/content/connectors/upstream/toolreference.md
+++ b/docs/content/connectors/upstream/toolreference.md
@@ -14,6 +14,8 @@ When setting up a Connector for a supported tool, you'll need to give DefectDojo
 
 Some tools will require additional API\-related fields beyond **Location** and **Secret**. They may also require you to make changes on their side to accommodate an incoming Connector from DefectDojo.
 
+Many tools serve one fixed API host. For those, DefectDojo fills in **Location** for you when you add the Connector, so you do not have to copy the URL out of this page. Keep the value you are given. Change it only if your instance uses a different host, such as a self\-hosted deployment or a different region.
+
 ![image](images/connectors_tool_reference.png)
 
 Each tool has a different API configuration, and this guide is intended to help you set up the tool's API so that DefectDojo can connect.
@@ -399,7 +401,7 @@ You will need a Bright **API key**, created in the Bright app under **User setti
 
 #### Connector Mappings
 
-1. Leave the **Location** field blank to use `https://app.brightsec.com`, or enter your Bright host explicitly.
+1. Keep the pre-filled **Location**, `https://app.brightsec.com`, or enter your Bright host explicitly.
 2. Enter the Bright API key in the **Secret** field.
 3. Optionally, set a **Minimum Severity** to limit which findings are imported.
 
@@ -905,7 +907,7 @@ You will need an Escape **API key**, created in the Escape app under **Settings 
 
 #### Connector Mappings
 
-1. Leave the **Location** field blank to use `https://public.escape.tech/v2`, or enter your Escape API host explicitly.
+1. Keep the pre-filled **Location**, `https://public.escape.tech/v2`, or enter your Escape API host explicitly.
 2. Enter the Escape API key in the **Secret** field.
 3. Optionally, set a **Minimum Severity** to limit which findings are imported.
 
@@ -923,7 +925,7 @@ You will need a Fairwinds Insights **organization** name and an **API token**. C
 
 #### Connector Mappings
 
-1. Leave the **Location** field blank to use `https://insights.fairwinds.com`, or enter your Insights host explicitly.
+1. Keep the pre-filled **Location**, `https://insights.fairwinds.com`, or enter your Insights host explicitly.
 2. Enter your Insights **Organization** name (the slug shown in your dashboard URL).
 3. Enter the Insights API token in the **Secret** field.
 4. Optionally, set a **Minimum Severity** to limit which findings are imported.
@@ -2191,7 +2193,7 @@ You will need a Socket **API token** — an organization token created in the So
 
 #### Connector Mappings
 
-1. Leave the **Location** field blank to use `https://api.socket.dev/v0`, or enter it explicitly.
+1. Keep the pre-filled **Location**, `https://api.socket.dev/v0`, or enter it explicitly.
 2. Enter the Socket API token in the **Secret** field.
 3. Optionally, set a **Minimum Severity** to limit which findings are imported.
 


### PR DESCRIPTION
## Description

Documentation only.

DefectDojo now pre-fills the **Location** field when you add a Connector for a tool that serves one fixed API host, so you no longer have to copy the URL out of the tool reference. This adds a paragraph saying so, near the top of the Upstream Connectors tool reference, in all five languages.

It also fixes four connectors whose instructions were not possible to follow. Bright Security, Escape, Fairwinds Insights and Socket told you to leave **Location** blank, but the form has always required a value. Those steps now say to keep the pre-filled value.

No behavior described anywhere else in the page changes, and the per-connector URLs are unchanged.
