### PR TITLE
fix(jira): gate the legacy endpoints block in the classic issue templates

### DIFF
--- a/dojo/templates_classic/issue-trackers/jira_full/jira-description.tpl
+++ b/dojo/templates_classic/issue-trackers/jira_full/jira-description.tpl
@@ -43,13 +43,23 @@
 *Commit hash:* {{ finding.test.engagement.commit_hash }}
 {% endif %}
 
+{% if V3_FEATURE_LOCATIONS %}
+{% if finding.locations.all %}
+*Systems/Locations*:
+||Location||Status||
+{% for location_ref in finding.locations.all %}|{{ location_ref.location }}|{{ location_ref.get_status_display }}|
+{% endfor %}
+{% endif %}
+{% else %}
+{% comment %} TODO: Delete this after the move to Locations {% endcomment %}
 {% if finding.endpoints.all %}
 *Systems/Endpoints*:
 ||System/Endpoint||Status||
 {% for endpoint in finding|get_vulnerable_endpoints %}|{{ endpoint }}|{{ endpoint|endpoint_display_status:finding }}|
 {% endfor %}{% for endpoint in finding|get_mitigated_endpoints %}|{{ endpoint }}|{{ endpoint|endpoint_display_status:finding }}|
 {% endfor %}
-{%endif%}
+{% endif %}
+{% endif %}
 
 
 {% if finding.component_name %}

--- a/dojo/templates_classic/issue-trackers/jira_full/jira-finding-group-description.tpl
+++ b/dojo/templates_classic/issue-trackers/jira_full/jira-finding-group-description.tpl
@@ -47,13 +47,23 @@ h3. [{{ finding.title|jiraencode}}|{{ finding_url|full_url }}]
 {% if finding.cve %}*CVE:* [{{ finding.cve }}|{{ finding.cve|vulnerability_url }}]{% else %}*CVE:* Unknown{% endif %}
 {% if finding.cvssv3_score %} *CVSSv3 Score:* {{ finding.cvssv3_score }} {% endif %}
 
+{% if V3_FEATURE_LOCATIONS %}
+{% if finding.locations.all %}
+*Systems/Locations*:
+||Location||Status||
+{% for location_ref in finding.locations.all %}|{{ location_ref.location }}|{{ location_ref.get_status_display }}|
+{% endfor %}
+{% endif %}
+{% else %}
+{% comment %} TODO: Delete this after the move to Locations {% endcomment %}
 {% if finding.endpoints.all %}
 *Systems/Endpoints*:
 ||System/Endpoint||Status||
 {% for endpoint in finding|get_vulnerable_endpoints %}|{{ endpoint }}|{{ endpoint|endpoint_display_status:finding }}|
 {% endfor %}{% for endpoint in finding|get_mitigated_endpoints %}|{{ endpoint }}|{{ endpoint|endpoint_display_status:finding }}|
 {% endfor %}
-{%endif%}
+{% endif %}
+{% endif %}
 
 {% if finding.sast_source_object %}
 *Source Object*: {{ finding.sast_source_object }}


### PR DESCRIPTION
**Description**

When `V3_FEATURE_LOCATIONS` is on, pushing a finding to JIRA or GitHub returns a 500.

The JIRA description templates have two copies. The Tailwind copy under `dojo/templates/issue-trackers/` got a `{% if V3_FEATURE_LOCATIONS %}` gate that renders `finding.locations` instead of `finding.endpoints`. The classic copy under `dojo/templates_classic/issue-trackers/` did not. `UIPreferenceLoader` puts the classic tree first for every user who has not opted into the Tailwind UI, so the ungated copy is what most deployments render.

The ungated block does `{% if finding.endpoints.all %}`. A tenant migrated to Locations keeps its legacy `Endpoint` rows on purpose, so that queryset hydrates a deprecated `Endpoint` and `Endpoint.__init__` raises `NotImplementedError`.

This PR copies the same gate into both classic templates:

- `dojo/templates_classic/issue-trackers/jira_full/jira-description.tpl`
- `dojo/templates_classic/issue-trackers/jira_full/jira-finding-group-description.tpl`

The group template gets it too. `jira_description()` renders that one for a finding-group push, and it carried the identical ungated block.

`jira_description()` and `github_body()` already pass `V3_FEATURE_LOCATIONS` into the context, so no Python change is needed.

**Test results**

Two tests in `unittests/test_endpoint_init_v3.py` already covered this and were failing:

- `TestEndpointInitV3.test_jira_description_renders_locations_under_v3`
- `TestEndpointInitV3.test_github_body_renders_locations_under_v3`

Before, with `DD_V3_FEATURE_LOCATIONS=True`:

```
Ran 2 tests
FAILED (errors=2)
NotImplementedError: Endpoint model is deprecated when V3_FEATURE_LOCATIONS is enabled
  File "dojo/jira/helper.py", line 765, in jira_description
    description = render_to_string(template, kwargs)
  ...
  File "django/template/defaulttags.py", line 326, in render
    if match:
```

After:

```
Ran 2 tests
OK
```

`unittests/test_jira_helper.py` still passes (47 tests). No test asserts the rendered description text, so nothing else changes.

**Documentation**

No documentation change. This restores the behavior the Locations docs already describe.
