### PR TITLE
Add RFC 9116 security.txt to docs.defectdojo.com

### DIFF
--- a/docs/static/.well-known/security.txt
+++ b/docs/static/.well-known/security.txt
@@ -1,0 +1,21 @@
+# DefectDojo vulnerability disclosure information (RFC 9116)
+# https://www.rfc-editor.org/rfc/rfc9116
+
+# Report security issues through the DefectDojo HackerOne disclosure program
+Contact: https://hackerone.com/defectdojo/reports/new
+
+# Coordinated disclosure policy and process
+Policy: https://github.com/DefectDojo/django-DefectDojo/blob/master/readme-docs/SECURITY.md
+
+Preferred-Languages: en
+
+Canonical: https://defectdojo.com/.well-known/security.txt
+Canonical: https://www.defectdojo.com/.well-known/security.txt
+Canonical: https://docs.defectdojo.com/.well-known/security.txt
+
+# NOTE: RFC 9116 requires the Expires field; this file must be refreshed
+# annually. Before the date below passes, bump Expires ~1 year ahead in BOTH
+# copies of this file:
+#   - HubSpot File Manager copy served at defectdojo.com (theme repo: well-known/)
+#   - docs/static/.well-known/security.txt in django-DefectDojo (docs site)
+Expires: 2027-08-01T00:00:00Z


### PR DESCRIPTION
**Description**

Adds `/.well-known/security.txt` (RFC 9116) to docs.defectdojo.com so security researchers can discover our disclosure channel mechanically. The file points at the HackerOne disclosure program and the SECURITY.md policy, matching the documented process.

The file lives in `docs/static/.well-known/`, so Hugo copies it to the site root and GitHub Pages serves it at `https://docs.defectdojo.com/.well-known/security.txt` as `text/plain`. Note the docs deploy workflow (`gh-pages.yml`) triggers on pushes to `bugfix`/`master` that touch `docs/**`, so this goes live when the PR merges; no manual publish step.

Notes for review:

- `Expires` is mandatory per RFC 9116 and is set to `2027-08-01T00:00:00Z` (the RFC recommends keeping it under a year out). It needs an annual bump; a reminder comment is baked into the file itself.
- `Canonical` lists `defectdojo.com` first: the live marketing site 302s www to the apex, so the apex is the primary host. The www and docs URIs are also listed so retrieval from any of the three validates.
- `Contact` is HackerOne only. GitHub private vulnerability reporting is disabled on this repo (the `security/advisories/new` URL would dead-end researchers), and SECURITY.md documents advisories as something maintainers create after HackerOne triage.
- A byte-identical copy will be served on defectdojo.com (HubSpot File Manager upload plus a URL redirect, tracked in the marketing theme repo).

**Test results**

- Built the docs site locally with Hugo and confirmed `public/.well-known/security.txt` is emitted with the exact file content, i.e. the doks module mounts do copy the dot-directory from `static/`.
- The "Docs: Dry Run Production Deployment" check on this PR runs the exact production build (Hugo 0.153.4).
- The `gh-pages` branch already carries `.nojekyll` (added by peaceiris/actions-gh-pages), so GitHub Pages serves dot-directories as-is; `fonts/` and `svgs/` from the same `docs/static/` mount are already live on the deployed branch.

**Documentation**

The added file is the deliverable; no docs content pages changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
