### PR TITLE
docs(psirt): who can use PSIRT, and why the permission beats the role

### DIFF
--- a/docs/content/psirt/_index.md
+++ b/docs/content/psirt/_index.md
@@ -37,6 +37,36 @@ If the entries are visible but locked, that is the other gate: the licence.
 PSIRT needs the **PSIRT Advisory Engine** entitlement, and a locked entry
 explains what to ask for.
 
+## Who can use PSIRT
+
+Three things admit a user, and only one of them needs to be true:
+
+- the **PSIRT** configuration permission,
+- a global **Maintainer** or **Owner** role, or
+- superuser.
+
+**Prefer the configuration permission.** A global Maintainer role is write access
+to every asset in the instance, so granting it to give somebody PSIRT hands them
+the rest of the product as well. The PSIRT permission grants PSIRT and nothing
+else.
+
+It comes in two halves, assignable separately from **Settings → User Management**
+on a user or — more usefully — on a group:
+
+| Permission | Admits |
+|---|---|
+| **View PSIRT** | Reading every PSIRT surface: the advisory queue, exposure verdicts, cases, components, rules. |
+| **Change PSIRT** | Everything View admits, plus writing: suppressing advisories, authoring feed and matching rules, opening cases, publishing advisories. |
+
+View is genuinely read-only. An analyst who should see whether you are affected,
+without being able to suppress an advisory or publish one, gets View alone.
+
+The licence is checked *before* any of this and is not a permission: with no
+**PSIRT Advisory Engine** entitlement, PSIRT is closed to everyone including
+superusers.
+
+The permission appears in the picker only when the PSIRT feature flag is on.
+
 ## How it fits together
 
 1. **[Advisory Feeds](feeds/)** — choose which publishers to poll. Every source


### PR DESCRIPTION
## Description

Documents who can use PSIRT, alongside a Pro change that adds a PSIRT configuration
permission.

Until now the module admitted a superuser or a global Maintainer/Owner and nobody
else, so the page had nothing to say about access beyond the feature flag and the
licence. With a PSIRT-specific permission available, the docs can say the thing that
actually matters: prefer the permission, because a global Maintainer role is write
access to every asset in the instance — granting it so somebody can read advisories
hands them the rest of the product too.

Covers:

- the three routes in, and which one to prefer;
- the View / Change split, and that View is genuinely read-only;
- that the licence is checked before any of it and is not a permission — with no
  PSIRT Advisory Engine entitlement the module is closed to everyone, superusers
  included;
- that the permission only appears in the picker while the PSIRT feature flag is on.

Docs-only: no code changes.
