### PR TITLE
docs: 3.3.x upgrade notes for the three deduplication identity changes

### DIFF
--- a/docs/content/releases/os_upgrading/3.3.md
+++ b/docs/content/releases/os_upgrading/3.3.md
@@ -20,22 +20,28 @@ history and risk acceptances along the way.
 | `Checkmarx One Scan` | `unique_id_from_tool` | The parser already deduplicates on the vendor id. The stored hash previously fell through to the legacy field set, whose title and description are the same volatile text for every result family, so the stored identity moved whenever Checkmarx reworded a finding even though matching did not. |
 | `Checkmarx Scan detailed` | `vuln_id_from_tool`, `file_path`, `line` | The same three fields as its sibling `Checkmarx CxFlow SAST`, which the parser populates on every detailed-mode finding. None of them carries scan text. |
 
-### If the identity signature ledger is enabled
+### DefectDojo Pro
 
-DefectDojo Pro 3.2.300 and later enable the identity signature ledger by default
-(`identity_signature_dual_write` and `identity_signature_matching`). On these instances
-no action is needed: drift detection notices the definition change, the scoped rehash
-recomputes the stored hashes, and signature matching bridges imports that still carry
-the old identity during the transition. The nightly backfill sweep closes small ledger
-gaps on its own; a large never-backfilled instance logs a notice instead, and should run
-`python manage.py identity_signatures_backfill` in a maintenance window, ideally
-**before** this upgrade, because the backfill records the identities findings currently
-have and a rehash replaces them.
+Pro 3.2.300 and later record identity signatures by default
+(`identity_signature_dual_write`), and the nightly drift watch will notice these
+definition changes and notify. The notification is a report, not a repair: recompute the
+stored hashes with the same three commands below, or accept the definition change in the
+Tuner, which runs the equivalent scoped rehash.
 
-### If it is not
+Two Pro-specific notes:
 
-Open-source installs, and Pro installs where the ledger was explicitly disabled, should
-rehash the affected scan types after upgrading so stored hashes match what imports now
+* If your instance has a signature ledger worth keeping (it has been recording for a
+  while, or you ran a backfill), run `python manage.py identity_signatures_backfill` in a
+  maintenance window **before** this upgrade. The backfill records the identities
+  findings currently have, and a rehash replaces them; done in this order, the previous
+  identities stay in the ledger and remain matchable during the transition on instances
+  where signature matching is enabled.
+* `identity_signature_matching` remains opt-in per instance. Where it is enabled, imports
+  still carrying the old identity bridge through the ledger during the transition.
+
+### Open source, and Pro instances that skip the rehash
+
+Rehash the affected scan types after upgrading so stored hashes match what imports now
 compute:
 
 ```bash

--- a/docs/content/releases/os_upgrading/3.3.md
+++ b/docs/content/releases/os_upgrading/3.3.md
@@ -2,6 +2,48 @@
 title: 'Upgrading to DefectDojo Version 3.3.x'
 toc_hide: true
 weight: -20260803
-description: No special instructions.
+description: Three parsers gain deduplication registrations, which changes the stored identity of their findings. Xeol Parser moves off the legacy hash so its identity stops depending on the wall clock; Checkmarx One Scan hashes the vendor id it already matches on; Checkmarx Scan detailed gains the same field list as its CxFlow sibling. Instances with the identity signature ledger enabled bridge these changes automatically; others should rehash the affected scan types after upgrading.
 ---
-There are no special instructions for upgrading to 3.3.x. Check the [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.3.0) for the contents of the release.
+
+## Deduplication identity changes
+
+Three scan types gain `HASHCODE_FIELDS_PER_SCANNER` registrations in this release. A
+registration changes how `hash_code` is computed, so findings imported by these parsers
+before the upgrade carry a hash that no longer matches what an import computes after it.
+Left alone, the next re-import of an unchanged report would treat every affected finding
+as new, close the stored one as absent, and recreate it, detaching false positive
+history and risk acceptances along the way.
+
+| Scan type | New hash fields | Why |
+|---|---|---|
+| `Xeol Parser` | `title`, `component_name`, `component_version` | Its severity is derived from the current date against the component's EOL date, and the legacy hash meant finding identity moved on its own as time passed. Severity still escalates as an EOL date recedes; it just no longer decides what the finding is. |
+| `Checkmarx One Scan` | `unique_id_from_tool` | The parser already deduplicates on the vendor id. The stored hash previously fell through to the legacy field set, whose title and description are the same volatile text for every result family, so the stored identity moved whenever Checkmarx reworded a finding even though matching did not. |
+| `Checkmarx Scan detailed` | `vuln_id_from_tool`, `file_path`, `line` | The same three fields as its sibling `Checkmarx CxFlow SAST`, which the parser populates on every detailed-mode finding. None of them carries scan text. |
+
+### If the identity signature ledger is enabled
+
+DefectDojo Pro 3.2.300 and later enable the identity signature ledger by default
+(`identity_signature_dual_write` and `identity_signature_matching`). On these instances
+no action is needed: drift detection notices the definition change, the scoped rehash
+recomputes the stored hashes, and signature matching bridges imports that still carry
+the old identity during the transition. The nightly backfill sweep closes small ledger
+gaps on its own; a large never-backfilled instance logs a notice instead, and should run
+`python manage.py identity_signatures_backfill` in a maintenance window, ideally
+**before** this upgrade, because the backfill records the identities findings currently
+have and a rehash replaces them.
+
+### If it is not
+
+Open-source installs, and Pro installs where the ledger was explicitly disabled, should
+rehash the affected scan types after upgrading so stored hashes match what imports now
+compute:
+
+```bash
+docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Xeol Parser' --hash_code_only"
+docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Checkmarx One Scan' --hash_code_only"
+docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Checkmarx Scan detailed' --hash_code_only"
+```
+
+Installs that never imported these scan types are unaffected. Check the
+[Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.3.0) for
+the full contents of the release.


### PR DESCRIPTION
The 3.3 upgrade page currently says "no special instructions". This release changes the stored identity of three scan types, so that is wrong three times over.

`Xeol Parser`, `Checkmarx One Scan` and `Checkmarx Scan detailed` all gain `HASHCODE_FIELDS_PER_SCANNER` registrations in 3.3.0. Findings imported before the upgrade therefore carry a `hash_code` that no longer matches what an import computes afterwards, and left alone the next re-import closes them as absent and recreates them, detaching false positive history and risk acceptances.

The page now follows the shape the 3.2 notes established:

* A table of the three scan types, the new field lists, and why each moved.
* The ledger path: instances with the identity signature ledger enabled (the default from Pro 3.2.300) need no action, with one caveat spelled out: a large never-backfilled instance should run `identity_signatures_backfill` **before** upgrading, because a rehash replaces the identities the backfill exists to record.
* The manual path: the three `manage.py dedupe --parser '...' --hash_code_only` commands, in the same form the 2.4x and 3.2 notes use (and the command name is `dedupe`, matching the correction merged in #15662).

Installs that never imported these scan types are unaffected, and the page says so.