### PR TITLE
Validate the Jira epic action body and reject reserved dispatch kwargs

### DIFF
--- a/dojo/celery_dispatch.py
+++ b/dojo/celery_dispatch.py
@@ -8,6 +8,10 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 
+# The dispatcher injects these itself; a caller must never supply them.
+RESERVED_DISPATCH_KWARGS = frozenset({"async_user_id", "_pgh_context"})
+
+
 class _SupportsSi(Protocol):
     def si(self, *args: Any, **kwargs: Any) -> Signature: ...
 
@@ -74,6 +78,10 @@ def dojo_dispatch_task(task_or_sig: _SupportsSi | _SupportsApplyAsync | Signatur
 
     """
     from dojo.decorators import dojo_async_task_counter, we_want_async  # noqa: PLC0415 circular import
+
+    if reserved := RESERVED_DISPATCH_KWARGS.intersection(kwargs):
+        msg = f"reserved dispatch kwargs may not be supplied by callers: {sorted(reserved)}"
+        raise ValueError(msg)
 
     countdown = cast("int", kwargs.pop("countdown", 0))
     # Per-dispatch result storage. The task default is `ignore_result` (global

--- a/dojo/engagement/api/views.py
+++ b/dojo/engagement/api/views.py
@@ -346,11 +346,14 @@ class EngagementViewSet(
     )
     def update_jira_epic(self, request, pk=None):
         engagement = self.get_object()
+        serializer = api_v2_serializers.EngagementUpdateJiraEpicSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        epic_kwargs = serializer.validated_data
         try:
             if engagement.has_jira_issue:
                 task = jira_services.get_epic_task("update_epic")
                 if task:
-                    dojo_dispatch_task(task, engagement.id, **request.data)
+                    dojo_dispatch_task(task, engagement.id, **epic_kwargs)
                 response = Response(
                     {"info": "Jira Epic update query sent"},
                     status=status.HTTP_200_OK,
@@ -358,7 +361,7 @@ class EngagementViewSet(
             else:
                 task = jira_services.get_epic_task("add_epic")
                 if task:
-                    dojo_dispatch_task(task, engagement.id, **request.data)
+                    dojo_dispatch_task(task, engagement.id, **epic_kwargs)
                 response = Response(
                     {"info": "Jira Epic create query sent"},
                     status=status.HTTP_200_OK,

--- a/unittests/test_permissions_audit.py
+++ b/unittests/test_permissions_audit.py
@@ -13,9 +13,11 @@ Tests verify:
 9. Finding Templates exposure via find_template_to_apply (H1 #3577363)
 10. Jira Epic BFLA - Reader cannot trigger update_jira_epic (H1 #3577193)
 11. Risk Acceptance remove_finding: edit_mode guard + scoped finding lookup (PR #14633)
+12. Jira Epic dispatch: the request body cannot set dispatcher control kwargs (H1 #3949034)
 """
 import datetime
-from unittest import skip
+import uuid
+from unittest import mock, skip
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client
@@ -29,6 +31,8 @@ from dojo.authorization.models import (
     Product_Type_Member,
     Role,
 )
+from dojo.celery_dispatch import dojo_dispatch_task
+from dojo.jira import services as jira_services
 from dojo.models import (
     Answered_Survey,
     Benchmark_Category,
@@ -1324,6 +1328,41 @@ class TestJiraEpicBFLA(LegacyAuthMirrorMixin, DojoTestCase):
         response = client.post(url, data={}, format="json")
         # Writer has Engagement_Edit, so should pass permission check.
         self.assertEqual(response.status_code, 200)
+
+    def test_request_body_cannot_set_dispatch_kwargs(self):
+        """H1 #3949034: only the declared epic fields reach the dispatcher."""
+        superuser = Dojo_User.objects.create_user(
+            username="jira_epic_super",
+            password="testTEST1234!@#$",  # noqa: S106
+            is_active=True,
+            is_superuser=True,
+        )
+        client = self._client_for_user(self.writer_user)
+        url = reverse("engagement-update-jira-epic", args=(self.engagement.id,))
+        with mock.patch("dojo.engagement.api.views.dojo_dispatch_task") as dispatch:
+            response = client.post(url, data={
+                "epic_name": "kept",
+                "async_user_id": superuser.pk,
+                "_pgh_context": {"id": str(uuid.uuid4()), "metadata": {"user": superuser.pk}},
+                "force_sync": True,
+            }, format="json")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(dispatch.call_args.kwargs, {"epic_name": "kept"})
+
+    def test_dispatch_rejects_reserved_kwargs(self):
+        """H1 #3949034: the dispatcher refuses its own control kwargs from a caller."""
+        task = jira_services.get_epic_task("add_epic")
+        for key in ("async_user_id", "_pgh_context"):
+            with self.subTest(key=key), self.assertRaises(ValueError):
+                dojo_dispatch_task(task, self.engagement.id, **{key: 1})
+
+    def test_non_mapping_body_is_rejected(self):
+        """H1 #3949034: a JSON array body is a 400, not an unhandled 500."""
+        client = self._client_for_user(self.writer_user)
+        url = reverse("engagement-update-jira-epic", args=(self.engagement.id,))
+        response = client.post(url, data=[1, 2, 3], format="json")
+        self.assertEqual(response.status_code, 400)
 
 
 class TestRelatedObjectPermissions(LegacyAuthMirrorMixin, DojoTestCase):


### PR DESCRIPTION
`POST /api/v2/engagements/{id}/update_jira_epic/` passed the whole request body into the Celery
dispatcher as keyword arguments. The action's schema already advertises
`EngagementUpdateJiraEpicSerializer`, but the code never instantiated it. Two results: any key a
client sent became a dispatcher keyword, and a body that was not a JSON object raised an unhandled
500.

This change uses that serializer, so only `epic_name` and `epic_priority` reach the dispatcher, and
a non-object body returns 400.

`dojo_dispatch_task` now also rejects `async_user_id` and `_pgh_context` when a caller supplies
them. The dispatcher injects both itself, and no call site in the codebase passes either one, so
this just makes the contract explicit.

## Behaviour changes

All of these are the declared schema being enforced. Nothing in the codebase sends any of them.

- `force_sync`, `force_async`, `countdown` and `ignore_result` stop affecting this action.
- An empty `epic_name`, or one over 200 characters, now returns 400.
- `epic_priority: null` still passes through. Both tasks already handle `None`.

## Tests

Three regression tests in the existing `unittests/test_permissions_audit.py::TestJiraEpicBFLA`. Each
one fails without this change.
