### PR TITLE
docs(connectors): explain the two wiz data classes and the import filter

### DIFF
--- a/docs/content/connectors/toolreference/wiz.md
+++ b/docs/content/connectors/toolreference/wiz.md
@@ -26,8 +26,8 @@ The service account must meet all of the following requirements. A service accou
 
 Wiz serves two different data classes, and the connector imports both by default:
 
-* **Issues** — a Wiz Control fired on a resource. These are policy and posture violations. A typical tenant has hundreds or thousands.
-* **Vulnerability Findings** — one CVE on one package on one asset. A tenant with a few thousand assets can hold millions, because each asset carries many packages and each package can carry many CVEs.
+* **Issues**: a Wiz Control fired on a resource. These are policy and posture violations. A typical tenant has hundreds or thousands.
+* **Vulnerability Findings**: one CVE on one package on one asset. A tenant with a few thousand assets can hold millions. Each asset carries many packages, and each package can carry many CVEs.
 
 If your DefectDojo finding count is far higher than your asset count, Vulnerability Findings are the reason. That is expected: a finding is one problem on one asset, not one asset.
 
@@ -35,7 +35,7 @@ Deselect **Vulnerability Findings** to import Issues only. The connector then sk
 
 Two things to know before you change this setting:
 
-* **Changing it triggers one full resync.** The connector normally asks Wiz only for what changed since the last sync. That cursor is cleared when you change the selection, so the next sync re-reads everything. Without the reset, re-enabling a data class would never backfill the rows it skipped while it was off.
-* **Deselecting a data class closes its existing findings.** The next sync sends none of that class, and DefectDojo closes what it no longer receives. If you turn off Vulnerability Findings on a connector that already imported a million of them, that sync closes a million findings.
+* **Changing it triggers one full resync.** The connector normally asks Wiz only for what changed since the last sync. That cursor is cleared when you change the selection, so the next sync re-reads everything. Without the reset, re-enabling a data class never backfills the rows it skipped while it was off.
+* **Deselecting a data class closes its existing findings.** The next sync sends none of that class, and DefectDojo closes what it no longer receives. Suppose you turn off Vulnerability Findings on a connector that already imported a million of them. That sync closes all one million.
 
 Minimum Severity is a separate control and cannot be changed after the connector is created.

--- a/docs/content/connectors/toolreference/wiz.md
+++ b/docs/content/connectors/toolreference/wiz.md
@@ -20,3 +20,22 @@ The service account must meet all of the following requirements. A service accou
 
 1. Enter your Wiz Client ID in the Client ID field.
 2. Enter the Wiz Client Secret in the Secret field.
+3. Choose which data classes to import in **Import Finding Types**. Both are selected by default.
+
+#### **Import Finding Types**
+
+Wiz serves two different data classes, and the connector imports both by default:
+
+* **Issues** — a Wiz Control fired on a resource. These are policy and posture violations. A typical tenant has hundreds or thousands.
+* **Vulnerability Findings** — one CVE on one package on one asset. A tenant with a few thousand assets can hold millions, because each asset carries many packages and each package can carry many CVEs.
+
+If your DefectDojo finding count is far higher than your asset count, Vulnerability Findings are the reason. That is expected: a finding is one problem on one asset, not one asset.
+
+Deselect **Vulnerability Findings** to import Issues only. The connector then skips the vulnerability query entirely, so nothing is fetched from Wiz rather than fetched and discarded.
+
+Two things to know before you change this setting:
+
+* **Changing it triggers one full resync.** The connector normally asks Wiz only for what changed since the last sync. That cursor is cleared when you change the selection, so the next sync re-reads everything. Without the reset, re-enabling a data class would never backfill the rows it skipped while it was off.
+* **Deselecting a data class closes its existing findings.** The next sync sends none of that class, and DefectDojo closes what it no longer receives. If you turn off Vulnerability Findings on a connector that already imported a million of them, that sync closes a million findings.
+
+Minimum Severity is a separate control and cannot be changed after the connector is created.


### PR DESCRIPTION
Documents the two data classes the Wiz connector imports, and the new Import Finding Types control that lets a user pick between them.

Background, because the finding counts confuse people: Wiz serves Issues and Vulnerability Findings on one connector. An Issue is a Wiz Control firing on a resource, and a tenant has hundreds or thousands. A Vulnerability Finding is one CVE on one package on one asset, and a tenant can have millions. A support ticket asked why DefectDojo showed 1.2 million findings for an environment with far fewer objects. This page now answers that.

The page also documents two things a user needs to know before changing the setting. Changing it clears the delta cursor, so the next sync re-reads everything. Deselecting a data class closes that class's existing findings.

Only the English page changes. The docs pipeline owns the translations.

Pairs with the DefectDojo Pro change that adds the control.
