### PR TITLE
fix(api): return a boolean from endpoint_status mitigated under V3 Locations

### DIFF
--- a/docs/content/asset_modelling/locations/PRO__migrating_from_endpoints.md
+++ b/docs/content/asset_modelling/locations/PRO__migrating_from_endpoints.md
@@ -97,6 +97,7 @@ A few things behave differently from the original Endpoint API:
 
 - **Single status instead of flags.** Locations have one status at a time. If your code relied on a Finding being *both* `mitigated=True` *and* `false_positive=True` simultaneously on an Endpoint_Status, that is no longer representable — the migration picks the highest-priority flag (the order shown in the table above).
 - **`endpoint` field on Endpoint_Status.** The legacy `endpoint` field is reconstructed by looking up the matching Asset Reference. In rare cases where a Finding's Asset no longer matches its Location's Asset references, this field may be null.
+- **`mitigated` returned a date before 3.2.400.** On releases before 3.2.400 the `mitigated` field of `/api/v2/endpoint_status/` returned the record's creation date instead of a boolean. Because a date string is truthy, `mitigated_time` and `mitigated_by` answered as though every status was mitigated. From 3.2.400 the field is a boolean that is true only when the Location status is `Mitigated`. If you poll for mitigated statuses, upgrade before you trust this field.
 - **Pagination and ordering.** Available ordering fields on the read-compat shim are `host`, `product`, `id`, and `active_finding_count`. If your client orders by another field, switch to one of these or move to the new Locations endpoints.
 
 ## Tags and Metadata

--- a/dojo/location/api/endpoint_compat.py
+++ b/dojo/location/api/endpoint_compat.py
@@ -273,7 +273,7 @@ class V3EndpointStatusCompatibleSerializer(ModelSerializer):
         return obj.created.date() if obj.created else None
 
     def get_mitigated(self, obj) -> bool | None:
-        return obj.created.date() if obj.created else None
+        return obj.status == FindingLocationStatus.Mitigated
 
     def get_mitigated_time(self, obj) -> datetime.datetime | None:
         return obj.audit_time if self.get_mitigated(obj) else None

--- a/unittests/test_endpoint_init_v3.py
+++ b/unittests/test_endpoint_init_v3.py
@@ -31,6 +31,7 @@ from django.test import Client
 from django.urls import reverse
 from django.utils import timezone
 from openpyxl import load_workbook
+from parameterized import parameterized
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
@@ -38,6 +39,7 @@ from dojo.finding.deduplication import get_finding_models_for_deduplication
 from dojo.finding.helper import post_process_findings_batch
 from dojo.github.services import github_body
 from dojo.jira.helper import jira_description
+from dojo.location.api.endpoint_compat import V3EndpointStatusCompatibleSerializer
 from dojo.location.models import LocationFindingReference, LocationProductReference
 from dojo.location.status import FindingLocationStatus, ProductLocationStatus
 from dojo.models import (
@@ -335,3 +337,54 @@ class TestEndpointInitV3(DojoTestCase):
         )
 
         self.assertTrue(Finding.objects.filter(id=tree.finding.id).exists())
+
+    # ------------------------------------------------------------------
+    # endpoint_status compatibility serializer
+    # ------------------------------------------------------------------
+    # Regression: V3EndpointStatusCompatibleSerializer.get_mitigated returned obj.created.date()
+    # (a copy of get_date) instead of the Mitigated status, so every row reported a truthy date.
+    @parameterized.expand([
+        (FindingLocationStatus.Active, False),
+        (FindingLocationStatus.Mitigated, True),
+        (FindingLocationStatus.FalsePositive, False),
+        (FindingLocationStatus.RiskAccepted, False),
+        (FindingLocationStatus.OutOfScope, False),
+    ])
+    def test_endpoint_status_mitigated_is_a_bool_tracking_the_status(self, status, expected):
+        """``mitigated`` must be a bool that is True only for a Mitigated location."""
+        tree = self._make_tree(f"mit-{status.value}")
+        ref = self._add_location(tree, f"loc-{status.value.lower()}.example.com", status=status)
+
+        data = V3EndpointStatusCompatibleSerializer(ref).data
+
+        self.assertIsInstance(
+            data["mitigated"], bool,
+            msg=f"expected a bool for status={status.value}, got {type(data['mitigated']).__name__} {data['mitigated']!r}",
+        )
+        self.assertEqual(
+            data["mitigated"], expected,
+            msg=f"expected mitigated={expected} for status={status.value}, got {data['mitigated']!r}",
+        )
+
+    @parameterized.expand([
+        (FindingLocationStatus.Active, False),
+        (FindingLocationStatus.Mitigated, True),
+    ])
+    def test_endpoint_status_mitigated_time_and_by_follow_mitigated(self, status, expected):
+        """``mitigated_time``/``mitigated_by`` branch on get_mitigated, so they must follow it."""
+        tree = self._make_tree(f"mitby-{status.value}")
+        ref = self._add_location(tree, f"loc-mitby-{status.value.lower()}.example.com", status=status)
+        ref.auditor = self.admin
+        ref.audit_time = timezone.now()
+        ref.save()
+
+        data = V3EndpointStatusCompatibleSerializer(ref).data
+
+        self.assertEqual(
+            data["mitigated_time"] is not None, expected,
+            msg=f"expected mitigated_time set={expected} for status={status.value}, got {data['mitigated_time']!r}",
+        )
+        self.assertEqual(
+            data["mitigated_by"], self.admin.id if expected else None,
+            msg=f"expected mitigated_by set={expected} for status={status.value}, got {data['mitigated_by']!r}",
+        )


### PR DESCRIPTION
**Description**

`V3EndpointStatusCompatibleSerializer.get_mitigated` returned a date instead of a boolean. It was a copy of `get_date` two methods above it:

```python
def get_mitigated(self, obj) -> bool | None:
    return obj.created.date() if obj.created else None
```

On a tenant with `V3_FEATURE_LOCATIONS` enabled, this affects three fields of `GET /api/v2/endpoint_status/`:

- `mitigated` reports a date string on every row instead of `true`/`false`.
- `mitigated_time` and `mitigated_by` both branch on `self.get_mitigated(obj)`. A date is truthy, so both answer as though every status is mitigated.

A client polling for mitigated statuses gets a wrong answer and no error.

The fix compares the status, which is what the three sibling methods below it (`get_false_positive`, `get_out_of_scope`, `get_risk_accepted`) already do:

```python
def get_mitigated(self, obj) -> bool | None:
    return obj.status == FindingLocationStatus.Mitigated
```

**Test results**

Two new regression tests in `unittests/test_endpoint_init_v3.py`:

- `test_endpoint_status_mitigated_is_a_bool_tracking_the_status` asserts `mitigated` is a `bool` and is true only for `Mitigated`. It runs over all five `FindingLocationStatus` values.
- `test_endpoint_status_mitigated_time_and_by_follow_mitigated` asserts `mitigated_time` and `mitigated_by` stay null when the location is not mitigated.

Before the fix, 6 of the 7 cases failed:

```
AssertionError: datetime.date(2026, 8, 26) is not an instance of <class 'bool'> :
expected a bool for status=Active, got date datetime.date(2026, 8, 26)
```

The `Mitigated` case of the first test passed before the fix as well, because the date was truthy. It is the control case.

After the fix all 7 cases pass. Five other tests in that module fail on my local stack, before and after this change, because the stack forces `SECURE_SSL_REDIRECT = True` and they get a 301. They are unrelated to this change.

**Documentation**

`docs/content/asset_modelling/locations/PRO__migrating_from_endpoints.md` gains a bullet under "Behavioural Differences to Watch For" that records the old behavior, so a reader on an older release knows the field cannot be trusted.

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [x] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.
