### PR TITLE
docs(findings): Quick Export opens a dialog and produces a named report

### DIFF
--- a/docs/content/asset_modelling/engagements_tests/PRO__findings.md
+++ b/docs/content/asset_modelling/engagements_tests/PRO__findings.md
@@ -276,4 +276,14 @@ DefectDojo’s report builder lets you assemble a custom report from a set of co
 More information about DefectDojo’s Report Builder can be found [here](/metrics_reports/reports/report-builder/).
 
 ### Export Findings 
-Pages that show a list of Findings or a list of Engagements have a CSV and Excel export option at the top left. For Findings, there is also the option to perform a Quick Export, which will open a new tab with tables of metadata pertaining to each Finding. 
+Pages that show a list of Findings or a list of Engagements have a CSV and Excel export option at the top left. For Findings, there is also the option to perform a **Quick Export**.
+
+Selecting Quick Export opens a dialog with three choices:
+
+- **Template**: the report template to apply. This defaults to the standard Findings table, so you can export without choosing one.
+- **Report name**: the name the finished report is stored under. It arrives prefilled, and you can edit it before running the export.
+- **Format**: whether the report is produced as HTML or PDF.
+
+The export runs in the background, and the finished report appears in your Generated Reports list under the name you chose.
+
+The prefilled name describes what you exported, followed by where you exported it from in parentheses. It carries no date, because the Generated Reports list already shows when each report was requested and completed. Exporting from a Findings list that is not scoped to anything gives just the content name. 


### PR DESCRIPTION
## Description

The Findings page described Quick Export as opening a new tab with tables of metadata for each Finding. It no longer works that way, so anyone following the page was told to expect something that does not happen.

Quick Export now opens a dialog with three choices:

- **Template**: the report template to apply, defaulting to the standard Findings table so you can export without picking one.
- **Report name**: the name the finished report is stored under, prefilled and editable before you run the export.
- **Format**: HTML or PDF.

The export runs in the background and the finished report appears in the Generated Reports list under the chosen name.

Also documents how the prefilled name is composed, since that is what makes the Generated Reports list readable: it names what you exported followed by where you exported it from in parentheses, and carries no date because the list already shows requested and completed times.

## Test Commands
- `/test all` - run all tests

---

### Test Configuration
```yaml
oss-branch:
oss-username:
```
