### PR TITLE
docs(audit-log): add the tracked objects missing from the index

### DIFF
--- a/docs/content/admin/user_management/PRO__audit_log_index.md
+++ b/docs/content/admin/user_management/PRO__audit_log_index.md
@@ -79,16 +79,25 @@ attributed to the user who triggered it.
 | Object                            | Create | Update | Delete | Notes                          |
 | --------------------------------- | :----: | :----: | :----: | ------------------------------ |
 | Enhanced Finding                  |   ✅   |   ✅   |   ✅   | Pro companion to Finding       |
+| Enhanced Risk Acceptance          |   ✅   |   ✅   |   ✅   | Pro companion to Risk Acceptance |
+| Risk Acceptance Finding Record    |   ✅   |   ✅   |   ✅   | Findings attached to a Risk Acceptance |
 | Rule                              |   ✅   |   ✅   |   ✅   | Rules engine                   |
 | Rule Action                       |   ✅   |   ✅   |   ✅   |                                |
 | Rule Action Condition             |   ✅   |   ✅   |   ✅   |                                |
 | Rule Filter Entry                 |   ✅   |   ✅   |   ✅   |                                |
 | Rules Engine Operation            |   ✅   |   ✅   |   ✅   |                                |
 | Rules Engine Operation Message    |   ✅   |   ✅   |   ✅   |                                |
+| Rules Engine 2.0 Rule             |   ✅   |   ✅   |   ✅   | Node based rules               |
+| Rules Engine 2.0 Delivery         |   ✅   |   ✅   |   ✅   | Entries in the Deliveries ledger |
 | Scheduled Task                    |   ✅   |   ✅   |   ✅   |                                |
 | Scheduled Task Run                |   ✅   |   ✅   |   ✅   |                                |
 | Mitigation Policy                 |   ✅   |   ✅   |   ✅   |                                |
+| Work Assignment                   |   ✅   |   ✅   |   ✅   | Findings and Risk Acceptances assigned to a person |
+| CMMC Assessment                   |   ✅   |   ✅   |   ✅   |                                |
 | Tunable Setting                   |   ✅   |   ✅   |   ✅   | System configuration changes   |
+| Custom Field Definition           |   ✅   |   ✅   |   ✅   | The custom field itself        |
+| Custom Field Value                |   ✅   |   ✅   |   ✅   | Values filled in on a record   |
+| Form Configuration                |   ✅   |   ✅   |   ✅   | Create and edit form settings  |
 | Feature Flag State                |   ✅   |   ✅   |   ✅   | Flag toggles + system pins     |
 | Feature Flag Definition           |   ✅   |   ✅   |   ✅   | Metadata / registry sync       |
 | Cloud Firewall                    |   ✅   |   ✅   |   ✅   | `locked` field excluded        |
@@ -100,6 +109,7 @@ attributed to the user who triggered it.
 | ----------------------------- | :----: | :----: | :----: |
 | Group                         |   ✅   |   ✅   |   ✅   |
 | Role                          |   ✅   |   ✅   |   ✅   |
+| Role permissions              |   ✅   |   ✅   |   ✅   |
 | Group Membership              |   ✅   |   ✅   |   ✅   |
 | Global Role                   |   ✅   |   ✅   |   ✅   |
 | Asset Group Assignment      |   ✅   |   ✅   |   ✅   |


### PR DESCRIPTION
## Description

The Audit Logging page publishes per-object tables of everything the audit log records. Because it reads as a complete list, an object missing from it tells the reader that object is not audited. Nine recorded objects were absent.

Adds rows for:

- **Enhanced Risk Acceptance** and **Risk Acceptance Finding Record**, the Pro companion to a Risk Acceptance and the Findings attached to it.
- **Rules Engine 2.0 Rule** and **Rules Engine 2.0 Delivery**. The table covered the original Rules Engine only.
- **Work Assignment**, for Findings and Risk Acceptances assigned to a person.
- **CMMC Assessment**.
- **Custom Field Definition** and **Custom Field Value**, following the same split the table already uses for Feature Flag Definition and Feature Flag State.
- **Form Configuration**, for create and edit form settings.
- **Role permissions**, in the RBAC table, so it is clear that changing the permissions granted on a custom role is recorded.

## Deliberately not included

Three more objects are recorded but are left out, because their user facing names could not be confirmed against documentation on this branch and a guessed name in a table like this would be worse than an absent row:

- CMMC requirement results
- The two PSIRT objects (advisories and feed sources). The PSIRT documentation is not present on this branch.

Happy to add all three in a follow-up once someone who owns those areas confirms what they are called in the UI.

## Test Commands
- `/test all` - run all tests

---

### Test Configuration
```yaml
oss-branch:
oss-username:
```
