### PR TITLE
Validate the request body on a finding metadata PUT

### DIFF
--- a/dojo/finding/api/views.py
+++ b/dojo/finding/api/views.py
@@ -749,17 +749,23 @@ class FindingViewSet(
                 "Metadata name is required", status=status.HTTP_400_BAD_REQUEST,
             )
 
+        metadata_data = FindingMetaSerializer(data=request.data)
+        if not metadata_data.is_valid():
+            return Response(
+                metadata_data.errors, status=status.HTTP_400_BAD_REQUEST,
+            )
+
         try:
             DojoMeta.objects.update_or_create(
                 name=metadata_name,
                 finding=finding,
                 defaults={
-                    "name": request.data.get("name"),
-                    "value": request.data.get("value"),
+                    "name": metadata_data.validated_data["name"],
+                    "value": metadata_data.validated_data["value"],
                 },
             )
 
-            return Response(data=request.data, status=status.HTTP_200_OK)
+            return Response(data=metadata_data.data, status=status.HTTP_200_OK)
         except IntegrityError:
             return Response(
                 "Update failed because the new name already exists",

--- a/unittests/test_rest_framework.py
+++ b/unittests/test_rest_framework.py
@@ -2490,6 +2490,26 @@ class FindingMetadataTest(BaseClass.BaseClassTest):
         self.assertEqual(result["name"], "test_meta", "Metadata not edited correctly")
         self.assertEqual(result["value"], "40", "Metadata not edited correctly")
 
+    def test_update_rejects_oversized_value(self):
+        response = self.client.put(
+            self.base_url + "?name=test_meta",
+            data={"name": "test_meta", "value": "x" * 301},
+        )
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code, response.data)
+
+        result = self.client.get(self.base_url).data[0]
+        self.assertEqual(result["value"], "20", "Rejected update still wrote to the database")
+
+    def test_update_rejects_missing_name(self):
+        response = self.client.put(self.base_url + "?name=test_meta", data={"value": "40"})
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code, response.data)
+        # The unvalidated path also 400s here, but via IntegrityError with a misleading message.
+        self.assertIsInstance(response.data, dict, response.data)
+        self.assertIn("name", response.data)
+
+        result = self.client.get(self.base_url).data[0]
+        self.assertEqual(result["value"], "20", "Rejected update still wrote to the database")
+
     def test_delete(self):
         self.client.delete(self.base_url + "?name=test_meta")
         result = self.client.get(self.base_url).data


### PR DESCRIPTION
**Description**

`_edit_metadata` handles the PUT on `/api/v2/findings/{id}/metadata/`. It declares `FindingMetaSerializer` in its schema. It never builds that serializer. It reads `name` and `value` off `request.data` and writes them straight into `update_or_create`.

Two things go wrong:

- If a client sends a `value` longer than 300 characters, Postgres raises `DataError`. The `except IntegrityError` below does not catch `DataError`. The caller gets a 500.
- If a client omits `name`, the code writes NULL. The caller gets a 400, but the message says "Update failed because the new name already exists". That message is wrong.

`_add_metadata` sits directly below and handles the POST. It already validates the same body with the same serializer. This change makes the PUT branch do the same.

One other change: the 200 response now returns the serialized `name` and `value`. Before, it echoed the raw request body.

**Test results**

I added two tests to `FindingMetadataTest` in `unittests/test_rest_framework.py`. I ran the class both ways.

| | Result |
|---|---|
| With the fix | `Ran 22 tests ... OK (skipped=10)` |
| Without the fix | `FAILED (failures=2, skipped=10)` |

The unfixed run shows the bug:

```
django.db.utils.DataError: value too long for type character varying(300)
AssertionError: 400 != 500
```

Ruff 0.16.0 passes.

**Documentation**

No documentation change. The endpoint contract stays the same. The declared schema already promised this validation.

**Checklist**

- [x] Bugfix, submitted against `bugfix`.
- [x] Code is Ruff compliant.
- [x] Tests added to the unit tests.
- [x] No model change, so no migration.
- [x] No new settings.
