### PR TITLE
Release drafter: exclude release-train merge PRs from release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -81,6 +81,8 @@ categories:
       label: 'patch'
 exclude-labels:
   - 'skip-changelog'
+  # Automated release-train PRs ('Release: Merge release ...' / 'Release: Merge back ...')
+  - 'release-management'
 
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |


### PR DESCRIPTION
**Description**

Our drafted release notes currently include lines like `- Release: Merge release into master from: release/3.2.300` and `- Release: Merge back 3.2.201 into dev from: ...`. Those are just the wrappers around the real changes, which already get their own lines. This PR drops them.

release-drafter can't filter by title text, but it doesn't have to. All three release workflows (`release-1-create-pr.yml`, `release-3-master-into-dev.yml`) already tag their PRs with `release-management`, so this adds that label to `exclude-labels` in `.github/release-drafter.yml`.

Side benefit: those merge PRs also pick up labels like `New Migration` and `settings_changes` from the path labeler, so today they show up under those flagged sections too. They won't anymore.

**Does it exclude anything else?**

I checked. Every PR that has ever carried `release-management` (80 in total) is a release-train merge. The only one whose title doesn't match the two patterns above is #14800, "Release 2.58.0: Merge Bugfix into Dev", which is the same kind of PR under an older title. Nothing else applies the label.

**Test results**

Config-only change, no code to test. It can be checked by running the "Release Drafter (custom range)" workflow with `dry-run: true` before the next real draft.

**Documentation**

None needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

