### PR TITLE
docs(rules-engine-2): the rule permission tier is four permissions, not two

### DIFF
--- a/docs/content/admin/user_management/user_permission_chart.md
+++ b/docs/content/admin/user_management/user_permission_chart.md
@@ -76,6 +76,7 @@ The majority of Configuration Permissions give users access to certain pages in 
 | Questionnaires | Access the **Questionnaires \> All Questionnaires** page | Add a new Questionnaire | Edit an existing Questionnaire | Delete a Questionnaire |
 | Questions | Access the **Questionnaires \> Questions** page | Add a new Question | Edit an existing Question | n/a |
 | Regulations | n/a | Add a Regulation to the **⚙️Configuration \> Regulations** page | Edit an existing Regulation | Delete a Regulation |
+| Rules Engine | Access the **Rules Engine 2.0** sidebar section and everything under it (All Rules, Runs, and Deliveries) | Create a rule, including converting one from the original Rules Engine | Change, enable, schedule, run, replay, or take ownership of an existing rule | Delete a rule |
 | Scheduling Service Schedule | Access the **Scheduling** page | Superuser only | Edit an existing Schedule (change trigger, enable/disable) | Delete a Schedule |
 | SLA Configuration | Access the **⚙️Configuration \> SLA Configuration** page | Add a new SLA Configuration | Edit an existing SLA Configuration | Delete an SLA Configuration |
 | Test Types | n/a | Add a new Test Type (under **Engagements \> Test Types**) | Edit an existing Test Type | n/a |

--- a/docs/content/automation/rules_engine_2/about.md
+++ b/docs/content/automation/rules_engine_2/about.md
@@ -37,12 +37,20 @@ Once the flag is on, a **Rules Engine 2.0** section appears in the sidebar with 
 
 ### Permissions
 
-Access is governed by two global role permissions, shared with the original Rules Engine:
+Access is governed by four global role permissions, shared with the original Rules Engine:
 
 * **Rule View** is required to see the sidebar section and everything under it.
-* **Rule Edit** is required to create, change, run, delete, convert, take ownership of, and replay.
+* **Rule Add** is required to create a rule, including converting one from the original Rules Engine.
+* **Rule Edit** is required to change, enable, schedule, run, replay, or take ownership of an existing rule.
+* **Rule Delete** is required to delete a rule.
 
-Rule Edit is close to an administrative permission. A rule author can reach any Finding their rule's owner can see, and can direct output at external systems, so grant it deliberately.
+Validating and previewing a rule are accepted with either authoring permission, Rule Add or Rule Edit.
+
+Rule Add and Rule Edit are close to administrative permissions. A rule author can reach any Finding their rule's owner can see, and can direct output at external systems, so grant them deliberately.
+
+All four are strict global permissions: a grant counts only when the role is held as a global role, never when it is held as an Organization or Asset membership role. Superusers keep access regardless.
+
+If you are upgrading, a role that already held Rule Edit keeps the ability to create and delete rules, so nobody loses access. No built-in role gains rule access on upgrade.
 
 ## The concepts
 


### PR DESCRIPTION
## Description

The Rules Engine page stated that access is governed by two global role permissions, Rule View and Rule Edit, and attributed creating and deleting a rule to Rule Edit. There are four permissions, and creating and deleting are no longer part of Rule Edit.

Corrects the Permissions section on the Rules Engine 2.0 page:

- **Rule View** to see the sidebar section and everything under it.
- **Rule Add** to create a rule, including converting one from the original Rules Engine.
- **Rule Edit** to change, enable, schedule, run, replay, or take ownership of an existing rule.
- **Rule Delete** to delete a rule.

Also documents three things the section did not say: validating and previewing a rule are accepted with either authoring permission; all four are strict global permissions, so a grant counts only when the role is held globally and not as an Organization or Asset membership role; and on upgrade a role that already held Rule Edit keeps the ability to create and delete, so nobody loses access.

Separately, the Configuration Permission Chart did not list the Rules Engine at all. Adds a row describing the four columns in the same voice as its neighbours.

## Test Commands
- `/test all` - run all tests

---

### Test Configuration
```yaml
oss-branch:
oss-username:
```
