### PR TITLE
docs(pro): custom fields on the create and edit forms

### DIFF
--- a/docs/content/asset_modelling/PRO__custom_fields.md
+++ b/docs/content/asset_modelling/PRO__custom_fields.md
@@ -1,6 +1,6 @@
 ---
 title: "Custom Fields"
-description: "Define typed custom fields per record type, fill them in on each record, and turn them on as typed table columns"
+description: "Define typed custom fields per record type, fill them in on the forms and on each record, and turn them on as typed table columns"
 audience: pro
 weight: 7
 ---
@@ -42,6 +42,8 @@ add the fields that apply to it. Each definition has:
   suggested automatically from the label and can be edited before you save.
 - **Data type**: one of seven types, which fixes how the value is entered, validated, filtered, and
   sorted.
+- **Required**: whether a value has to be filled in on the record type's create and edit forms. A
+  required field always appears on those forms and cannot be hidden from them.
 
 ### Data types
 
@@ -70,6 +72,26 @@ Risk Acceptances.
 
 If no fields are defined for the record type yet, the editor says so, and an administrator can define
 them under **Settings → Configuration → Custom Fields**.
+
+## Custom fields on the create and edit forms
+
+Custom fields also appear on the create and edit forms for their record type, so a value can be filled
+in while the record is being created rather than only afterwards. Each field uses the same input as the
+typed editor, and is validated the same way when the form is submitted.
+
+By default custom fields appear at the end of the **Optional Fields** section. An administrator can
+change that for each form under **Settings → UI Defaults → Form Configuration**, where every custom
+field is listed alongside the built-in fields and can be moved into the main body of the form, hidden,
+made required for that form, or reordered. See
+[Configuring Forms](../../navigation/pro__form_configuration/) for how those controls work.
+
+A field marked **Required** when it was defined is required on every form for its record type: the form
+cannot be submitted until it has a value, and it cannot be hidden. Form Configuration can additionally
+require a field that was not defined as required, which applies to that one form.
+
+Custom field values are stored separately from the record itself, so they are saved immediately after
+the record is. If a value cannot be saved, the record is still created or updated and a message names
+the fields that were not saved.
 
 ## Showing custom fields on a record's page
 

--- a/docs/content/navigation/PRO__form_configuration.md
+++ b/docs/content/navigation/PRO__form_configuration.md
@@ -29,6 +29,20 @@ For a configurable field you can set:
 - **Required**, which makes the field mandatory. Someone filling in the form cannot submit it until the field has a value.
 - **Disabled**, which takes the field off the form entirely.
 
+## Custom fields
+
+If [Custom Fields](../../asset_modelling/pro__custom_fields/) is enabled, the fields defined for a
+form's record type are listed here too, marked **Custom Field**, and configure exactly like the
+built-in ones. They start in the Optional Fields section, so this page is where you promote one into
+the body of the form, hide it, require it, or move it in the order.
+
+A custom field defined as required carries **Always Required**: it cannot be hidden or made optional
+here, though you can still change where it appears. Requiring a custom field on this page instead
+makes it mandatory on this form only, leaving the same field optional elsewhere.
+
+Only forms whose records can carry custom fields list them: Organizations, Assets, Engagements, Tests,
+Findings, and Risk Acceptances. The Import Scan, Reimport Scan, and JIRA Instance forms do not.
+
 ## Changing the order
 
 Drag the handle at the left of a row to change the order fields render in. This controls the sequence only. Whether a field sits in the body of the form or in Optional Fields is still governed by its Placement setting, so reordering a field will not move it between the two sections.


### PR DESCRIPTION
## Description

Documentation for a DefectDojo Pro change: custom fields now render on the create and edit forms for the six record types that can carry them (Organizations, Assets, Engagements, Tests, Findings, Risk Acceptances), and are listed in Form Configuration alongside the built-in fields.

Two pages change:

**Custom Fields** (`docs/content/asset_modelling/PRO__custom_fields.md`)
- Documents the **Required** attribute on a field definition.
- Adds a section covering where custom fields appear on a form, that they default to the Optional Fields section, and how an administrator changes that per form.
- Explains how a definition-level Required composes with requiring a field on one particular form.
- Notes that values are stored separately from the record and saved immediately after it, so a value that fails to save does not lose the record.

**Configuring Forms** (`docs/content/navigation/PRO__form_configuration.md`)
- Adds a Custom fields section: they are listed like built-in fields, marked as custom, and configure the same way.
- Covers the Always Required state for a field defined as required, and which forms list custom fields at all.

Docs only, no code changes.
