### PR TITLE
Apply the global template gate to the add-from-template listing

### DIFF
--- a/dojo/test/ui/views.py
+++ b/dojo/test/ui/views.py
@@ -803,6 +803,8 @@ def add_finding_from_template(request, tid, fid):
 
 def search(request, tid):
     test = get_object_or_404(Test, id=tid)
+    # This listing returns template content, a shared cross-product store
+    user_has_global_permission_or_403(request.user, "edit")
     templates = Finding_Template.objects.all()
     templates = TemplateFindingFilter(request.GET, queryset=templates)
     paged_templates = get_page_items(request, templates.qs, 25)

--- a/unittests/test_apply_finding_template.py
+++ b/unittests/test_apply_finding_template.py
@@ -690,3 +690,18 @@ class TestFindingTemplateCrossTenantReadAuthz(DojoTestCase):
         with impersonate(staff):
             result = views.choose_finding_template_options(request, tid=self.template.id, fid=self.own_finding.id)
         self.assertEqual(200, result.status_code)
+
+    def test_search_listing_denied(self):
+        request = FindingTemplateTestUtil.create_get_request(
+            self.attacker, f"/test/{self.test_a.id}/search")
+        with impersonate(self.attacker), self.assertRaises(PermissionDenied):
+            test_views.search(request, tid=self.test_a.id)
+
+    def test_search_listing_allows_global_edit(self):
+        staff = FindingTemplateTestUtil.create_user(is_staff=True)
+        request = FindingTemplateTestUtil.create_get_request(
+            staff, f"/test/{self.test_a.id}/search")
+        with impersonate(staff):
+            result = test_views.search(request, tid=self.test_a.id)
+        self.assertEqual(200, result.status_code)
+        self.assertIn(self.SECRET, result.content.decode())


### PR DESCRIPTION
Hardening / consistency improvement to finding-template authorization. Adds an additional authorization check on one template listing view, plus a regression test in the existing template authorization suite.

No functional change for users who already hold the global template permission. The check is placed in the view body rather than the route permission map so it applies the same way on every edition.