### PR TITLE
docs(navigation): document searching the sidebar menu

### DIFF
--- a/docs/content/navigation/PRO__global_search.md
+++ b/docs/content/navigation/PRO__global_search.md
@@ -7,7 +7,7 @@ weight: 3
 
 DefectDojo Pro includes a **global search** that looks across your Findings and related objects from a single box in the topbar. It is backed by native Postgres full-text search with fuzzy, typo-tolerant matching, so you can find an object without remembering its exact wording.
 
-Global search finds your **data**: findings, assets, engagements, and the other records listed below. To find a **page** (a menu destination such as a settings screen or a list view), use the menu search instead: press **Cmd+K** or **Ctrl+K**, or the **Search menu** button at the top of the sidebar. See [The Sidebar Menu](/navigation/pro__sidebar/).
+Global search finds your **data**: findings, assets, engagements, and the other records listed below. To find a **page** (a menu destination such as a settings screen or a list view), use the menu search instead: press **Cmd+K** or **Ctrl+K**, or the magnifying-glass control in the top-right corner of the sidebar. See [The Sidebar Menu](/navigation/pro__sidebar/).
 
 ## Running a search
 

--- a/docs/content/navigation/PRO__global_search.md
+++ b/docs/content/navigation/PRO__global_search.md
@@ -7,6 +7,8 @@ weight: 3
 
 DefectDojo Pro includes a **global search** that looks across your Findings and related objects from a single box in the topbar. It is backed by native Postgres full-text search with fuzzy, typo-tolerant matching, so you can find an object without remembering its exact wording.
 
+Global search finds your **data**: findings, assets, engagements, and the other records listed below. To find a **page** (a menu destination such as a settings screen or a list view), use the menu search instead: press **Cmd+K** or **Ctrl+K**, or the **Search menu** button at the top of the sidebar. See [The Sidebar Menu](/navigation/pro__sidebar/).
+
 ## Running a search
 
 - **Topbar search box** — click the **Search** box in the top navigation and start typing. As you type, a dropdown previews the top matches **grouped by object type**, with a count next to each type and a **See all *N* results** link at the bottom.

--- a/docs/content/navigation/PRO__sidebar.md
+++ b/docs/content/navigation/PRO__sidebar.md
@@ -25,7 +25,7 @@ You only ever see the entries your account has permission to open, and a group d
 
 ## Searching the menu
 
-Press **Cmd+K** (Mac) or **Ctrl+K**, or select the **Search menu** button pinned at the top of the sidebar, to open **Search Navigation Options**: a search over every menu destination your account can currently reach.
+Press **Cmd+K** (Mac) or **Ctrl+K**, or select the small magnifying-glass control pinned in the top-right corner of the sidebar, to open **Search Navigation Options**: a search over every menu destination your account can currently reach. The control shows the shortcut for your platform, so it reads `Ctrl K` on Windows and Linux, and the whole control is clickable. It stays in the corner as the menu scrolls.
 
 Results match more than the entry's label. Each destination is also searchable by its position in the menu and by related vocabulary, so `finding` surfaces **Findings > All** even though the entry itself is labelled "All", and `sso` surfaces the authorization providers. Each result shows where the entry lives in the menu and a one line description of the page.
 

--- a/docs/content/navigation/PRO__sidebar.md
+++ b/docs/content/navigation/PRO__sidebar.md
@@ -1,6 +1,6 @@
 ---
 title: "The Sidebar Menu"
-description: "How the DefectDojo Pro sidebar is organized, the All Settings directory page, and how to switch between the current and previous layouts"
+description: "How the DefectDojo Pro sidebar is organized, how to search it, the All Settings directory page, and how to switch between the current and previous layouts"
 weight: 6
 audience: pro
 aliases:
@@ -22,6 +22,14 @@ Either way, **every page keeps the same URL**. Bookmarks, saved links and anythi
 | **Settings** | All Settings, plus the eight groups described under [The Settings section](#the-settings-section) |
 
 You only ever see the entries your account has permission to open, and a group disappears entirely when none of its pages are available to you.
+
+## Searching the menu
+
+Press **Cmd+K** (Mac) or **Ctrl+K**, or select the **Search menu** button pinned at the top of the sidebar, to open **Search Navigation Options**: a search over every menu destination your account can currently reach.
+
+Results match more than the entry's label. Each destination is also searchable by its position in the menu and by related vocabulary, so `finding` surfaces **Findings > All** even though the entry itself is labelled "All", and `sso` surfaces the authorization providers. Each result shows where the entry lives in the menu and a one line description of the page.
+
+Move through results with the arrow keys, open one with **Enter**, and close the search with **Escape**. Entries that open in the Classic UI are marked and open in a new tab. The search only ever lists pages you could also reach through the sidebar: permissions, feature flags, and license entitlements apply to it identically, and it follows whichever menu layout is active.
 
 Three conventions run through the whole menu:
 


### PR DESCRIPTION
## Description

Documents the menu search that DefectDojo Pro adds to the sidebar, and clarifies the boundary between the two searches the product now offers.

**`navigation/PRO__sidebar.md`** gains a "Searching the menu" section covering how to open the search (Cmd+K / Ctrl+K, or the trigger pinned at the top of the sidebar), what it matches, and how it behaves:

- Results match more than an entry's visible label. Each destination is also searchable by its position in the menu and by related vocabulary, so `finding` reaches **Findings > All** even though that entry is labelled just "All", and `sso` reaches the authorization providers page. This matters because the reorganized menu deliberately shortens child labels.
- Each result shows where the entry sits in the menu and a one line description of the page.
- Arrow keys move, Enter opens, Escape closes. Entries that open in the Classic UI are marked and open in a new tab.
- The search only lists pages the reader could also reach through the sidebar: permissions, feature flags and licence entitlements apply to it identically, and it follows whichever menu layout is active.

The page's frontmatter description is extended to mention searching.

**`navigation/PRO__global_search.md`** gains a short paragraph after the intro separating the two: global search finds your **data** (findings, assets, engagements and the other record types listed on that page), while the menu search finds a **page**. It links to the sidebar page.

English pages only. The translated siblings are regenerated separately.

## Test Commands
- `/test all` — run all tests
