### PR TITLE
docs(pro): engagement checklists in the Pro UI

### DIFF
--- a/docs/content/asset_modelling/engagements_tests/PRO__engagements.md
+++ b/docs/content/asset_modelling/engagements_tests/PRO__engagements.md
@@ -169,6 +169,47 @@ For auditing purposes, it is recommended to close any completed Engagements, rat
 | **Expire** | Visual warning only; optional auto-close; notifications | N/A |
 | **Delete** | Permanently removes Engagement, Tests, Findings, notes, files, and any Jira Epic mappings (Epics remain in Jira) | No |
 
+## Engagement Checklists
+
+A checklist records the review work a tester performed during an Engagement, across eight fixed
+security categories: Session, Encryption, Configuration, Authentication, Authorization, Data
+Input, Sensitive Data, and Other.
+
+Each category holds three things:
+
+- A **status**: Pass, Fail, or N/A. A category you have not looked at yet reads "Not Evaluated".
+- Any **Findings** that back up that status, linked from the Findings already in the Engagement.
+- A **note**, for the detail a status alone cannot carry.
+
+The checklist appears on the Engagement page. If the Engagement does not have one yet, the panel
+says so and offers to start one. The checklist is also available from the Engagement's settings
+menu, as **Complete Checklist** or **Edit Checklist**.
+
+### Filling in a Checklist
+
+Select **Complete Checklist** to open the form. You do not have to complete every category at
+once: a partial checklist saves, so you can record categories as the review progresses and return
+to it later. The Findings picker for each category is limited to the Findings in that Engagement,
+and to those you have permission to view.
+
+Once saved, the panel lists each category with its status, its note, and its linked Findings as
+chips you can select to open the Finding. The panel also shows who last saved the checklist and
+when.
+
+### Availability
+
+Checklists apply to **Interactive** Engagements only, because a checklist records testing a
+person performed. CI/CD Engagements collect automated scan results, so they do not offer one.
+
+Checklists can also be switched off for the whole instance. A superuser can clear **Enable
+checklists** in System Settings, which hides the checklist panel and its menu entry everywhere.
+
+### Permissions
+
+Viewing a checklist requires View permission on the Engagement. Creating or editing one requires
+Edit permission on the Engagement. Users without Edit permission see the checklist but are not
+offered the buttons to change it.
+
 ## Jira Integration
 
 Engagements can be linked to a connected Jira Space, allowing Findings within the Engagement to be pushed to Jira as Issues. For a complete guide to setting up Jira, see **[Connecting DefectDojo to Jira](/connectors/downstream/pro__jira_guide/)**.


### PR DESCRIPTION
Documents the engagement checklist as it now works in the Pro UI.

The checklist records the review work a tester performed during an engagement, across eight fixed security categories. This page previously did not cover the feature at all.

What the new section covers:

- The eight categories, and the three things each one holds: a status (Pass, Fail, N/A, or an unevaluated default), any findings that back up that status, and a note.
- Filling one in, including that a partial checklist saves so categories can be recorded as a review progresses, and that the findings picker is limited to the engagement's own findings and to those the user may view.
- What the panel shows once saved: each category with its status, note, and linked findings, plus who last saved it and when.
- Availability: checklists apply to Interactive engagements only, since a checklist records testing a person performed, and CI/CD engagements collect automated scan results. Also the instance-wide Enable checklists system setting.
- Permissions: viewing requires View permission on the engagement, creating or editing requires Edit permission, and users without Edit permission see the checklist but are not offered the controls to change it.

Docs-only change. No code is touched.

Pairs with the corresponding DefectDojo Pro change, which ships in the same release.
