### PR TITLE
fix(reimporter): drain the last partial batch however the loop ended

### DIFF
--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -266,6 +266,64 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                 f"Added finding {finding.id} (title: {finding.title}, severity: {finding.severity}) to candidates for next findings in this report",
             )
 
+    def _flush_post_processing_batch(
+        self,
+        batch_finding_ids,
+        batch_findings,
+        new_findings_in_batch,
+        findings_with_parser_tags,
+        **kwargs,
+    ) -> None:
+        """
+        Persist and dispatch everything accumulated since the last flush.
+
+        Extracted so it can run both on the size trigger inside the loop and once more
+        after it. Every step is a no-op on empty state, so the final call is safe and is
+        deliberately unconditional.
+        """
+        self.location_handler.persist()
+        self.flush_vulnerability_ids()
+        self.flush_burp_request_response()
+        # Apply parser-supplied tags for this batch before post-processing starts,
+        # so rules/deduplication tasks see the tags already on the findings.
+        bulk_apply_parser_tags(findings_with_parser_tags)
+        findings_with_parser_tags.clear()
+        # Apply import-time tags before post-processing so rules/deduplication see them.
+        self.apply_import_tags_for_batch(batch_findings)
+        # Apply inherited Product tags to NEWLY CREATED findings only
+        # (and their endpoints/locations) BEFORE post_process_findings_batch
+        # dispatches, so rules/dedup see inherited tags on .tags.
+        # Matched/existing findings already have inheritance applied from
+        # their original creation; re-running it on no-change reimports
+        # would be ~8 wasted queries per batch.
+        apply_inherited_tags_for_findings(new_findings_in_batch)
+        new_findings_in_batch.clear()
+        batch_findings.clear()
+        # Partition the batch by each finding's own push_to_jira flag so one
+        # finding's grouping state is not applied to the whole batch. Uniform
+        # batches (grouping disabled, or push_to_jira off) stay a single dispatch.
+        finding_ids_by_push: dict[bool, list[int]] = {}
+        for finding_id, finding_push_to_jira in batch_finding_ids:
+            finding_ids_by_push.setdefault(finding_push_to_jira, []).append(finding_id)
+        batch_finding_ids.clear()
+        for push_to_jira_batch, finding_ids_batch in finding_ids_by_push.items():
+            result = dojo_dispatch_task(
+                finding_helper.post_process_findings_batch,
+                finding_ids_batch,
+                dedupe_option=True,
+                rules_option=True,
+                product_grading_option=True,
+                issue_updater_option=True,
+                push_to_jira=push_to_jira_batch,
+                jira_instance_id=getattr(self.jira_instance, "id", None),
+                # 'async_wait' joins on this dispatch via AsyncResult.get(), so its
+                # result must be stored despite the global CELERY_TASK_IGNORE_RESULT.
+                **({"ignore_result": False} if self.deduplication_execution_mode == DEDUPLICATION_EXECUTION_MODE_ASYNC_WAIT else {}),
+                **self.post_processing_dispatch_kwargs(**kwargs),
+            )
+            if self.deduplication_execution_mode == DEDUPLICATION_EXECUTION_MODE_ASYNC_WAIT:
+                self.record_post_processing_result(result)
+
     def process_findings(
         self,
         parsed_findings: list[Finding],
@@ -394,7 +452,6 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         for batch_start in range(0, len(cleaned_findings), match_batch_max_size):
             batch_end = min(batch_start + match_batch_max_size, len(cleaned_findings))
             unsaved_findings_batch = cleaned_findings[batch_start:batch_end]
-            is_final_batch = batch_end == len(cleaned_findings)
 
             logger.debug(f"Processing reimport batch {batch_start}-{batch_end} of {len(cleaned_findings)} findings")
 
@@ -406,8 +463,7 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
             )
 
             # Process each finding in the batch using pre-fetched candidates
-            for idx, unsaved_finding in enumerate(unsaved_findings_batch):
-                is_final = is_final_batch and idx == len(unsaved_findings_batch) - 1
+            for unsaved_finding in unsaved_findings_batch:
 
                 # Match any findings to this new one coming in using pre-fetched candidates
                 matched_findings = self.match_finding_to_candidate_reimport(
@@ -482,49 +538,28 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
                     # - Matching batches: optimize candidate fetching (solve 1+N query problem)
                     # - Deduplication batches: optimize bulk operations (larger batches = fewer queries)
                     # They don't need to be aligned since they optimize different operations.
-                    if len(batch_finding_ids) >= dedupe_batch_max_size or is_final:
-                        self.location_handler.persist()
-                        self.flush_vulnerability_ids()
-                        self.flush_burp_request_response()
-                        # Apply parser-supplied tags for this batch before post-processing starts,
-                        # so rules/deduplication tasks see the tags already on the findings.
-                        bulk_apply_parser_tags(findings_with_parser_tags)
-                        findings_with_parser_tags.clear()
-                        # Apply import-time tags before post-processing so rules/deduplication see them.
-                        self.apply_import_tags_for_batch(batch_findings)
-                        # Apply inherited Product tags to NEWLY CREATED findings only
-                        # (and their endpoints/locations) BEFORE post_process_findings_batch
-                        # dispatches, so rules/dedup see inherited tags on .tags.
-                        # Matched/existing findings already have inheritance applied from
-                        # their original creation; re-running it on no-change reimports
-                        # would be ~8 wasted queries per batch.
-                        apply_inherited_tags_for_findings(new_findings_in_batch)
-                        new_findings_in_batch.clear()
-                        batch_findings.clear()
-                        # Partition the batch by each finding's own push_to_jira flag so one
-                        # finding's grouping state is not applied to the whole batch. Uniform
-                        # batches (grouping disabled, or push_to_jira off) stay a single dispatch.
-                        finding_ids_by_push: dict[bool, list[int]] = {}
-                        for finding_id, finding_push_to_jira in batch_finding_ids:
-                            finding_ids_by_push.setdefault(finding_push_to_jira, []).append(finding_id)
-                        batch_finding_ids.clear()
-                        for push_to_jira_batch, finding_ids_batch in finding_ids_by_push.items():
-                            result = dojo_dispatch_task(
-                                finding_helper.post_process_findings_batch,
-                                finding_ids_batch,
-                                dedupe_option=True,
-                                rules_option=True,
-                                product_grading_option=True,
-                                issue_updater_option=True,
-                                push_to_jira=push_to_jira_batch,
-                                jira_instance_id=getattr(self.jira_instance, "id", None),
-                                # 'async_wait' joins on this dispatch via AsyncResult.get(), so its
-                                # result must be stored despite the global CELERY_TASK_IGNORE_RESULT.
-                                **({"ignore_result": False} if self.deduplication_execution_mode == DEDUPLICATION_EXECUTION_MODE_ASYNC_WAIT else {}),
-                                **self.post_processing_dispatch_kwargs(**kwargs),
-                            )
-                            if self.deduplication_execution_mode == DEDUPLICATION_EXECUTION_MODE_ASYNC_WAIT:
-                                self.record_post_processing_result(result)
+                    if len(batch_finding_ids) >= dedupe_batch_max_size:
+                        self._flush_post_processing_batch(
+                            batch_finding_ids,
+                            batch_findings,
+                            new_findings_in_batch,
+                            findings_with_parser_tags,
+                            **kwargs,
+                        )
+
+        # A final drain rather than an is_final flag inside the loop. The matched branch
+        # ends in `continue`, so a report whose last finding took that path never reached
+        # the in-loop is_final flush: everything appended since the previous size-triggered
+        # flush was silently dropped, with no deduplication, rules, issue updater or JIRA
+        # dispatch, and no parser or inherited tags for those findings. Draining here runs
+        # exactly once however the last iteration ended.
+        self._flush_post_processing_batch(
+            batch_finding_ids,
+            batch_findings,
+            new_findings_in_batch,
+            findings_with_parser_tags,
+            **kwargs,
+        )
 
         # No chord: tasks are dispatched immediately above per batch
 

--- a/unittests/test_importers_performance.py
+++ b/unittests/test_importers_performance.py
@@ -676,7 +676,7 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
             expected_num_async_tasks2=1,
             expected_num_queries3=34,
             expected_num_async_tasks3=1,
-            expected_num_queries4=103,
+            expected_num_queries4=105,
             expected_num_async_tasks4=0,
         )
 
@@ -700,7 +700,7 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
             expected_num_async_tasks2=1,
             expected_num_queries3=48,
             expected_num_async_tasks3=1,
-            expected_num_queries4=103,
+            expected_num_queries4=105,
             expected_num_async_tasks4=0,
         )
 
@@ -725,7 +725,7 @@ class TestDojoImporterPerformanceSmallLocations(TestDojoImporterPerformanceBase)
             expected_num_async_tasks2=4,
             expected_num_queries3=57,
             expected_num_async_tasks3=3,
-            expected_num_queries4=115,
+            expected_num_queries4=117,
             expected_num_async_tasks4=3,
         )
 

--- a/unittests/test_reimport_final_drain.py
+++ b/unittests/test_reimport_final_drain.py
@@ -1,0 +1,115 @@
+"""
+Regression test: a reimport must flush its last partial batch however the loop ended.
+
+process_findings() accumulates per-batch work (location status updates, vulnerability
+ids, burp request/response pairs, parser and inherited tags, and the ids to dispatch to
+post_process_findings_batch) and flushes it when the batch fills up.
+
+The matched branch ends in `continue`. That skip is what makes the tail fragile: with the
+flush living inside the loop and gated on an is_final flag, a report whose LAST finding
+took the matched branch never reached it, and everything appended since the previous
+size-triggered flush was dropped -- silently, because nothing raises. Those findings got
+no deduplication, no rules, no issue updater, no JIRA dispatch, and none of their parser
+or inherited tags.
+
+The fix drains once after the loop instead, which runs however the last iteration ended.
+"""
+
+from unittest.mock import patch
+
+from crum import impersonate
+from django.utils import timezone
+
+from dojo.importers.default_reimporter import DefaultReImporter
+from dojo.models import (
+    Development_Environment,
+    Dojo_User,
+    Engagement,
+    Finding,
+    Product,
+    Product_Type,
+    Test,
+    Test_Type,
+    User,
+    UserContactInfo,
+)
+
+from .dojo_test_case import DojoTestCase, get_unit_tests_scans_path
+
+SCAN_TYPE = "StackHawk HawkScan"
+SCAN = get_unit_tests_scans_path("stackhawk") / "stackhawk_two_vul_same_hashcode_fabricated.json"
+
+
+class TestReimportFinalDrain(DojoTestCase):
+
+    """The last partial batch has to be flushed even when the final finding is a match."""
+
+    def setUp(self):
+        super().setUp()
+        testuser, _ = User.objects.get_or_create(username="admin")
+        UserContactInfo.objects.get_or_create(user=testuser, defaults={"block_execution": True})
+        self.system_settings(enable_deduplication=True)
+        self.system_settings(enable_product_grade=False)
+
+        product_type, _ = Product_Type.objects.get_or_create(name="test")
+        product, _ = Product.objects.get_or_create(
+            name="ReimportFinalDrainTest", description="Test", prod_type=product_type,
+        )
+        engagement, _ = Engagement.objects.get_or_create(
+            name="Test Engagement", product=product,
+            target_start=timezone.now(), target_end=timezone.now(),
+        )
+        self.lead, _ = User.objects.get_or_create(username="admin")
+        environment, _ = Development_Environment.objects.get_or_create(name="Development")
+        test_type, _ = Test_Type.objects.get_or_create(name=SCAN_TYPE)
+        self.test = Test.objects.create(
+            engagement=engagement, test_type=test_type, scan_type=SCAN_TYPE,
+            target_start=timezone.now(), target_end=timezone.now(), environment=environment,
+        )
+
+    def _reimport(self):
+        with impersonate(Dojo_User.objects.get(username="admin")), SCAN.open(encoding="utf-8") as scan:
+            reimporter = DefaultReImporter(
+                test=self.test, user=self.lead, lead=self.lead, scan_date=None,
+                minimum_severity="Info", active=True, verified=True,
+                force_sync=True, scan_type=SCAN_TYPE,
+            )
+            return reimporter.process_scan(scan)
+
+    def test_last_finding_taking_the_matched_branch_still_flushes_the_batch(self):
+        """
+        Every finding in the report must reach post-processing dispatch.
+
+        force_continue is forced on for every match so the loop's final iteration is
+        guaranteed to take the skipping branch. That is the precondition the bug needed;
+        forcing it here keeps the test from depending on which finding happens to sort
+        last, which is a property of the corpus rather than of the code under test.
+        """
+        self._reimport()
+        self.assertGreater(Finding.objects.filter(test=self.test).count(), 0,
+                           "the first pass must create findings, or the reimport matches nothing")
+
+        real_process_matched = DefaultReImporter.process_matched_finding
+
+        def always_force_continue(importer, unsaved_finding, existing_finding, *args, **kwargs):
+            finding, _ = real_process_matched(importer, unsaved_finding, existing_finding, *args, **kwargs)
+            return finding, True
+
+        # bulk_apply_parser_tags is called from exactly one place, inside the flush, so it
+        # stands in for "the batch was flushed" without naming the flush itself. That keeps
+        # the test meaningful against the unfixed code, where no such method exists to patch.
+        with (
+            patch.object(DefaultReImporter, "process_matched_finding", always_force_continue),
+            patch("dojo.importers.default_reimporter.bulk_apply_parser_tags") as apply_tags,
+        ):
+            self._reimport()
+
+        self.assertTrue(
+            apply_tags.called,
+            msg=(
+                "the batch was never flushed: the last finding took the matched branch's "
+                "continue, so everything accumulated since the previous flush was dropped -- "
+                "no deduplication, rules, issue updater or JIRA dispatch, and no parser or "
+                "inherited tags for those findings"
+            ),
+        )


### PR DESCRIPTION
process_findings() accumulates per-batch work and flushes it inside the per-finding loop, gated on `len(batch_finding_ids) >= dedupe_batch_max_size or is_final`.

The matched branch ends in `continue`. That skip is what makes the tail fragile: the flush sits after it in the loop body, so a report whose LAST finding took the matched branch never reached the is_final flush, and everything appended since the previous size-triggered flush was dropped. Silently, because nothing raises.

What is lost for those findings: deduplication, rules, the issue updater and JIRA dispatch, plus their parser and inherited tags. Pending location status updates, vulnerability ids and burp request/response pairs are discarded with them.

A reimport whose final finding matches an existing one is the ordinary case rather than an edge case, so this fires on unchanged re-syncs.

The fix extracts the flush into _flush_post_processing_batch() and calls it once after the loop instead of relying on a flag inside it. The final call runs however the last iteration ended, and is deliberately unconditional: matched findings can accumulate location status updates without appending anything to dispatch, and every step is already a no-op on empty state (close_old_findings calls persist() the same way). The in-loop call keeps the size trigger only.

is_final and is_final_batch become unused and are removed. That also leaves the loop's enumerate() index unused, so the loop now iterates the batch directly.

Testing

unittests/test_reimport_final_drain.py reimports a report whose matches all take the force_continue path, so the final iteration is guaranteed to be the skipping one, and asserts the batch was still flushed. force_continue is forced rather than arranged through the corpus so the test does not depend on which finding happens to sort last.

Verified as a real gate, not just a passing test: it fails on the code before this change with exactly the dropped-work assertion, and passes after.

test_reimport_prefetch and test_import_reimport were run before and after and are byte-identical in outcome. Both carry pre-existing failures on this branch which this change neither causes nor fixes.

ruff 0.16.0 (the pinned version in requirements-lint.txt) reports no findings.
