### PR TITLE
docs: drop hardcoded (Pro)/(Open Source) suffix from translated titles

### DIFF
--- a/docs/content/admin/user_management/OS__sso_user_local_login_fallback.it.md
+++ b/docs/content/admin/user_management/OS__sso_user_local_login_fallback.it.md
@@ -1,5 +1,5 @@
 ---
-title: Riattivare l'accesso per gli utenti SSO (Open Source)
+title: Riattivare l'accesso per gli utenti SSO
 description: Assegna una password locale agli utenti creati tramite SSO dopo il passaggio
   a Open Source, dove SSO è una funzionalità disponibile solo in Pro
 audience: opensource

--- a/docs/content/admin/user_management/OS__sso_user_local_login_fallback.pt-br.md
+++ b/docs/content/admin/user_management/OS__sso_user_local_login_fallback.pt-br.md
@@ -1,5 +1,5 @@
 ---
-title: Reativando o login para usuários de SSO (Open Source)
+title: Reativando o login para usuários de SSO
 description: Defina uma senha local para usuários provisionados via SSO após migrar
   para o Open Source, onde o SSO é um recurso exclusivo do Pro
 audience: opensource

--- a/docs/content/triage_findings/finding_correlation/PRO__root_cause_correlation.it.md
+++ b/docs/content/triage_findings/finding_correlation/PRO__root_cause_correlation.it.md
@@ -1,5 +1,5 @@
 ---
-title: Correlazione delle cause radice (Pro)
+title: Correlazione delle cause radice
 description: Raggruppa i Riscontri che condividono una causa radice — lo stesso componente
   vulnerabile, la stessa CVE, la stessa risorsa infrastrutturale o la stessa debolezza
   a un URL — in modo che una singola correzione possa essere ricondotta a ogni Riscontro

--- a/docs/content/triage_findings/finding_correlation/PRO__root_cause_correlation.pt-br.md
+++ b/docs/content/triage_findings/finding_correlation/PRO__root_cause_correlation.pt-br.md
@@ -1,5 +1,5 @@
 ---
-title: Correlação de Causa Raiz (Pro)
+title: Correlação de Causa Raiz
 description: Agrupe Achados que compartilham uma causa raiz -- o mesmo componente
   vulnerável, CVE, recurso de infraestrutura ou fraqueza em uma URL -- para que uma
   única correção possa ser rastreada até cada Achado que ela resolve

--- a/docs/content/triage_findings/finding_deduplication/OS__deduplication_tuning.it.md
+++ b/docs/content/triage_findings/finding_deduplication/OS__deduplication_tuning.it.md
@@ -1,5 +1,5 @@
 ---
-title: Ottimizzazione della Deduplicazione (Open Source)
+title: Ottimizzazione della Deduplicazione
 description: 'Configura la deduplicazione in DefectDojo Open Source: algoritmi, campi
   hash, endpoint e servizio'
 weight: 5

--- a/docs/content/triage_findings/finding_deduplication/OS__deduplication_tuning.pt-br.md
+++ b/docs/content/triage_findings/finding_deduplication/OS__deduplication_tuning.pt-br.md
@@ -1,5 +1,5 @@
 ---
-title: Ajuste de Deduplicação (Open Source)
+title: Ajuste de Deduplicação
 description: 'Configure a deduplicação no DefectDojo Open Source: algoritmos, campos
   de hash, endpoints e serviço'
 weight: 5

--- a/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.it.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.it.md
@@ -1,5 +1,5 @@
 ---
-title: Deduplication Tuning (Pro)
+title: Deduplication Tuning
 description: Configura il modo in cui DefectDojo identifica e gestisce i riscontri
   duplicati
 weight: 4

--- a/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.pt-br.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__deduplication_tuning.pt-br.md
@@ -1,5 +1,5 @@
 ---
-title: Ajuste de Deduplicação (Pro)
+title: Ajuste de Deduplicação
 description: Configure como o DefectDojo identifica e gerencia achados duplicados
 weight: 4
 audience: pro

--- a/docs/content/triage_findings/finding_deduplication/PRO__global_component_deduplication.it.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__global_component_deduplication.it.md
@@ -1,5 +1,5 @@
 ---
-title: Global Component Deduplication (Pro)
+title: Global Component Deduplication
 description: Deduplica i riscontri di Software Composition Analysis in base al nome
   e alla versione del componente in tutti i Prodotti
 weight: 5

--- a/docs/content/triage_findings/finding_deduplication/PRO__global_component_deduplication.pt-br.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__global_component_deduplication.pt-br.md
@@ -1,5 +1,5 @@
 ---
-title: Global Component Deduplication (Pro)
+title: Global Component Deduplication
 description: Deduplique achados de Software Composition Analysis (SCA) por nome e
   versão do componente em todos os Produtos
 weight: 5

--- a/docs/content/triage_findings/finding_deduplication/PRO__global_locations_deduplication.it.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__global_locations_deduplication.it.md
@@ -1,5 +1,5 @@
 ---
-title: Global Locations Deduplication (Pro)
+title: Global Locations Deduplication
 description: Deduplica i riscontri in base a una posizione condivisa (URL o dipendenza)
   in tutti i Prodotti
 weight: 6

--- a/docs/content/triage_findings/finding_deduplication/PRO__global_locations_deduplication.pt-br.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__global_locations_deduplication.pt-br.md
@@ -1,5 +1,5 @@
 ---
-title: Global Locations Deduplication (Pro)
+title: Global Locations Deduplication
 description: Deduplique achados por localização compartilhada (URL ou dependência)
   em todos os Produtos
 weight: 6

--- a/docs/content/triage_findings/finding_deduplication/PRO__location_drift_matching.it.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__location_drift_matching.it.md
@@ -1,5 +1,5 @@
 ---
-title: Location Drift Matching (Pro)
+title: Location Drift Matching
 description: 'Tieni traccia dei riscontri man mano che le loro posizioni cambiano
   tra un reimport e l''altro: spostamenti di riga, rinomine di file, spostamenti di
   URL e aggiornamenti di versione delle dipendenze non chiudono più i riscontri per

--- a/docs/content/triage_findings/finding_deduplication/PRO__location_drift_matching.pt-br.md
+++ b/docs/content/triage_findings/finding_deduplication/PRO__location_drift_matching.pt-br.md
@@ -1,5 +1,5 @@
 ---
-title: Correspondência por Deriva de Localização (Pro)
+title: Correspondência por Deriva de Localização
 description: Acompanhe achados enquanto suas localizações mudam entre reimportações
   — mudanças de linha, renomeações de arquivo, movimentações de URL e atualizações
   de versão de dependência não fecham mais e recriam achados


### PR DESCRIPTION
## Description

The docs dry-run deploy check (`validate_docs_build.yml`) greps all of `docs/content/` for front-matter titles that hardcode the edition suffix `(Pro)` / `(Open Source)`. The English pages already moved this signal into the `audience` front-matter field, but 14 translated pages (`.it.md` / `.pt-br.md`) still carried the suffix in `title:`. Because the check scans the whole tree, this left the `deploy` step red for every docs PR opened against `bugfix`.

This strips the suffix from the 14 translated titles. Each file already has the correct `audience:` field, so no edition information is lost.

## Files

14 translated pages under `docs/content/triage_findings/finding_deduplication/`, `docs/content/triage_findings/finding_correlation/`, and `docs/content/admin/user_management/`. Only the `title:` line changed in each.