### PR TITLE
docs(mcp): state that active_* summary counts ignore verified status

### DIFF
--- a/docs/content/metrics_reports/ai/mcp_server_pro.md
+++ b/docs/content/metrics_reports/ai/mcp_server_pro.md
@@ -397,6 +397,11 @@ get_findings({
 
 **Description:** Retrieve aggregate finding metrics in a single call, rather than fetching findings and counting them. Returns counts by severity, average priority and risk score, average finding age, and the most common CWEs.
 
+> **Note on counts:** The `active_*` counts cover every active finding, whether or not it has
+> been verified. Verified findings are reported separately as `verified_findings` and
+> `active_verified_findings`, so one call gives you both views. The **Enforce Verified Status**
+> system settings do not narrow these counts.
+
 **Parameters:**
 
 **product_id** (Optional)
@@ -435,6 +440,11 @@ finding_summary({
 <summary><h4>risk_summary</h4></summary>
 
 **Description:** Retrieve the aggregate risk posture for a single product, including average priority, risk score, active finding counts, and business criticality.
+
+> **Note on counts:** The `active_*` counts cover every active finding, whether or not it has
+> been verified. Verified findings are reported separately as `verified_findings` and
+> `active_verified_findings`, so one call gives you both views. The **Enforce Verified Status**
+> system settings do not narrow these counts.
 
 **Parameters:**
 


### PR DESCRIPTION
[sc-14856]

## Description

Documents how the `finding_summary` and `risk_summary` MCP tools count findings.

Both tools return `active_*` counts alongside separate `verified_findings` and
`active_verified_findings` counts. The page described the parameters but never said what the
`active_*` counts include, which left it ambiguous whether verification narrows them. It does
not: the `active_*` counts cover every active finding regardless of verification status, and
the **Enforce Verified Status** system settings do not restrict them.

Adds a short note to both tool sections of
`docs/content/metrics_reports/ai/mcp_server_pro.md` saying so.

This pairs with a Pro change on the same release line that makes the server behave as
documented — previously the counts were silently narrowed to verified findings only, which on
an instance with nothing verified reported zero active findings for products that had
hundreds.

Only the English page is updated; the translated variants are left for the normal translation
pass.
