### PR TITLE
docs(rules_engine_2): custom fields in Rules Engine 2.0

### DIFF
--- a/docs/content/automation/rules_engine_2/building_rules.md
+++ b/docs/content/automation/rules_engine_2/building_rules.md
@@ -153,6 +153,8 @@ An **If / Filter** node holds a list of condition rows. Each row is a path, an o
 | `not_contains` | does not contain |
 | `in` | is one of |
 | `not_in` | is not one of |
+| `has` | includes (one of a multi-select custom field's stored options) |
+| `not_has` | does not include |
 | `gt` | is greater than |
 | `gte` | is greater than or equal to |
 | `lt` | is less than |
@@ -163,6 +165,23 @@ An **If / Filter** node holds a list of condition rows. Each row is a path, an o
 | `not_exists` | is not set |
 
 Comparisons are **loose**. A number is tried first, and if that fails the values are compared as trimmed, case-insensitive text. So a condition written as `finding.severity eq high` matches a Finding whose severity is `High`, which is almost always what the author meant.
+
+#### Custom fields
+
+With [Custom Fields](/asset_modelling/pro__custom_fields/) enabled, every custom field defined for the rule's kind of item is offered as a condition path too, under a `custom_fields` block:
+
+```
+finding.custom_fields.cost_center
+product.custom_fields.owner_team
+```
+
+A rule over Findings reads the Finding's custom fields and a rule over Assets reads the Asset's; there is no cross-kind path. A record holding no value for a field reads as not set, so `exists` and `not_exists` are how you condition on a field being filled in at all. The same paths work as `{{ }}` placeholders in templates.
+
+The field's data type decides which operators the editor offers: numbers take equality, list membership and ordering, dates take equality and ordering (against a `YYYY-MM-DD` value), booleans take equality, and a single-select offers equality and list membership over the field's own options. Text fields keep the full operator list.
+
+A **multi-select** field holds several options at once, and two operators exist for exactly that. `has` (*includes*) matches when the compared option is one of the stored ones, whole and exact: a Finding holding only `gdpr-eu` is not matched by `has gdpr`, where `contains` would match on the fragment. `not_has` (*does not include*) is its negation.
+
+"Includes **any of** several options" is one **If / Filter** node with one `has` row per option and **Match** set to `any`. To combine that with conditions that must all hold, chain two **If / Filter** nodes: the any-of rows in the first (Match `any`), everything else in the second (Match `all`).
 
 #### Transforms
 

--- a/docs/content/automation/rules_engine_2/node_reference.md
+++ b/docs/content/automation/rules_engine_2/node_reference.md
@@ -8,7 +8,7 @@ aliases:
 ---
 <span style="background-color:rgba(242, 86, 29, 0.3)">Note: Rules Engine 2.0 is a DefectDojo Pro-only feature.</span>
 
-Rules Engine 2.0 ships 25 nodes in four categories. This page documents all of them.
+Rules Engine 2.0 ships 29 nodes in five categories. This page documents all of them.
 
 Unless stated otherwise, a node takes one input, produces one output called `out`, and passes every item it received on to that output. That matters when you chain nodes: a Findings node changes the Finding and then hands the item onward, so several of them in a row all apply.
 
@@ -223,6 +223,62 @@ Sets the risk, overriding the computed one.
 | Setting | Options |
 |---------|---------|
 | **Risk** | `Low`, `Medium`, `Needs Action`, `Urgent` |
+
+### Set a Custom Field
+
+`finding.set_custom_field`
+
+Writes one of this instance's [Custom Fields](/asset_modelling/pro__custom_fields/) on the Finding. Offered only while Custom Fields is enabled, with one value control per field an administrator has defined for Findings.
+
+| Setting | Notes |
+|---------|-------|
+| **Field** | Which custom field to write. |
+| **Value** | Typed to the field: text takes a template with `{{finding.title}}` style placeholders, numbers take a number, dates take a `YYYY-MM-DD` date, booleans take true or false, and the select types offer the field's own options. |
+
+The value is checked against the field's current definition when the rule is saved and again on every run, so a rule can never write a value the field's data type refuses. A text template that renders empty for a Finding leaves that Finding untouched (removal is the Clear node's job), setting a multi-select replaces the whole stored list, and Findings already holding the value are left alone.
+
+Three behaviours worth knowing:
+
+* **Scope is the boundary.** Like every Findings node, the write applies to every Finding the trigger produced under the rule owner's visibility.
+* **A custom field write is not a Finding save.** Nothing that follows a Finding save runs: no SLA recomputation, no deduplication, no re-prioritization. A custom field edited by hand on a Finding's page does not wake **On Finding Event** rules either. A write made by a rule does cascade: other rules see it as an `updated` event, and later nodes in the same run read the new value.
+* **The field must still exist.** If the field is deleted after the rule was saved, the run errors naming it. If Custom Fields is switched off entirely, the node skips with the reason on its trace instead, so a saved rule never starts erroring over a feature flag.
+
+### Clear a Custom Field
+
+`finding.clear_custom_field`
+
+Removes one custom field's value from the Finding. The value it held is recorded on the Finding's provenance timeline, and a Finding holding no value counts as unchanged.
+
+| Setting | Notes |
+|---------|-------|
+| **Field** | Which custom field to clear. |
+
+## Assets
+
+These nodes change Assets (Products). They only join graphs whose trigger produces Assets, and every change is attributed back to the rule, run and node that made it on the Asset's provenance.
+
+### Set a Custom Field
+
+`asset.set_custom_field`
+
+Writes one of this instance's [Custom Fields](/asset_modelling/pro__custom_fields/) on the Asset. The value control follows the field's data type exactly as the Findings node of the same name does (templates read `{{product.name}}` style paths), the same save-time and run-time validation applies, and a deleted field or a switched-off feature behaves the same.
+
+| Setting | Notes |
+|---------|-------|
+| **Field** | Which custom field to write. One entry per Asset custom field defined on the instance. |
+| **Value** | Typed to the field. |
+
+Two behaviours of its own: Assets the rule owner may not edit are counted on the node trace as `skipped_unauthorized` rather than touched, and the write lands on the custom field value rather than the Asset row itself, so nothing that follows an Asset edit runs. A custom field edited by hand does not wake **On Asset Event** rules; a write made by a rule still cascades as an `updated` event.
+
+### Clear a Custom Field
+
+`asset.clear_custom_field`
+
+Removes one custom field's value from the Asset, recording what it held on the Asset's provenance.
+
+| Setting | Notes |
+|---------|-------|
+| **Field** | Which custom field to clear. |
 
 ## Egress
 


### PR DESCRIPTION
Documents custom fields support in Rules Engine 2.0 (a DefectDojo Pro feature): conditioning on typed custom fields, and the four nodes that write them.

**node_reference.md**

- Two new Findings entries: **Set a Custom Field** (`finding.set_custom_field`) and **Clear a Custom Field** (`finding.clear_custom_field`), covering the typed value inputs (template for text, number, `YYYY-MM-DD` date, true/false, the field's own options for selects), save-time and run-time validation against the live definition, empty-render and multi-select replacement semantics, the rule-owner-scope permission note, and the caveat that a custom field write is not a Finding save (no SLA recomputation, deduplication, or re-prioritization; hand edits do not wake event rules, while rule writes still cascade as `updated` events).
- A new **Assets** section with the asset twins (`asset.set_custom_field`, `asset.clear_custom_field`), including the `skipped_unauthorized` counting for Assets the rule owner may not edit.
- The node count line moves from 25 to 29.

**building_rules.md**

- The operator table gains `has` (*includes*) and `not_has` (*does not include*).
- A new **Custom fields** subsection under Conditions: the `finding.custom_fields.*` / `product.custom_fields.*` paths, how the field's data type narrows the offered operators, why `has` is exact membership where `contains` would match a fragment (`gdpr-eu` vs `gdpr`), the not-set semantics, template placeholders, and the two-node pattern for combining "any of several options" with conditions that must all hold.

Written against `bugfix` as it stands today. Note for reviewers: the pending asset-support docs branch also introduces an `## Assets` section on this page, so whichever change lands second takes a small, expected conflict on the node-count line and that section header.
