### PR TITLE
Scope engagement related-object choices to the caller's authorized queryset

### DIFF
--- a/dojo/engagement/api/serializer.py
+++ b/dojo/engagement/api/serializer.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from rest_framework import serializers
 
 from dojo.models import Check_List, Engagement, Engagement_Presets
+from dojo.product.queries import get_authorized_engagement_presets
 
 
 class EngagementSerializer(serializers.ModelSerializer):
@@ -15,6 +16,8 @@ class EngagementSerializer(serializers.ModelSerializer):
         )
         fields = super().get_fields()
         fields["tags"] = TagListSerializerField(required=False)
+        if preset := fields.get("preset"):
+            preset.queryset = get_authorized_engagement_presets("view")
         return fields
 
     def validate(self, data):

--- a/unittests/test_fk_reassignment_authorization.py
+++ b/unittests/test_fk_reassignment_authorization.py
@@ -297,6 +297,75 @@ class TestFKReassignmentAuthorization(LegacyAuthMirrorMixin, DojoTestCase):
         self.assertEqual(preset.product_id, self.product_src.id)
 
     # ────────────────────────────────────────────────────────────────────
+    # EngagementSerializer.preset (sibling FK; the preset's own fields are
+    # rendered back on the engagement page and its exports)
+    # ────────────────────────────────────────────────────────────────────
+    def _outside_preset(self):
+        return Engagement_Presets.objects.create(
+            title="FK Reassign Outside Preset",
+            product=self.product_outside,
+            notes="outside notes",
+            scope="outside scope",
+        )
+
+    def test_engagement_patch_preset_to_unauthorized_blocked(self):
+        preset = self._outside_preset()
+        r = self._client().patch(
+            reverse("engagement-detail", args=(self.engagement_src.id,)),
+            {"preset": preset.id},
+            format="json",
+        )
+        self._assert_rejected(r)
+        self.engagement_src.refresh_from_db()
+        self.assertIsNone(self.engagement_src.preset_id)
+
+    def test_engagement_put_preset_to_unauthorized_blocked(self):
+        preset = self._outside_preset()
+        r = self._client().put(
+            reverse("engagement-detail", args=(self.engagement_src.id,)),
+            {
+                "name": self.engagement_src.name,
+                "product": self.product_src.id,
+                "preset": preset.id,
+                "target_start": "2024-01-01",
+                "target_end": "2024-12-31",
+            },
+            format="json",
+        )
+        self._assert_rejected(r)
+        self.engagement_src.refresh_from_db()
+        self.assertIsNone(self.engagement_src.preset_id)
+
+    def test_engagement_create_with_unauthorized_preset_blocked(self):
+        preset = self._outside_preset()
+        r = self._client().post(
+            reverse("engagement-list"),
+            {
+                "name": "FK Reassign Preset Create",
+                "product": self.product_src.id,
+                "preset": preset.id,
+                "target_start": "2024-01-01",
+                "target_end": "2024-12-31",
+            },
+            format="json",
+        )
+        self._assert_rejected(r)
+        self.assertFalse(Engagement.objects.filter(preset=preset).exists())
+
+    def test_engagement_patch_preset_to_owned_allowed(self):
+        preset = Engagement_Presets.objects.create(
+            title="FK Reassign Owned Preset", product=self.product_src, scope="x",
+        )
+        r = self._client().patch(
+            reverse("engagement-detail", args=(self.engagement_src.id,)),
+            {"preset": preset.id},
+            format="json",
+        )
+        self.assertEqual(r.status_code, 200, r.content[:500])
+        self.engagement_src.refresh_from_db()
+        self.assertEqual(self.engagement_src.preset_id, preset.id)
+
+    # ────────────────────────────────────────────────────────────────────
     # BurpRawRequestResponseMultiSerializer.finding
     # ────────────────────────────────────────────────────────────────────
     def test_burp_request_response_finding_reassignment_blocked(self):


### PR DESCRIPTION
Hardening / consistency improvement to the engagement API. One related-object field on the engagement serializer accepted any row in its table, while the classic engagement form and the read endpoint for that table both already narrow it to the caller's authorized queryset. This makes the API agree with them, and adds regression tests for create, update and replace.

No functional change for correctly-permissioned users.