### PR TITLE
docs(connectors): Wiz imports without Projects via a tenant-level Record

### DIFF
--- a/docs/content/connectors/upstream/toolreference.de.md
+++ b/docs/content/connectors/upstream/toolreference.de.md
@@ -1470,13 +1470,17 @@ Die Schwachstellenerkennung muss in Wazuh aktiviert sein, damit der Vulnerabilit
 
 ## Wiz
 
+Der Wiz-Connector importiert **Issues und Schwachstellen-Befunde**. DefectDojo erstellt einen Record für jedes **Wiz-Projekt** sowie einen Record auf Tenant-Ebene, der nach dem Tenant selbst benannt ist, zum Beispiel **Wiz Tenant abc12**. Dieser Record deckt den gesamten Wiz-Tenant ab.
+
+**Sie benötigen keine Wiz-Projekte, um diesen Connector zu verwenden.** Wenn Ihr Tenant keine Projekte hat, ordnen Sie den Record diesen Tenant-Record zu. DefectDojo importiert dann jedes Issue und jeden Schwachstellen-Befund, den Ihr Service-Konto sehen kann. Dieser Record erfasst auch Befunde zu Ressourcen, die kein Projekt abdeckt. Ordnen Sie ihn daher zusätzlich zu Ihren Projekt-Records zu, wenn Ihre Projekte nicht alles abdecken. Wenn Sie sowohl einen Projekt-Record als auch den Record diesen Tenant-Record zuordnen, werden die Befunde dieses Projekts in zwei Assets importiert. Tun Sie das nur, wenn Sie beide Ansichten wünschen.
+
 Um den Wiz-Connector zu verwenden, müssen Sie ein Service-Konto erstellen: siehe die [Wiz-Dokumentation](https://docs.wiz.io/wiz-docs/docs/service-accounts-settings#add-a-service-account) für weitere Informationen. Sie benötigen ein Wiz-Konto, um auf die Dokumentation zuzugreifen.
 
 Das Service-Konto muss alle folgenden Anforderungen erfüllen. Ein Service-Konto, dem eine davon fehlt, kann sich zwar erfolgreich authentifizieren, importiert aber nichts:
 
 * **Type**: Custom Integration (GraphQL API).
-* **API-Scopes**: mindestens `read:projects`, `read:issues` und `read:vulnerabilities`.
-* **Projekt-Sichtbarkeit**: Das Service-Konto muss auf jedes zu importierende Wiz-Projekt beschränkt sein (oder auf alle Projekte). Der Connector ermittelt zunächst Ihre Wiz-Projekte und ruft dann die Befunde jedes Projekts ab — ein Konto, das Issues lesen kann, aber keine Projekt-Sichtbarkeit hat, ermittelt null Projekte, sodass nichts zu importieren ist und von keiner Seite ein Fehler gemeldet wird.
+* **API-Scopes**: mindestens `read:projects`, `read:issues` und `read:vulnerabilities`. `read:projects` wird auch bei einem Tenant ohne Projekte benötigt, weil Discover weiterhin die Projektliste bei Wiz abfragt.
+* **Projekt-Sichtbarkeit**: Das Service-Konto muss auf jedes zu importierende Wiz-Projekt beschränkt sein (oder auf alle Projekte). Ein Konto, das Issues lesen kann, aber keine Projekt-Sichtbarkeit hat, ermittelt keine Projekt-Records. Es steht dann nur der Record diesen Tenant-Record zur Verfügung.
 
 #### **Connector-Zuordnungen**
 

--- a/docs/content/connectors/upstream/toolreference.es.md
+++ b/docs/content/connectors/upstream/toolreference.es.md
@@ -1470,13 +1470,17 @@ La detección de vulnerabilidades debe estar habilitada en Wazuh para que se rel
 
 ## Wiz
 
+El conector de Wiz importa **issues y hallazgos de vulnerabilidades**. DefectDojo crea un Record por cada **Wiz Project**, más un Record a nivel de tenant con el nombre del propio tenant, por ejemplo **Wiz Tenant abc12**, que cubre todo el tenant de Wiz.
+
+**No necesita Wiz Projects para usar este conector.** Si su tenant no tiene Projects, asigne el Record ese Record de tenant y DefectDojo importará todos los issues y hallazgos de vulnerabilidades que su cuenta de servicio pueda ver. Ese Record también recoge hallazgos de recursos que ningún Project cubre, así que asígnelo junto a sus Records de Project si sus Projects no lo cubren todo. Si asigna a la vez un Record de Project y el Record ese Record de tenant, los hallazgos de ese Project se importan en dos Assets. Hágalo solo si desea ambas vistas.
+
 Para usar el conector de Wiz es necesario crear una cuenta de servicio: consulte la [documentación de Wiz](https://docs.wiz.io/wiz-docs/docs/service-accounts-settings#add-a-service-account) para más información. Necesitará una cuenta de Wiz para acceder a la documentación.
 
 La cuenta de servicio debe cumplir todos los siguientes requisitos. Una cuenta de servicio a la que le falte alguno de ellos aún puede autenticarse correctamente, pero no importará nada:
 
 * **Type**: Custom Integration (GraphQL API).
-* **API scopes**: como mínimo `read:projects`, `read:issues`, y `read:vulnerabilities`.
-* **Project visibility**: la cuenta de servicio debe tener alcance sobre cada Wiz Project que desee importar (o sobre todos los Projects). El conector descubre primero sus Wiz Projects y luego obtiene los hallazgos de cada Project — una cuenta que puede leer issues pero no tiene visibilidad de Projects descubre cero Projects, por lo que no hay nada que importar y ninguno de los dos lados reporta un error.
+* **API scopes**: como mínimo `read:projects`, `read:issues`, y `read:vulnerabilities`. `read:projects` es necesario incluso en un tenant sin Projects, porque Discover sigue pidiendo la lista de Projects a Wiz.
+* **Project visibility**: la cuenta de servicio debe tener alcance sobre cada Wiz Project que desee importar (o sobre todos los Projects). Una cuenta que puede leer issues pero no tiene visibilidad de Projects no descubre ningún Record de Project, y solo queda disponible el Record ese Record de tenant.
 
 #### **Asignaciones del conector**
 

--- a/docs/content/connectors/upstream/toolreference.fr.md
+++ b/docs/content/connectors/upstream/toolreference.fr.md
@@ -1470,13 +1470,17 @@ La détection de vulnérabilités doit être activée dans Wazuh pour que l'inde
 
 ## Wiz
 
+Le connecteur Wiz importe les **issues et les constatations de vulnérabilités**. DefectDojo crée un Record pour chaque **Wiz Project**, ainsi qu'un Record au niveau du tenant nommé d'après le tenant lui-même, par exemple **Wiz Tenant abc12**, qui couvre l'ensemble du tenant Wiz.
+
+**Vous n'avez pas besoin de Wiz Projects pour utiliser ce connecteur.** Si votre tenant n'a aucun Project, mappez le Record ce Record de tenant et DefectDojo importe toutes les issues et constatations de vulnérabilités que votre compte de service peut voir. Ce Record récupère aussi les constatations sur des ressources qu'aucun Project ne couvre. Mappez-le donc en plus de vos Records de Project si vos Projects ne couvrent pas tout. Si vous mappez à la fois un Record de Project et le Record ce Record de tenant, les constatations de ce Project sont importées dans deux Assets. Ne le faites que si vous souhaitez les deux vues.
+
 L'utilisation du connecteur Wiz nécessite la création d'un compte de service : consultez la [documentation Wiz](https://docs.wiz.io/wiz-docs/docs/service-accounts-settings#add-a-service-account) pour plus d'informations.  Vous aurez besoin d'un compte Wiz pour accéder à la documentation.
 
 Le compte de service doit répondre à toutes les exigences suivantes. Un compte de service qui n'en respecte pas une peut tout de même s'authentifier avec succès mais n'importera rien :
 
 * **Type**: Custom Integration (GraphQL API).
-* **API scopes**: au minimum `read:projects`, `read:issues`, et `read:vulnerabilities`.
-* **Project visibility**: le compte de service doit être limité à chaque Wiz Project que vous souhaitez importer (ou à tous les Projects). Le connecteur découvre d'abord vos Wiz Projects, puis récupère les constatations de chaque Project — un compte qui peut lire les issues mais n'a de visibilité sur aucun Project ne découvre aucun Project, il n'y a donc rien à importer et aucune erreur n'est signalée par l'un ou l'autre des systèmes.
+* **API scopes**: au minimum `read:projects`, `read:issues`, et `read:vulnerabilities`. `read:projects` reste nécessaire même sur un tenant sans Project, car Discover demande toujours la liste des Projects à Wiz.
+* **Project visibility**: le compte de service doit être limité à chaque Wiz Project que vous souhaitez importer (ou à tous les Projects). Un compte qui peut lire les issues mais n'a de visibilité sur aucun Project ne découvre aucun Record de Project, et seul le Record ce Record de tenant reste disponible.
 
 #### **Mappages du connecteur**
 

--- a/docs/content/connectors/upstream/toolreference.ja.md
+++ b/docs/content/connectors/upstream/toolreference.ja.md
@@ -1469,13 +1469,17 @@ DefectDojo は Wazuh エージェント(エンドポイント)ごとに Record �
 
 ## Wiz
 
+Wiz コネクタは **issue と脆弱性の検出事項**をインポートします。DefectDojo は **Wiz Project** ごとに Record を作成し、さらに Wiz テナント全体を対象とするテナントレベルの Record を作成します。この Record にはテナント自身の名前が付きます。例: **Wiz Tenant abc12**。
+
+**このコネクタの利用に Wiz Project は必要ありません。** テナントに Project がない場合は、このテナントレベルの Record の Record をマッピングしてください。サービスアカウントが参照できるすべての issue と脆弱性の検出事項が DefectDojo にインポートされます。この Record は、どの Project にも含まれないリソースの検出事項も取得します。Project がすべてを網羅していない場合は、Project の Record と併せてマッピングしてください。Project の Record と このテナントレベルの Record の Record を両方マッピングすると、その Project の検出事項は 2 つの Asset にインポートされます。両方のビューが必要な場合にのみ行ってください。
+
 Wiz コネクタを使用するには、サービスアカウントを作成する必要があります。詳細については [Wiz のドキュメント](https://docs.wiz.io/wiz-docs/docs/service-accounts-settings#add-a-service-account)を参照してください。ドキュメントにアクセスするには Wiz アカウントが必要です。
 
 サービスアカウントは、以下の要件をすべて満たしている必要があります。いずれかを満たしていないサービスアカウントでも認証自体は成功しますが、何もインポートされません。
 
 * **Type**: Custom Integration(GraphQL API)。
-* **API scopes**: 最低限 `read:projects`、`read:issues`、`read:vulnerabilities` が必要です。
-* **Project visibility**: サービスアカウントは、インポートしたいすべての Wiz Project(またはすべての Project)に対してスコープが設定されている必要があります。コネクタはまず Wiz Project を検出し、その後各 Project の検出事項を取得します — issue を読み取れても Project の可視性がないアカウントは Project を 1 つも検出できないため、インポートするものがなく、双方からエラーも報告されません。
+* **API scopes**: 最低限 `read:projects`、`read:issues`、`read:vulnerabilities` が必要です。Discover は常に Wiz へ Project 一覧を問い合わせるため、Project がないテナントでも `read:projects` は必要です。
+* **Project visibility**: サービスアカウントは、インポートしたいすべての Wiz Project(またはすべての Project)に対してスコープが設定されている必要があります。issue を読み取れても Project の可視性がないアカウントは Project の Record を検出できず、このテナントレベルの Record の Record のみが利用可能になります。
 
 #### **Connector Mappings**
 

--- a/docs/content/connectors/upstream/toolreference.md
+++ b/docs/content/connectors/upstream/toolreference.md
@@ -2457,13 +2457,17 @@ Each application becomes a Record, and its findings come from that application's
 
 ## Wiz
 
+The Wiz connector imports **Issues and vulnerability findings**. DefectDojo creates a Record for each **Wiz Project**, plus a tenant\-level Record named after the tenant itself, for example **Wiz Tenant abc12**, that covers the entire Wiz tenant.
+
+**You do not need Wiz Projects to use this connector.** If your tenant has no Projects, map the that tenant\-level Record Record and DefectDojo imports every Issue and vulnerability finding your service account can see. That Record also picks up findings on resources that no Project covers, so map it alongside your Project Records if your Projects do not cover everything. Mapping both a Project Record and the that tenant\-level Record Record imports that Project's findings into two Assets, so only do that if you want both views.
+
 Using the Wiz connector requires you to create a service account: see the [Wiz documentation](https://docs.wiz.io/wiz-docs/docs/service-accounts-settings#add-a-service-account) for more info.  You will need a Wiz account to access the documentation.
 
 The service account must meet all of the following requirements. A service account that misses one of them can still authenticate successfully but will import nothing:
 
 * **Type**: Custom Integration (GraphQL API).
-* **API scopes**: at minimum `read:projects`, `read:issues`, and `read:vulnerabilities`.
-* **Project visibility**: the service account must be scoped to every Wiz Project you want imported (or to all Projects). The connector discovers your Wiz Projects first and then pulls each Project's findings — an account that can read issues but has no Project visibility discovers zero Projects, so there is nothing to import and no error is reported by either side.
+* **API scopes**: at minimum `read:projects`, `read:issues`, and `read:vulnerabilities`. `read:projects` is required even on a tenant with no Projects, because Discover still asks Wiz for the Project list.
+* **Project visibility**: the service account must be scoped to every Wiz Project you want imported (or to all Projects). An account that can read issues but has no Project visibility discovers no Project Records, and only the that tenant\-level Record Record is available.
 
 #### **Connector Mappings**
 


### PR DESCRIPTION
## Description

The Wiz connector used to create a Record only for each Wiz Project. If a Wiz tenant has no
Projects, that meant no Records, nothing to map, and no findings imported. The sync still
reported success, so nothing pointed at the problem.

The connector now always reports a tenant-level Record as well, named after the tenant, for
example `Wiz Tenant abc12`. Mapping that Record imports every Issue and vulnerability finding
the service account can see. It also picks up findings on resources that no Project covers.

This PR is the docs half of that change. It rewrites the Wiz section of the upstream connector
tool reference to say what the connector imports and what a Record is, matching how the other
tool sections read. It also removes the old note claiming an account without Project visibility
has nothing to import, because that is no longer true.

The `read:projects` scope requirement stays, because Discover still asks Wiz for the Project
list.

The four translations get the same edit.

The code change lives in the Pro connectors repo and ships in the same release.
