### PR TITLE
docs(changelog): add Pro changelog entry for 3.2.201

### DIFF
--- a/docs/content/releases/pro/changelog.md
+++ b/docs/content/releases/pro/changelog.md
@@ -13,10 +13,29 @@ For Open Source release notes, please see the [Releases page on GitHub](https://
 
 ## August 2026: v3.2
 
-### August 24, 2026: v3.2.300
+### August 18, 2026: v3.2.201
+
+New features:
+* **(Page Layouts)** The Risk Acceptance view page now uses a customizable widget grid, like the other View pages.
+* **(Sensei)** Added Amazon Bedrock as an on-prem LLM connection.
+* **(Locations)** The data-migration suite on the Feature Flags page can now be cancelled while a backfill is running. Cancelling stops the run at the next batch boundary and keeps everything migrated so far, so re-running the item resumes and converges on the same result. A run whose worker is lost is now detected and marked failed on its own, so a stuck suite becomes runnable again instead of blocking every item.
+* **(Endpoints)** Endpoints are now deprecated in favour of Locations.
+* **(Menu)** Classic-menu users are now warned that Menu 2.0 becomes the standard in 3.3.0.
 
 Enhancements:
-* **(Locations)** The data-migration suite on the Feature Flags page can now be cancelled while a backfill is running. Cancelling stops the run at the next batch boundary and keeps everything migrated so far, so re-running the item resumes and converges on the same result. A run whose worker is lost is now detected and marked failed on its own, so a stuck suite becomes runnable again instead of blocking every item.
+* **(CSPM)** Cloud Security Posture Management is now gated on the Sensei license rather than a separate feature flag.
+* **(Sensei)** Scan-and-fix scanner parallelism is now configurable, via `--max-parallel` / `MAX_PARALLEL` (and `sensei.maxParallel` in Helm).
+
+Bug fixes:
+* **(Authorization)** Import and reimport preview targets are now scoped to the caller's permissions, POA&M item findings are validated against the record's own product, and questionnaire expiration and question-set editing are checked against the response route and the questionnaire change permission.
+* **(Risk Acceptance)** A companion-less risk acceptance is now counted correctly, as active and as non-global, when filtering.
+* **(Reporting)** Report graph blocks that no browser captured are now drawn instead of failing silently, and the BETA badge that Menu 2.0 re-added after GA is gone.
+* **(Licensing)** License enforcement no longer blocks authentication.
+* **(Connectors)** The Action1 connector derives severity from the CVSS score when no severity bucket is usable, and a chunked sync now records one Import History row per sync.
+* **(Locations)** The endpoints-to-locations backfill now reports distinct locations and per-endpoint failures.
+* **(Dedupe)** Finding post-processing now retries on a transient DB deadlock.
+* **(UI)** The Advisor now renders with PrimeVue, and PSIRT and Field Mappings are nested correctly in the legacy sidebar.
+* **(Threat Model)** The schema-repair loop no longer deletes the prompt it is repairing.
 
 ### August 17, 2026: v3.2.200
 


### PR DESCRIPTION
[sc-14630]

Adds the DefectDojo Pro changelog entry for release 3.2.201, summarizing user-facing features, enhancements, and bug fixes from the release PR list (grouped by type). Dependency bumps, CI/test chores, docs-only PRs, and internal deployment plumbing are omitted.

Also folds the misfiled v3.2.300 (Aug 24) Locations entry into 3.2.201, where that change (#15701) actually ships, removing the duplicate/future-dated section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
