### PR TITLE
fix(findings): return 404 when a finding is deleted mid-PATCH instead of 500

### DIFF
--- a/dojo/finding/api/views.py
+++ b/dojo/finding/api/views.py
@@ -18,6 +18,7 @@ from drf_spectacular.utils import (
 )
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound
 from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.parsers import MultiPartParser
 from rest_framework.permissions import IsAuthenticated
@@ -39,6 +40,7 @@ from dojo.api_v2.views import (
     report_generate_response,
 )
 from dojo.authorization import api_permissions as permissions
+from dojo.db_utils import is_foreign_key_conflict
 from dojo.finding.api.filters import ApiFindingFilter, ApiTemplateFindingFilter
 from dojo.finding.api.serializer import (
     BurpRawRequestResponseMultiSerializer,
@@ -175,7 +177,24 @@ class FindingViewSet(
         if get_system_setting("enable_jira") and jira_project:
             push_to_jira = push_to_jira or jira_project.push_all_issues
 
-        serializer.save(push_to_jira=push_to_jira)
+        finding_pk = serializer.instance.pk
+        try:
+            serializer.save(push_to_jira=push_to_jira)
+        except IntegrityError as exc:
+            # A finding PATCH is not wrapped in a single transaction
+            # (ATOMIC_REQUESTS is False), so a concurrent delete of this finding --
+            # a reimport close_old_findings, a bulk delete, or another pipeline step --
+            # can remove the parent dojo_finding row mid-update. The child writes then
+            # reference a finding_id that is already gone and raise a foreign-key
+            # violation: the dojo_finding_tags through-row, and on Pro the
+            # pro_enhanced_finding companion. That is not a server defect -- the
+            # resource the client PATCHed no longer exists -- so answer 404 rather than
+            # letting a bare FK violation fall through to a 500. A genuine FK defect
+            # (the finding is still present) keeps surfacing as the original error.
+            if is_foreign_key_conflict(exc) and not Finding.objects.filter(pk=finding_pk).exists():
+                msg = "This finding was deleted while the update was being processed."
+                raise NotFound(msg) from exc
+            raise
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/unittests/test_finding_patch_concurrent_delete.py
+++ b/unittests/test_finding_patch_concurrent_delete.py
@@ -1,0 +1,122 @@
+"""
+Unit tests for the finding-update concurrent-deletion guard.
+
+Regression: PATCH 500s with FK violation when finding is deleted mid-request (#2610)
+
+``PATCH /api/v2/findings/{id}/`` is not wrapped in a single transaction
+(``ATOMIC_REQUESTS = False``), so a concurrent delete of the target finding -- a reimport
+``close_old_findings``, a bulk delete, or another pipeline step -- can remove the parent
+``dojo_finding`` row while the update is mid-flight. The child writes then reference a
+``finding_id`` that is already gone and raise a foreign-key violation (SQLSTATE 23503):
+
+* the ``dojo_finding_tags`` M2M through-row (OSS), and
+* the ``pro_enhanced_finding`` companion (Pro).
+
+The exception handler deliberately keeps a bare FK violation as a 500 (only unique
+violations become 409), so the caller saw an opaque Internal Server Error naming a Postgres
+constraint. ``FindingViewSet.perform_update`` now catches that specific case -- an FK
+violation whose parent finding no longer exists -- and answers 404, because the resource the
+client PATCHed genuinely no longer exists. A real FK defect (the finding is still there) must
+keep surfacing as a 500.
+
+These tests exercise ``perform_update`` directly with the wrapped-exception shape the cloud
+reports show, mirroring ``test_finding_delete_conflict_retry.py`` -- no database needed.
+"""
+from unittest.mock import MagicMock, patch
+
+from django.db import IntegrityError
+from django.test import SimpleTestCase
+from psycopg.errors import ForeignKeyViolation, UniqueViolation
+from rest_framework.exceptions import NotFound
+
+from dojo.finding.api.views import FindingViewSet
+
+# The two child-write FK violations from the report: the Pro companion and the OSS tag write.
+COMPANION_FK_MESSAGE = (
+    'insert or update on table "pro_enhanced_finding" violates foreign key constraint '
+    '"pro_enhanced_finding_finding_id_8ee99fa3_fk_dojo_finding_id"\n'
+    'DETAIL:  Key (finding_id)=(42) is not present in table "dojo_finding".'
+)
+TAG_FK_MESSAGE = (
+    'insert or update on table "dojo_finding_tags" violates foreign key constraint '
+    '"dojo_finding_tags_finding_id_d4968e76_fk_dojo_finding_id"\n'
+    'DETAIL:  Key (finding_id)=(42) is not present in table "dojo_finding".'
+)
+
+
+def _wrapped(exc_class, driver_error_class, message="db error"):
+    """
+    Build the exception shape Django surfaces for a driver error.
+
+    Django re-raises the driver error as its own IntegrityError and keeps the psycopg
+    exception -- the one carrying the SQLSTATE -- as ``__cause__``. ``is_foreign_key_conflict``
+    reads the SQLSTATE off that cause, so the wrapping has to be reproduced here.
+    """
+    cause = driver_error_class(message)
+    exc = exc_class(str(cause))
+    exc.__cause__ = cause
+    return exc
+
+
+class TestPerformUpdateConcurrentDelete(SimpleTestCase):
+
+    FINDING_PK = 42
+
+    def _serializer(self):
+        serializer = MagicMock(name="serializer")
+        serializer.instance.pk = self.FINDING_PK
+        serializer.validated_data = {}
+        return serializer
+
+    def _perform_update(self, serializer, *, finding_exists):
+        """
+        Call ``FindingViewSet.perform_update`` with jira disabled and the parent-finding
+        existence check stubbed to ``finding_exists``.
+        """
+        view = FindingViewSet()
+        with (
+            patch("dojo.finding.api.views.get_system_setting", return_value=False),
+            patch("dojo.finding.api.views.jira_services.get_project", return_value=None),
+            patch("dojo.finding.api.views.Finding") as mock_finding,
+        ):
+            mock_finding.objects.filter.return_value.exists.return_value = finding_exists
+            view.perform_update(serializer)
+
+    def test_finding_deleted_mid_update_returns_404(self):
+        """Both child-write FK violations, with the parent gone, must become a 404 (NotFound)."""
+        for label, message in (("companion", COMPANION_FK_MESSAGE), ("tags", TAG_FK_MESSAGE)):
+            with self.subTest(write=label):
+                serializer = self._serializer()
+                serializer.save.side_effect = _wrapped(IntegrityError, ForeignKeyViolation, message)
+                with self.assertRaises(NotFound) as caught:
+                    self._perform_update(serializer, finding_exists=False)
+                self.assertIn(
+                    "deleted while the update was being processed",
+                    str(caught.exception),
+                    msg=f"the {label} FK violation on a vanished finding must report the deletion, "
+                        f"got: {caught.exception}",
+                )
+
+    def test_fk_violation_while_finding_still_exists_is_not_translated(self):
+        """
+        Control: an FK violation while the finding is still present is a genuine defect and
+        must keep surfacing as the original IntegrityError (a 500), not a 404.
+        """
+        serializer = self._serializer()
+        serializer.save.side_effect = _wrapped(IntegrityError, ForeignKeyViolation, COMPANION_FK_MESSAGE)
+        with self.assertRaises(IntegrityError):
+            self._perform_update(serializer, finding_exists=True)
+
+    def test_non_fk_integrity_error_is_not_translated(self):
+        """Control: a unique violation (23505) is not the delete race and must not become a 404."""
+        serializer = self._serializer()
+        serializer.save.side_effect = _wrapped(IntegrityError, UniqueViolation, "duplicate key value")
+        with self.assertRaises(IntegrityError):
+            self._perform_update(serializer, finding_exists=False)
+
+    def test_successful_update_saves_and_does_not_raise(self):
+        """Control: an ordinary update saves once and raises nothing."""
+        serializer = self._serializer()
+        serializer.save.return_value = None
+        self._perform_update(serializer, finding_exists=True)
+        serializer.save.assert_called_once_with(push_to_jira=None)


### PR DESCRIPTION
## Problem

`PATCH /api/v2/findings/<id>/` can return HTTP 500 with a Postgres foreign-key violation
when the target finding is deleted by a concurrent operation while the update is still in
flight.

A finding update is not wrapped in a single transaction (`ATOMIC_REQUESTS` is False), so the
finding save and the `dojo_finding_tags` M2M through-row write are separate statements. If
another request deletes the finding row in between (a reimport closing old findings, a bulk
delete, or another pipeline step), the child insert references a `finding_id` that no longer
exists and raises a foreign-key violation (SQLSTATE 23503).

`custom_exception_handler` down-converts only unique violations (23505) to 409 and keeps
every other `IntegrityError`, foreign-key violations included, as a 500. That is deliberate:
a bare FK violation usually points at a real defect. So this race reached the caller as an
opaque 500 naming a database constraint rather than a status that says what happened.

## Fix

`FindingViewSet.perform_update` now catches the `IntegrityError` from `serializer.save()`.
When it is a foreign-key violation (`is_foreign_key_conflict`, SQLSTATE 23503) and the parent
finding no longer exists, it raises `NotFound` (404): the resource the client PATCHed is
genuinely gone, so 404 is the honest answer, and a subsequent GET on the same id returns 404
too. Every other `IntegrityError`, including a foreign-key violation while the finding is
still present, re-raises unchanged, so a real defect still surfaces as a 500.

No lock is taken, so there is no new deadlock surface between the finding-edit and
finding-delete paths. The single-finding delete already retries transient conflicts, and this
change adds nothing it has to serialize against.

## Tests

`unittests/test_finding_patch_concurrent_delete.py` exercises `perform_update` with the
wrapped-exception shape the reports show (an `IntegrityError` whose `__cause__` carries the
SQLSTATE), covering both the `dojo_finding_tags` through-row and the companion signatures.
Controls hold the rest of the contract in place: a foreign-key violation while the finding is
still present, a unique violation, and an ordinary update all behave exactly as before.
