### PR TITLE
docs(navigation): document Form Configuration

### DIFF
--- a/docs/content/navigation/PRO__form_configuration.md
+++ b/docs/content/navigation/PRO__form_configuration.md
@@ -1,0 +1,46 @@
+---
+title: "Configuring Forms"
+description: "Choose which fields the DefectDojo Pro create and edit forms show, which are required, and the order they appear in"
+draft: false
+weight: 10
+audience: pro
+---
+<span style="background-color:rgba(242, 86, 29, 0.3)">Note: Form Configuration is a DefectDojo Pro feature, and is available to administrators from **Settings > UI Defaults > Form Configuration**.</span>
+
+The create and edit forms in DefectDojo Pro ship with a sensible set of fields, but not every organization collects the same information. Form Configuration lets an administrator decide, per form, which fields appear, which are mandatory, where they sit, and what order they come in.
+
+**This is an instance-wide setting, not a personal preference.** Changes apply to everyone, and each person picks them up the next time they navigate to a new page.
+
+## Choosing a form
+
+Pick the form you want to change from the selector at the top of the page. Each entity that has a create and edit form has an entry, for example the Finding form and the Asset form. The rest of the page then shows that form's fields.
+
+## The field list
+
+Fields are listed one per row, with a **State** column describing what you can do with each. A field falls into one of three cases:
+
+- **Not Configurable**: the form needs this field to work, so it cannot be moved, hidden, or made optional. It is still listed so you can see the form's full shape.
+- **Always Required**: the field is mandatory and stays that way, though you can still change where it appears in the order.
+- **Configurable**: the field offers the controls below.
+
+For a configurable field you can set:
+
+- **Placement**, either **Main** or **Optional**. Main puts the field in the body of the form, where it is visible as soon as the form opens. Optional moves it into the collapsible Optional Fields section.
+- **Required**, which makes the field mandatory. Someone filling in the form cannot submit it until the field has a value.
+- **Disabled**, which takes the field off the form entirely.
+
+## Changing the order
+
+Drag the handle at the left of a row to change the order fields render in. This controls the sequence only. Whether a field sits in the body of the form or in Optional Fields is still governed by its Placement setting, so reordering a field will not move it between the two sections.
+
+You can reorder a field that is otherwise not configurable, because its position still affects how the form reads.
+
+## Optional Fields on open
+
+**Expand Optional Fields by Default** decides whether the Optional Fields section starts open or closed when someone opens one of these forms. Turn it on when most of your fields live in Optional Fields and you would rather people saw them without an extra click.
+
+## Saving
+
+**Save** applies your changes for everyone. **Reset to Defaults** returns the selected form to the configuration DefectDojo ships with, which is a good way back if a form has been narrowed too far.
+
+Each form is saved separately, so resetting one leaves your changes to the others alone.

--- a/docs/content/navigation/PRO__sidebar.md
+++ b/docs/content/navigation/PRO__sidebar.md
@@ -103,7 +103,7 @@ The last category, **Elsewhere in the app**, lists pages that configure DefectDo
 
 The **UI Defaults** group collects the settings that control how much of the interface each person can tailor:
 
-- **Form Configuration**: choose which fields the create and edit forms show and require, and whether the Optional Fields panel starts expanded.
+- **[Form Configuration](/navigation/pro__form_configuration/)**: choose which fields the create and edit forms show and require, and whether the Optional Fields panel starts expanded.
 - **Layout Defaults**: the **Restrict Layout Customization** switch, plus the global defaults designated for dashboards, page layouts, and table views. With the switch on, only superusers can create or change dashboards, page layouts, and table views; everyone else is shown the designated defaults, or the built-in defaults when none are chosen. Personal layouts saved earlier are kept and reappear if the switch is turned back off. You choose each default from a dropdown of the layouts an administrator has shared, or designate one in context (a shared dashboard's Manage dialog, a view page's layout menu, or a table's Views menu).
 
 ## What moved


### PR DESCRIPTION
## Description

Form Configuration had a single bullet on the Sidebar Menu page, and that bullet was added in passing by an unrelated documentation change, so there was nowhere explaining how to use the feature.

Adds a Configuring Forms page under Navigation, beside Customizing Tables, covering:

- Where the setting lives, and that it applies to everyone rather than being a personal preference. Changes are picked up on the next page navigation.
- Choosing which form to configure.
- The three states a field can be in: not configurable, always required, or configurable.
- The controls on a configurable field: Placement between the main body and the Optional Fields section, Required, and Disabled.
- Reordering fields by dragging, including that reordering controls sequence only and does not move a field between the main body and Optional Fields, and that an otherwise non-configurable field can still be reordered.
- The Expand Optional Fields by Default setting.
- What Save and Reset to Defaults do, and that each form is stored separately so resetting one does not affect the others.

Also links the Form Configuration bullet on the Sidebar Menu page through to the new page.

## Note for whoever merges

This changes the Form Configuration bullet on the Sidebar Menu page. The page layouts documentation PR changes the Layout Defaults bullet directly beneath it. They are independent and either can go first, but the second one merged will want a one line rebase on that file.

## Test Commands
- `/test all` - run all tests

---

### Test Configuration
```yaml
oss-branch:
oss-username:
```
