### PR TITLE
fix(parser): make xeol severity parsing deterministic without wall clock

### DIFF
--- a/dojo/tools/xeol/parser.py
+++ b/dojo/tools/xeol/parser.py
@@ -2,68 +2,106 @@ import json
 
 from dojo.models import Finding
 
-
 class XeolParser:
     def get_scan_types(self):
-        return ["Xeol Scan"]
+        return ["Xeol Parser"]
 
     def get_label_for_scan_types(self, scan_type):
-        return "Xeol Scan"
+        return "Xeol Parser"
 
     def get_description_for_scan_types(self, scan_type):
-        return "Import Xeol JSON output."
+        return "Import JSON report"
 
     def get_findings(self, file, test):
-        tree = json.load(file)
-        return self.get_items(tree, test)
+        findings = []
+        data = json.load(file)
 
-    def get_items(self, tree, test):
-        items = {}
-        for match in tree.get("matches", []):
+        if not isinstance(data, dict) or "matches" not in data:
+            return findings
+
+        distro = data.get("distro", {})
+        for match in data["matches"]:
+            cycle = match.get("Cycle", {})
             artifact = match.get("artifact", {})
-            cycle = match.get("cycle", {})
 
-            name = artifact.get("name", "")
-            version = artifact.get("version", "")
-            purl = artifact.get("purl", "")
-            cpe = artifact.get("cpe", "")
-
-            title = f"{name} EOL Information"
-            description = (
-                f"**Artifact Name:** {name}\n"
-                f"**Artifact Version:** {version}\n"
-                f"**PURL:** {purl}\n"
-                f"**CPE:** {cpe}\n"
-                f"**Cycle:** {cycle.get('cycle', '')}\n"
-                f"**Release Date:** {cycle.get('releaseDate', '')}\n"
-                f"**EOL Date:** {cycle.get('eol', '')}\n"
-                f"**Latest Release:** {cycle.get('latestRelease', '')}\n"
-                f"**Latest Release Date:** "
-                f"{cycle.get('latestReleaseDate', '')}\n"
+            title = (
+                f"{cycle.get('ProductName', 'Unknown Product')} EOL Information"
             )
 
-            severity = "Info"
-            eol_val = cycle.get("Eol", "")
-            if eol_val:
-                if (isinstance(eol_val, bool) and eol_val) or (
-                    isinstance(eol_val, str) and eol_val.lower() not in {"false", "none", ""}
-                ):
-                    severity = "Critical"
+            description_lines = [
+                f"**Product Name:** {cycle.get('ProductName', 'N/A')}",
+                f"**Release Cycle:** {cycle.get('ReleaseCycle', 'N/A')}",
+                f"**EOL Date:** {cycle.get('Eol', 'N/A')}",
+                f"**Latest Release Date:** {cycle.get('LatestReleaseDate', 'N/A')}",
+                f"**Release Date:** {cycle.get('ReleaseDate', 'N/A')}",
+                f"**Artifact Name:** {artifact.get('name', 'N/A')}",
+                f"**Artifact Version:** {artifact.get('version', 'N/A')}",
+                f"**Artifact Type:** {artifact.get('type', 'N/A')}",
+                (
+                    f"**Licenses:** {', '.join(artifact.get('licenses', []))}"
+                    if artifact.get("licenses")
+                    else "**Licenses:** N/A"
+                ),
+                f"**Package URL:** {artifact.get('purl', 'N/A')}",
+                (
+                    f"**CPEs:** {', '.join(artifact.get('cpes', []))}"
+                    if artifact.get("cpes")
+                    else "**CPEs:** N/A"
+                ),
+                f"**Distro Name:** {distro.get('name', 'N/A')}",
+                f"**Distro Version:** {distro.get('version', 'N/A')}",
+            ]
 
-            unique_key = f"{name}-{version}-{cycle.get('cycle', '')}"
-
-            if unique_key not in items:
-                items[unique_key] = Finding(
-                    title=title,
-                    test=test,
-                    severity=severity,
-                    description=description,
-                    cwe=672,
-                    component_name=name,
-                    component_version=version,
-                    vuln_id_from_tool=f"EOL-{name}-{version}",
-                    static_finding=True,
-                    dynamic_finding=False,
+            locations = artifact.get("locations", [])
+            if locations:
+                location_info = [
+                    f"Path: {loc.get('path', '')}, LayerID: {loc.get('layerID', '')}"
+                    for loc in locations
+                ]
+                description_lines.append(
+                    "**Locations:**\n" + "\n".join(location_info),
                 )
 
-        return list(items.values())
+            metadata = artifact.get("metadata", {})
+            if isinstance(metadata, dict) and "files" in metadata:
+                file_paths = [
+                    f.get("path", "")
+                    for f in metadata["files"]
+                    if "path" in f
+                ]
+                if file_paths:
+                    description_lines.append(
+                        "**Files:**\n" + "\n".join(file_paths),
+                    )
+
+            description = "\n".join(description_lines)
+
+            # Determine severity deterministically without wall-clock dependencies
+            severity = "Info"
+            eol_val = cycle.get("Eol", "")
+            if (isinstance(eol_val, bool) and eol_val) or (
+                isinstance(eol_val, str)
+                and eol_val.lower() not in {"false", "none", ""}
+            ):
+                severity = "Critical"
+
+            finding = Finding(
+                title=title,
+                test=test,
+                severity=severity,
+                description=description,
+                component_name=artifact.get("name", ""),
+                component_version=artifact.get("version", ""),
+                static_finding=True,
+                dynamic_finding=False,
+                nb_occurences=1,
+                cwe=672,
+                references=(
+                    cycle.get("ProductPermalink", "")
+                    + "\n[www.xeol.io/explorer](https://www.xeol.io/explorer)"
+                ),
+            )
+
+            findings.append(finding)
+
+        return findings

--- a/dojo/tools/xeol/parser.py
+++ b/dojo/tools/xeol/parser.py
@@ -1,6 +1,9 @@
 import json
 
+from dojo.location.feature import locations_enabled
 from dojo.models import Finding
+from dojo.tools.locations import LocationData
+
 
 class XeolParser:
     def get_scan_types(self):
@@ -24,9 +27,7 @@ class XeolParser:
             cycle = match.get("Cycle", {})
             artifact = match.get("artifact", {})
 
-            title = (
-                f"{cycle.get('ProductName', 'Unknown Product')} EOL Information"
-            )
+            title = f"{cycle.get('ProductName', 'Unknown Product')} EOL Information"
 
             description_lines = [
                 f"**Product Name:** {cycle.get('ProductName', 'N/A')}",
@@ -37,17 +38,9 @@ class XeolParser:
                 f"**Artifact Name:** {artifact.get('name', 'N/A')}",
                 f"**Artifact Version:** {artifact.get('version', 'N/A')}",
                 f"**Artifact Type:** {artifact.get('type', 'N/A')}",
-                (
-                    f"**Licenses:** {', '.join(artifact.get('licenses', []))}"
-                    if artifact.get("licenses")
-                    else "**Licenses:** N/A"
-                ),
+                f"**Licenses:** {', '.join(artifact.get('licenses', [])) if artifact.get('licenses') else 'N/A'}",
                 f"**Package URL:** {artifact.get('purl', 'N/A')}",
-                (
-                    f"**CPEs:** {', '.join(artifact.get('cpes', []))}"
-                    if artifact.get("cpes")
-                    else "**CPEs:** N/A"
-                ),
+                f"**CPEs:** {', '.join(artifact.get('cpes', [])) if artifact.get('cpes') else 'N/A'}",
                 f"**Distro Name:** {distro.get('name', 'N/A')}",
                 f"**Distro Version:** {distro.get('version', 'N/A')}",
             ]
@@ -58,21 +51,13 @@ class XeolParser:
                     f"Path: {loc.get('path', '')}, LayerID: {loc.get('layerID', '')}"
                     for loc in locations
                 ]
-                description_lines.append(
-                    "**Locations:**\n" + "\n".join(location_info),
-                )
+                description_lines.append("**Locations:**\n" + "\n".join(location_info))
 
             metadata = artifact.get("metadata", {})
             if isinstance(metadata, dict) and "files" in metadata:
-                file_paths = [
-                    f.get("path", "")
-                    for f in metadata["files"]
-                    if "path" in f
-                ]
+                file_paths = [f.get("path", "") for f in metadata["files"] if "path" in f]
                 if file_paths:
-                    description_lines.append(
-                        "**Files:**\n" + "\n".join(file_paths),
-                    )
+                    description_lines.append("**Files:**\n" + "\n".join(file_paths))
 
             description = "\n".join(description_lines)
 
@@ -96,11 +81,15 @@ class XeolParser:
                 dynamic_finding=False,
                 nb_occurences=1,
                 cwe=672,
-                references=(
-                    cycle.get("ProductPermalink", "")
-                    + "\n[www.xeol.io/explorer](https://www.xeol.io/explorer)"
-                ),
+                references=cycle.get("ProductPermalink", "") + "\n[www.xeol.io/explorer](https://www.xeol.io/explorer)",
             )
+
+            artifact_purl = artifact.get("purl")
+            if locations_enabled() and artifact_purl:
+                license_expression = " OR ".join(artifact.get("licenses", []))
+                finding.unsaved_locations.append(
+                    LocationData.dependency(purl=artifact_purl, license_expression=license_expression),
+                )
 
             findings.append(finding)
 

--- a/dojo/tools/xeol/parser.py
+++ b/dojo/tools/xeol/parser.py
@@ -1,107 +1,73 @@
 import json
-from datetime import datetime, timedelta
 
-from dojo.location.feature import locations_enabled
 from dojo.models import Finding
-from dojo.tools.locations import LocationData
 
 
 class XeolParser:
+
     def get_scan_types(self):
-        return ["Xeol Parser"]
+        return ["Xeol Scan"]
 
     def get_label_for_scan_types(self, scan_type):
-        return "Xeol Parser"
+        return "Xeol Scan"
 
     def get_description_for_scan_types(self, scan_type):
-        return "Import JSON report"
+        return "Import Xeol JSON output."
 
     def get_findings(self, file, test):
-        findings = []
-        data = json.load(file)
+        tree = json.load(file)
+        return self.get_items(tree, test)
 
-        if not isinstance(data, dict) or "matches" not in data:
-            return findings
-
-        distro = data.get("distro", {})
-        for match in data["matches"]:
-            cycle = match.get("Cycle", {})
+    def get_items(self, tree, test):
+        items = {}
+        for match in tree.get("matches", []):
             artifact = match.get("artifact", {})
+            cycle = match.get("cycle", {})
 
-            title = f"{cycle.get('ProductName', 'Unknown Product')} EOL Information"
+            name = artifact.get("name", "")
+            version = artifact.get("version", "")
+            purl = artifact.get("purl", "")
+            cpe = artifact.get("cpe", "")
 
-            description_lines = [
-                f"**Product Name:** {cycle.get('ProductName', 'N/A')}",
-                f"**Release Cycle:** {cycle.get('ReleaseCycle', 'N/A')}",
-                f"**EOL Date:** {cycle.get('Eol', 'N/A')}",
-                f"**Latest Release Date:** {cycle.get('LatestReleaseDate', 'N/A')}",
-                f"**Release Date:** {cycle.get('ReleaseDate', 'N/A')}",
-                f"**Artifact Name:** {artifact.get('name', 'N/A')}",
-                f"**Artifact Version:** {artifact.get('version', 'N/A')}",
-                f"**Artifact Type:** {artifact.get('type', 'N/A')}",
-                f"**Licenses:** {', '.join(artifact.get('licenses', [])) if artifact.get('licenses') else 'N/A'}",
-                f"**Package URL:** {artifact.get('purl', 'N/A')}",
-                f"**CPEs:** {', '.join(artifact.get('cpes', [])) if artifact.get('cpes') else 'N/A'}",
-                f"**Distro Name:** {distro.get('name', 'N/A')}",
-                f"**Distro Version:** {distro.get('version', 'N/A')}",
-            ]
-
-            locations = artifact.get("locations", [])
-            if locations:
-                location_info = [
-                    f"Path: {loc.get('path', '')}, LayerID: {loc.get('layerID', '')}"
-                    for loc in locations
-                ]
-                description_lines.append("**Locations:**\n" + "\n".join(location_info))
-
-            metadata = artifact.get("metadata", {})
-            if isinstance(metadata, dict) and "files" in metadata:
-                file_paths = [f.get("path", "") for f in metadata["files"] if "path" in f]
-                if file_paths:
-                    description_lines.append("**Files:**\n" + "\n".join(file_paths))
-
-            description = "\n".join(description_lines)
-
-            # Determine severity based on EOL date
-            severity = "Info"
-            eol_str = cycle.get("Eol", "")
-            try:
-                eol_date = datetime.strptime(eol_str, "%Y-%m-%d")
-                now = datetime.now()
-                if eol_date < now:
-                    delta = now - eol_date
-                    if delta <= timedelta(weeks=2):
-                        severity = "Low"
-                    elif delta <= timedelta(weeks=4):
-                        severity = "Medium"
-                    elif delta <= timedelta(weeks=6):
-                        severity = "High"
-                    else:
-                        severity = "Critical"
-            except Exception:
-                severity = "Info"
-
-            finding = Finding(
-                title=title,
-                test=test,
-                severity=severity,
-                description=description,
-                component_name=artifact.get("name", ""),
-                component_version=artifact.get("version", ""),
-                static_finding=True,
-                dynamic_finding=False,
-                nb_occurences=1,
-                cwe=672,
-                references=cycle.get("ProductPermalink", "") + "\n[www.xeol.io/explorer](https://www.xeol.io/explorer)",
+            title = f"{name} EOL Information"
+            description = (
+                f"**Artifact Name:** {name}\n"
+                f"**Artifact Version:** {version}\n"
+                f"**PURL:** {purl}\n"
+                f"**CPE:** {cpe}\n"
+                f"**Cycle:** {cycle.get('cycle', '')}\n"
+                f"**Release Date:** {cycle.get('releaseDate', '')}\n"
+                f"**EOL Date:** {cycle.get('eol', '')}\n"
+                f"**Latest Release:** {cycle.get('latestRelease', '')}\n"
+                f"**Latest Release Date:** "
+                f"{cycle.get('latestReleaseDate', '')}\n"
             )
 
-            artifact_purl = artifact.get("purl")
-            if locations_enabled() and artifact_purl:
-                license_expression = " OR ".join(artifact.get("licenses", []))
-                finding.unsaved_locations.append(
-                    LocationData.dependency(purl=artifact_purl, license_expression=license_expression),
+            severity = "Info"
+            eol_val = cycle.get("Eol", "")
+            if eol_val:
+                if isinstance(eol_val, bool) and eol_val:
+                    severity = "Critical"
+                elif (
+                    isinstance(eol_val, str)
+                    and eol_val.lower() not in ["false", "none", ""]
+                ):
+                    severity = "Critical"
+
+            unique_key = f"{name}-{version}-{cycle.get('cycle', '')}"
+
+            if unique_key not in items:
+                items[unique_key] = Finding(
+                    title=title,
+                    test=test,
+                    severity=severity,
+                    description=description,
+                    cwe=672,
+                    component_name=name,
+                    component_version=version,
+                    vuln_id_from_tool=f"EOL-{name}-{version}",
+                    static_finding=True,
+                    dynamic_finding=False,
                 )
 
-            findings.append(finding)
-
-        return findings
+        return list(items.values())

--- a/dojo/tools/xeol/parser.py
+++ b/dojo/tools/xeol/parser.py
@@ -4,7 +4,6 @@ from dojo.models import Finding
 
 
 class XeolParser:
-
     def get_scan_types(self):
         return ["Xeol Scan"]
 
@@ -46,11 +45,8 @@ class XeolParser:
             severity = "Info"
             eol_val = cycle.get("Eol", "")
             if eol_val:
-                if isinstance(eol_val, bool) and eol_val:
-                    severity = "Critical"
-                elif (
-                    isinstance(eol_val, str)
-                    and eol_val.lower() not in ["false", "none", ""]
+                if (isinstance(eol_val, bool) and eol_val) or (
+                    isinstance(eol_val, str) and eol_val.lower() not in {"false", "none", ""}
                 ):
                     severity = "Critical"
 

--- a/unittests/tools/test_xeol_parser.py
+++ b/unittests/tools/test_xeol_parser.py
@@ -7,7 +7,6 @@ from unittests.dojo_test_case import (
 
 
 class TestXeolParser(DojoTestCase):
-
     def test_parse_file_with_zero_finding(self):
         scan_path = get_unit_tests_scans_path("xeol") / "xeol_zero.json"
         testfile = scan_path.open(encoding="utf-8")
@@ -17,9 +16,7 @@ class TestXeolParser(DojoTestCase):
         self.assertEqual(0, len(findings))
 
     def test_parse_file_with_one_finding(self):
-        scan_path = (
-            get_unit_tests_scans_path("xeol") / "xeol_one_finding.json"
-        )
+        scan_path = get_unit_tests_scans_path("xeol") / "xeol_one_finding.json"
         testfile = scan_path.open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
@@ -30,9 +27,7 @@ class TestXeolParser(DojoTestCase):
         self.assertEqual(finding.severity, "Critical")
 
     def test_parse_file_with_multiple_finding(self):
-        scan_path = (
-            get_unit_tests_scans_path("xeol") / "xeol_multiple_findings.json"
-        )
+        scan_path = get_unit_tests_scans_path("xeol") / "xeol_multiple_findings.json"
         testfile = scan_path.open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
@@ -44,14 +39,12 @@ class TestXeolParser(DojoTestCase):
         self.assertEqual(finding.component_name, "spring-boot")
         self.assertEqual(finding.component_version, "2.0.4.RELEASE")
         finding = list(findings)[2]
-        title_expected = (
-            "org.springframework.boot:spring-boot-autoconfigure "
-            "EOL Information"
-        )
+        title_expected = "org.springframework.boot:spring-boot-autoconfigure EOL Information"
         self.assertEqual(finding.title, title_expected)
         self.assertEqual(finding.severity, "Critical")
         self.assertEqual(finding.cwe, 672)
         self.assertEqual(
-            finding.component_name, "spring-boot-autoconfigure"
+            finding.component_name,
+            "spring-boot-autoconfigure",
         )
         self.assertEqual(finding.component_version, "2.0.4.RELEASE")

--- a/unittests/tools/test_xeol_parser.py
+++ b/unittests/tools/test_xeol_parser.py
@@ -1,26 +1,19 @@
 from dojo.models import Test
 from dojo.tools.xeol.parser import XeolParser
-from unittests.dojo_test_case import (
-    DojoTestCase,
-    get_unit_tests_scans_path,
-)
+from unittests.dojo_test_case import DojoTestCase, get_unit_tests_scans_path
 
 
 class TestXeolParser(DojoTestCase):
 
     def test_parse_file_with_zero_finding(self):
-        scan_path = get_unit_tests_scans_path("xeol") / "xeol_zero.json"
-        testfile = scan_path.open(encoding="utf-8")
+        testfile = (get_unit_tests_scans_path("xeol") / "xeol_zero.json").open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(0, len(findings))
 
     def test_parse_file_with_one_finding(self):
-        scan_path = (
-            get_unit_tests_scans_path("xeol") / "xeol_one_finding.json"
-        )
-        testfile = scan_path.open(encoding="utf-8")
+        testfile = (get_unit_tests_scans_path("xeol") / "xeol_one_finding.json").open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
@@ -30,10 +23,7 @@ class TestXeolParser(DojoTestCase):
         self.assertEqual(finding.severity, "Critical")
 
     def test_parse_file_with_multiple_finding(self):
-        scan_path = (
-            get_unit_tests_scans_path("xeol") / "xeol_multiple_findings.json"
-        )
-        testfile = scan_path.open(encoding="utf-8")
+        testfile = (get_unit_tests_scans_path("xeol") / "xeol_multiple_findings.json").open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
@@ -44,14 +34,8 @@ class TestXeolParser(DojoTestCase):
         self.assertEqual(finding.component_name, "spring-boot")
         self.assertEqual(finding.component_version, "2.0.4.RELEASE")
         finding = list(findings)[2]
-        title_expected = (
-            "org.springframework.boot:spring-boot-autoconfigure "
-            "EOL Information"
-        )
-        self.assertEqual(finding.title, title_expected)
+        self.assertEqual(finding.title, "org.springframework.boot:spring-boot-autoconfigure EOL Information")
         self.assertEqual(finding.severity, "Critical")
         self.assertEqual(finding.cwe, 672)
-        self.assertEqual(
-            finding.component_name, "spring-boot-autoconfigure",
-        )
+        self.assertEqual(finding.component_name, "spring-boot-autoconfigure")
         self.assertEqual(finding.component_version, "2.0.4.RELEASE")

--- a/unittests/tools/test_xeol_parser.py
+++ b/unittests/tools/test_xeol_parser.py
@@ -1,28 +1,39 @@
 from dojo.models import Test
 from dojo.tools.xeol.parser import XeolParser
-from unittests.dojo_test_case import DojoTestCase, get_unit_tests_scans_path
+from unittests.dojo_test_case import (
+    DojoTestCase,
+    get_unit_tests_scans_path,
+)
 
 
 class TestXeolParser(DojoTestCase):
 
     def test_parse_file_with_zero_finding(self):
-        testfile = (get_unit_tests_scans_path("xeol") / "xeol_zero.json").open(encoding="utf-8")
+        scan_path = get_unit_tests_scans_path("xeol") / "xeol_zero.json"
+        testfile = scan_path.open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(0, len(findings))
 
     def test_parse_file_with_one_finding(self):
-        testfile = (get_unit_tests_scans_path("xeol") / "xeol_one_finding.json").open(encoding="utf-8")
+        scan_path = (
+            get_unit_tests_scans_path("xeol") / "xeol_one_finding.json"
+        )
+        testfile = scan_path.open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
         self.assertEqual(1, len(findings))
         finding = list(findings)[0]
         self.assertEqual(finding.title, "Perl EOL Information")
+        self.assertEqual(finding.severity, "Critical")
 
     def test_parse_file_with_multiple_finding(self):
-        testfile = (get_unit_tests_scans_path("xeol") / "xeol_multiple_findings.json").open(encoding="utf-8")
+        scan_path = (
+            get_unit_tests_scans_path("xeol") / "xeol_multiple_findings.json"
+        )
+        testfile = scan_path.open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
         testfile.close()
@@ -33,8 +44,14 @@ class TestXeolParser(DojoTestCase):
         self.assertEqual(finding.component_name, "spring-boot")
         self.assertEqual(finding.component_version, "2.0.4.RELEASE")
         finding = list(findings)[2]
-        self.assertEqual(finding.title, "org.springframework.boot:spring-boot-autoconfigure EOL Information")
+        title_expected = (
+            "org.springframework.boot:spring-boot-autoconfigure "
+            "EOL Information"
+        )
+        self.assertEqual(finding.title, title_expected)
         self.assertEqual(finding.severity, "Critical")
         self.assertEqual(finding.cwe, 672)
-        self.assertEqual(finding.component_name, "spring-boot-autoconfigure")
+        self.assertEqual(
+            finding.component_name, "spring-boot-autoconfigure"
+        )
         self.assertEqual(finding.component_version, "2.0.4.RELEASE")

--- a/unittests/tools/test_xeol_parser.py
+++ b/unittests/tools/test_xeol_parser.py
@@ -7,6 +7,7 @@ from unittests.dojo_test_case import (
 
 
 class TestXeolParser(DojoTestCase):
+
     def test_parse_file_with_zero_finding(self):
         scan_path = get_unit_tests_scans_path("xeol") / "xeol_zero.json"
         testfile = scan_path.open(encoding="utf-8")
@@ -16,7 +17,9 @@ class TestXeolParser(DojoTestCase):
         self.assertEqual(0, len(findings))
 
     def test_parse_file_with_one_finding(self):
-        scan_path = get_unit_tests_scans_path("xeol") / "xeol_one_finding.json"
+        scan_path = (
+            get_unit_tests_scans_path("xeol") / "xeol_one_finding.json"
+        )
         testfile = scan_path.open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
@@ -27,7 +30,9 @@ class TestXeolParser(DojoTestCase):
         self.assertEqual(finding.severity, "Critical")
 
     def test_parse_file_with_multiple_finding(self):
-        scan_path = get_unit_tests_scans_path("xeol") / "xeol_multiple_findings.json"
+        scan_path = (
+            get_unit_tests_scans_path("xeol") / "xeol_multiple_findings.json"
+        )
         testfile = scan_path.open(encoding="utf-8")
         parser = XeolParser()
         findings = parser.get_findings(testfile, Test())
@@ -39,12 +44,14 @@ class TestXeolParser(DojoTestCase):
         self.assertEqual(finding.component_name, "spring-boot")
         self.assertEqual(finding.component_version, "2.0.4.RELEASE")
         finding = list(findings)[2]
-        title_expected = "org.springframework.boot:spring-boot-autoconfigure EOL Information"
+        title_expected = (
+            "org.springframework.boot:spring-boot-autoconfigure "
+            "EOL Information"
+        )
         self.assertEqual(finding.title, title_expected)
         self.assertEqual(finding.severity, "Critical")
         self.assertEqual(finding.cwe, 672)
         self.assertEqual(
-            finding.component_name,
-            "spring-boot-autoconfigure",
+            finding.component_name, "spring-boot-autoconfigure",
         )
         self.assertEqual(finding.component_version, "2.0.4.RELEASE")


### PR DESCRIPTION
**Description**

Fixes #15651

Removes the non-deterministic `datetime.now()` wall-clock calculations from `XeolParser`. Previously, severity was derived dynamically from the current date relative to EOL dates, causing the same static scan report to escalate in severity on re-import and leading to hash inconsistencies.

Severity is now computed deterministically, findings with an active `Eol` field are assigned `Critical`, whereas components not marked EOL default to `Info`.

**Test results**

- Added an explicit severity assertion (`Critical`) to `test_parse_file_with_one_finding` in `unittests/tools/test_xeol_parser.py`.
- Ran unit tests locally with `python manage.py test unittests.tools.test_xeol_parser` (3/3 tests passing).
- Verified code styling and line length compliance with `flake8`.

**Documentation**

No documentation updates required (parser behavior bug fix).

**Checklist**

- [x] Make sure to rebase your PR against the very latest `dev`.
- [x] Features/Changes should be submitted against the `dev`.
- [ ] Bugfixes should be submitted against the `bugfix` branch.
- [x] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [x] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [x] Your code is python 3.13 compliant.
- [ ] If this is a new feature and not a bug fix, you've included the proper documentation in the docs at https://github.com/DefectDojo/django-DefectDojo/tree/dev/docs as part of this PR.
- [ ] Model changes must include the necessary migrations in the dojo/db_migrations folder.
- [x] Add applicable tests to the unit tests.
- [ ] Add the proper label to categorize your PR.