### PR TITLE
fix(parsers): drop unique ids that repeat within a report (SARIF family, Generic JSON)

### DIFF
--- a/docs/content/releases/os_upgrading/3.3.md
+++ b/docs/content/releases/os_upgrading/3.3.md
@@ -2,7 +2,7 @@
 title: 'Upgrading to DefectDojo Version 3.3.x'
 toc_hide: true
 weight: -20260803
-description: Three parsers gain deduplication registrations, which changes the stored identity of their findings. Xeol Parser moves off the legacy hash so its identity stops depending on the wall clock; Checkmarx One Scan hashes the vendor id it already matches on; Checkmarx Scan detailed gains the same field list as its CxFlow sibling. Instances with the identity signature ledger enabled bridge these changes automatically; others should rehash the affected scan types after upgrading.
+description: Three parsers gain deduplication registrations, which changes the stored identity of their findings. Xeol Parser moves off the legacy hash so its identity stops depending on the wall clock; Checkmarx One Scan hashes the vendor id it already matches on; Checkmarx Scan detailed gains the same field list as its CxFlow sibling. Instances with the identity signature ledger enabled bridge these changes automatically; others should rehash the affected scan types after upgrading. Separately, SARIF-family parsers stop trusting fingerprints that repeat within a report, which stops unrelated findings from being merged; no rehash is needed for that change.
 ---
 
 ## Deduplication identity changes
@@ -50,6 +50,29 @@ docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Checkm
 docker compose exec uwsgi /bin/bash -c "python manage.py dedupe --parser 'Checkmarx Scan detailed' --hash_code_only"
 ```
 
-Installs that never imported these scan types are unaffected. Check the
+Installs that never imported these scan types are unaffected.
+
+## SARIF-family parsers stop trusting repeated fingerprints
+
+The SARIF parser (and the parsers built on it: CodeQL, Flawfinder, Cppcheck, DevSkim,
+Mayhem, and the other SARIF subclasses) previously copied a result's fingerprint into
+`unique_id_from_tool` verbatim. SARIF fingerprints are frequently not unique: partial
+fingerprints hash line content, so identical lines in different files collide, and some
+scanners emit a constant placeholder for every result. Because these scan types
+deduplicate on `unique_id_from_tool` first, a repeated fingerprint silently merged
+findings that were visibly different.
+
+From 3.3.0, a fingerprint value carried by more than one finding in the same report is
+dropped at parse time. Findings whose fingerprint is dropped deduplicate by hash code,
+exactly like findings the scanner gave no fingerprint. Fingerprints that are genuinely
+unique within their report are kept and behave as before.
+
+No rehash is needed: stored hash codes are unchanged, and reimport continuity holds
+because a unique-id comparison against a now-absent id falls through to the same hash
+match it previously ended at. The visible effect is that new imports stop merging
+unrelated findings that happen to share a fingerprint; findings previously merged that
+way stay as they are and can be unmarked from each finding's duplicates list if wanted.
+
+Check the
 [Release Notes](https://github.com/DefectDojo/django-DefectDojo/releases/tag/3.3.0) for
 the full contents of the release.

--- a/dojo/tools/generic/json_parser.py
+++ b/dojo/tools/generic/json_parser.py
@@ -9,6 +9,7 @@ from dojo.location.feature import locations_enabled
 from dojo.models import Endpoint, FileUpload, Finding
 from dojo.tools.locations import LocationData
 from dojo.tools.parser_test import ParserTest
+from dojo.tools.utils import drop_repeated_unique_ids
 
 # Accepted fields that map to a numeric column on Finding, and the type they hold.
 NUMERIC_FIELDS = {
@@ -236,6 +237,12 @@ class GenericJSONParser:
                     finding.cwe = cwe_number(unsaved_cwes[0])
                 finding.unsaved_cwes = unsaved_cwes
             test_internal.findings.append(finding)
+        # The generic format hands unique_id_from_tool straight to callers' pipelines, and the
+        # shipped algorithm is hash-only, so classic matching never reads it. It is still
+        # recorded as a vendor identity by consumers that do (an operator-configured unique-id
+        # algorithm, Pro's identity ledger), so an id repeating inside one report is dropped
+        # rather than stored as if it named a single finding.
+        drop_repeated_unique_ids(test_internal.findings)
         return test_internal
 
     def _normalize_numeric_fields(self, item):

--- a/dojo/tools/sarif/parser.py
+++ b/dojo/tools/sarif/parser.py
@@ -10,6 +10,7 @@ from dojo.location.feature import locations_enabled
 from dojo.models import Finding
 from dojo.tools.locations import LocationData
 from dojo.tools.parser_test import ParserTest
+from dojo.tools.utils import drop_repeated_unique_ids
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +107,7 @@ class SarifParser:
         # for each runs we just aggregate everything
         for run in tree.get("runs", []):
             items.extend(self.__get_items_from_run(run))
-        return items
+        return drop_repeated_unique_ids(items)
 
     def get_tests(self, scan_type, handle):
         tree = json.load(handle)
@@ -117,7 +118,7 @@ class SarifParser:
                 parser_type=run["tool"]["driver"]["name"],
                 version=run["tool"]["driver"].get("version"),
             )
-            test.findings = self.__get_items_from_run(run)
+            test.findings = drop_repeated_unique_ids(self.__get_items_from_run(run))
             tests.append(test)
         return tests
 

--- a/dojo/tools/utils.py
+++ b/dojo/tools/utils.py
@@ -118,3 +118,26 @@ def get_npm_cwe(item_node):
 
     # Use CWE-1035 as fallback (vulnerable third party component)
     return 1035
+
+
+def drop_repeated_unique_ids(items):
+    """
+    Drop a `unique_id_from_tool` that more than one finding in the same report carries.
+
+    A unique id that repeats inside its own report is not an identity. Scanners emit
+    constant placeholders (a live SARIF report carried the literal string "requires
+    login" on eleven findings), SARIF partial fingerprints hash line content so identical
+    lines collide, and a multi-location result becomes one finding per location, each
+    holding the result's single fingerprint. Downstream deduplication trusts
+    `unique_id_from_tool` equality, so keeping the value would merge findings that are
+    visibly different. Findings whose id is dropped deduplicate by hash code, exactly
+    like findings the scanner gave no id.
+    """
+    from collections import Counter  # noqa: PLC0415
+
+    counts = Counter(item.unique_id_from_tool for item in items if item.unique_id_from_tool)
+    repeated = {value for value, count in counts.items() if count > 1}
+    for item in items:
+        if item.unique_id_from_tool in repeated:
+            item.unique_id_from_tool = None
+    return items

--- a/unittests/scans/generic/generic_repeated_unique_ids.json
+++ b/unittests/scans/generic/generic_repeated_unique_ids.json
@@ -1,0 +1,28 @@
+{
+  "findings": [
+    {
+      "title": "SQL string concatenation in db.py",
+      "severity": "High",
+      "description": "Query built by concatenation.",
+      "unique_id_from_tool": "requires login"
+    },
+    {
+      "title": "AWS access key committed in settings.py",
+      "severity": "Critical",
+      "description": "Access key id committed.",
+      "unique_id_from_tool": "requires login"
+    },
+    {
+      "title": "TLS verification disabled in client.py",
+      "severity": "Medium",
+      "description": "Certificate verification explicitly disabled.",
+      "unique_id_from_tool": "requires login"
+    },
+    {
+      "title": "Outdated dependency lodash",
+      "severity": "Low",
+      "description": "Update lodash.",
+      "unique_id_from_tool": "dep-lodash-4.17.20"
+    }
+  ]
+}

--- a/unittests/scans/sarif/sentinel_fingerprints.sarif
+++ b/unittests/scans/sarif/sentinel_fingerprints.sarif
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "SentinelScanner",
+          "rules": [
+            {"id": "mutable-tag", "shortDescription": {"text": "GitHub Actions step uses a mutable tag"}, "defaultConfiguration": {"level": "warning"}},
+            {"id": "sql-concat", "shortDescription": {"text": "SQL string concatenation"}, "defaultConfiguration": {"level": "error"}},
+            {"id": "aws-key", "shortDescription": {"text": "AWS access key id detected"}, "defaultConfiguration": {"level": "error"}},
+            {"id": "cert-verify", "shortDescription": {"text": "Certificate verification disabled"}, "defaultConfiguration": {"level": "warning"}}
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "mutable-tag",
+          "message": {"text": "Step uses a mutable tag."},
+          "locations": [{"physicalLocation": {"artifactLocation": {"uri": ".github/workflows/ci.yml"}, "region": {"startLine": 12}}}],
+          "fingerprints": {"hashV1": "requires login"}
+        },
+        {
+          "ruleId": "sql-concat",
+          "message": {"text": "Query built by concatenation."},
+          "locations": [{"physicalLocation": {"artifactLocation": {"uri": "app/db.py"}, "region": {"startLine": 44}}}],
+          "fingerprints": {"hashV1": "requires login"}
+        },
+        {
+          "ruleId": "aws-key",
+          "message": {"text": "Access key id committed."},
+          "locations": [{"physicalLocation": {"artifactLocation": {"uri": "config/settings.py"}, "region": {"startLine": 7}}}],
+          "fingerprints": {"hashV1": "requires login"}
+        },
+        {
+          "ruleId": "cert-verify",
+          "message": {"text": "TLS verification explicitly disabled."},
+          "locations": [{"physicalLocation": {"artifactLocation": {"uri": "app/client.py"}, "region": {"startLine": 89}}}],
+          "fingerprints": {"hashV1": "5c1f36e0a9de13c3c96c26fa9a1a02a5d5be0c4a3ad9d0f27b3c4d2f8f4a91aa"}
+        }
+      ]
+    }
+  ]
+}

--- a/unittests/test_importers_deduplication.py
+++ b/unittests/test_importers_deduplication.py
@@ -494,7 +494,8 @@ class TestDojoImportersDeduplication(DojoAPITestCase):
     # These are used on purpose so we capture the behaviour of import and reimport in this scenario.
     def test_sarif_single_import_no_duplicates(self):
         """Test that importing SARIF scan (UNIQUE_ID_FROM_TOOL_OR_HASH_CODE algorithm) creates 0 duplicate findings"""
-        # bash-report.sarif has 18 internal duplicates, so we expect 18 duplicates even on first import
+        # bash-report.sarif has 15 internal duplicates (since 3.3.0 fingerprints repeated within a report
+        # are dropped and only hash-equal findings merge), so the fabricated variant is used here
         test_id = self._test_single_import_assess_duplicates("scans/sarif/bash-report-fabricated-no-internal-dupes.sarif", "SARIF", 0)
 
         # duplicates should be sorted by id (currently not usefull as tests are running celery tasks in the foreground)
@@ -510,7 +511,7 @@ class TestDojoImportersDeduplication(DojoAPITestCase):
 
     def test_sarif_different_products_no_duplicates(self):
         """Test that importing SARIF scan into different products creates 0 duplicates"""
-        # bash-report.sarif has 18 internal duplicates per import
+        # raw bash-report.sarif has internal duplicates per import, hence the fabricated variant
         self._test_different_products_no_duplicates("scans/sarif/bash-report-fabricated-no-internal-dupes.sarif", "SARIF", 0)
 
     def test_sarif_same_product_different_engagements_duplicates(self):
@@ -529,38 +530,41 @@ class TestDojoImportersDeduplication(DojoAPITestCase):
     # The samples for SARIF is the bash report that has internal duplicates
     # These are used on purpose so we capture the behaviour of import and reimport in this scenario.
     def test_sarif_single_import_internal_duplicates(self):
-        """Test that importing SARIF scan (UNIQUE_ID_FROM_TOOL_OR_HASH_CODE algorithm) creates 18 internal duplicates"""
-        # bash-report.sarif has 18 internal duplicates, so we expect 18 duplicates even on first import
-        test_id = self._test_single_import_assess_duplicates("scans/sarif/bash-report.sarif", "SARIF", 18)
+        """Test that importing SARIF scan (UNIQUE_ID_FROM_TOOL_OR_HASH_CODE algorithm) creates 15 internal duplicates"""
+        # bash-report.sarif has 15 internal duplicates: its repeated fingerprints are dropped at parse
+        # time (they hash line content and collide), so only hash-equal findings merge on first import
+        test_id = self._test_single_import_assess_duplicates("scans/sarif/bash-report.sarif", "SARIF", 15)
 
         # duplicates should be sorted by id (currently not usefull as tests are running celery tasks in the foreground)
         for finding in Finding.objects.filter(test_id=test_id, duplicate=True):
             self.assertTrue(finding.duplicate_finding.id < finding.id)
 
     def test_sarif_full_then_subset_internal_duplicates(self):
-        """Test that importing full SARIF scan then subset creates 18 internal duplicates + 9 cross-import duplicates = 27 duplicates in second import"""
+        """Test that importing full SARIF scan then subset marks every second-import finding a duplicate"""
         # For now, use the same file for both full and subset
-        # First import has 18 internal duplicates, second import also has 18 internal duplicates + 9 cross-import duplicates = 27 total in second test
-        # Total = 18 (first) + 27 (second) = 45
-        self._test_full_then_subset_duplicates("scans/sarif/bash-report.sarif", "scans/sarif/bash-report.sarif", "SARIF", 27, first_import_duplicates=18)
+        # First import has 15 internal duplicates; on the identical second import every finding
+        # matches something (4 by their kept unique ids, 23 by equal hash) = 27 total in second test
+        # Total = 15 (first) + 27 (second) = 42
+        self._test_full_then_subset_duplicates("scans/sarif/bash-report.sarif", "scans/sarif/bash-report.sarif", "SARIF", 27, first_import_duplicates=15)
 
     def test_sarif_different_products_internal_duplicates(self):
-        """Test that importing SARIF scan into different products creates 18 internal duplicates per import"""
-        # bash-report.sarif has 18 internal duplicates per import
-        self._test_different_products_no_duplicates("scans/sarif/bash-report.sarif", "SARIF", 18)
+        """Test that importing SARIF scan into different products creates 15 internal duplicates per import"""
+        # bash-report.sarif has 15 internal duplicates per import
+        self._test_different_products_no_duplicates("scans/sarif/bash-report.sarif", "SARIF", 15)
 
     def test_sarif_same_product_different_engagements_internal_duplicates(self):
-        """Test that importing SARIF scan into same product but different engagements creates 45 total duplicates (18 + 18 + 9)"""
-        # 18 internal duplicates in first import + 18 in second import + 9 cross-import duplicates = 45 total
-        self._test_same_product_different_engagements_duplicates("scans/sarif/bash-report.sarif", "SARIF", 45)
+        """Test that importing SARIF scan into same product but different engagements creates 42 total duplicates (15 + 27)"""
+        # 15 internal duplicates in first import + 27 in the second (every finding matches across
+        # engagements: 4 by kept unique ids, 23 by equal hash) = 42 total
+        self._test_same_product_different_engagements_duplicates("scans/sarif/bash-report.sarif", "SARIF", 42)
 
     def test_sarif_same_product_different_engagements_dedupe_on_engagements_internal_duplicates(self):
-        """Test that importing SARIF scan with 18 internal duplicates into same product but different engagements with dedupe_on_engagements creates only 18 duplicates (no cross-engagement duplicates)"""
-        # bash-report.sarif has 18 internal duplicates per import
-        # Second test has 18 internal duplicates (no cross-engagement duplicates due to dedupe_on_engagements=True)
-        # Total product duplicates = 18 (first) + 18 (second) = 36
+        """Test that importing SARIF scan with 15 internal duplicates into same product but different engagements with dedupe_on_engagements creates only 15 duplicates (no cross-engagement duplicates)"""
+        # bash-report.sarif has 15 internal duplicates per import
+        # Second test has 15 internal duplicates (no cross-engagement duplicates due to dedupe_on_engagements=True)
+        # Total product duplicates = 15 (first) + 15 (second) = 30
         self._test_same_product_different_engagements_dedupe_on_engagements_no_duplicates("scans/sarif/bash-report.sarif", "SARIF",
-        18, first_import_duplicates=18)
+        15, first_import_duplicates=15)
 
     # Test cases for Veracode (UNIQUE_ID_FROM_TOOL_OR_HASH_CODE algorithm)
     def test_veracode_single_import_no_duplicates(self):

--- a/unittests/tools/test_generic_parser.py
+++ b/unittests/tools/test_generic_parser.py
@@ -837,3 +837,23 @@ True,11/7/2015,Title,0,http://localhost,Severity,Description,Mitigation,Impact,R
             self.assertEqual("OSV-2021-1234", finding.unsaved_vulnerability_ids[2])
             for vid in finding.unsaved_vulnerability_ids:
                 self.assertIsInstance(vid, str)
+
+    def test_parse_json_repeated_unique_ids_are_dropped(self):
+        """
+        A unique id carried by several findings in one report is not an identity.
+
+        The shipped algorithm for this scan type is hash-only, so classic matching never
+        reads the field, but it is stored and consumed as a vendor identity by anything
+        that does (an operator-configured unique-id algorithm, Pro's identity ledger).
+        A repeated value would merge visibly different findings there, so it is dropped
+        at parse time; a genuinely unique id is kept.
+        """
+        with (get_unit_tests_scans_path("generic") / "generic_repeated_unique_ids.json").open(encoding="utf-8") as file:
+            parser = GenericParser()
+            findings = parser.get_findings(file, Test())
+        self.assertEqual(4, len(findings))
+        dropped = [f for f in findings if f.unique_id_from_tool is None]
+        self.assertEqual(3, len(dropped))
+        kept = [f for f in findings if f.unique_id_from_tool is not None]
+        self.assertEqual(1, len(kept))
+        self.assertEqual("dep-lodash-4.17.20", kept[0].unique_id_from_tool)

--- a/unittests/tools/test_sarif_parser.py
+++ b/unittests/tools/test_sarif_parser.py
@@ -182,10 +182,9 @@ add_core(ptr, offset, val);
                 )
                 self.assertEqual("Info", finding.severity)
                 self.assertIsNone(finding.unsaved_vulnerability_ids)
-                self.assertEqual(
-                    "scanFileHash:5b05533780915bfc|scanPrimaryLocationHash:4d655189c485c086",
-                    finding.unique_id_from_tool,
-                )
+                # This fingerprint repeats within the report, so it is dropped as
+                # non-identifying and the finding deduplicates by hash code.
+                self.assertIsNone(finding.unique_id_from_tool)
             for finding in findings:
                 self.common_checks(finding)
 
@@ -390,9 +389,10 @@ add_core(ptr, offset, val);
                 self.assertEqual(29, finding.line)
                 self.assertEqual(327, finding.cwe)
                 self.assertEqual("FF1048", finding.vuln_id_from_tool)
-                self.assertEqual(
-                    "e6c1ad2b1d96ffc4035ed8df070600566ad240b8ded025dac30620f3fd4aa9fd", finding.unique_id_from_tool,
-                )
+                # Flawfinder fingerprints hash the flagged line's content, and this
+                # line appears verbatim elsewhere in the report, so the repeated value
+                # is dropped as non-identifying.
+                self.assertIsNone(finding.unique_id_from_tool)
                 self.assertEqual("https://cwe.mitre.org/data/definitions/327.html", finding.references)
             with self.subTest(i=20):
                 finding = findings[20]
@@ -414,9 +414,8 @@ add_core(ptr, offset, val);
                 self.assertEqual(120, finding.cwe)
                 self.assertEqual([120], finding.unsaved_cwes)
                 self.assertEqual("FF1004", finding.vuln_id_from_tool)
-                self.assertEqual(
-                    "327fc54b75ab37bbbb31a1b71431aaefa8137ff755acc103685ad5adf88f5dda", finding.unique_id_from_tool,
-                )
+                # Same shape: the line-content hash repeats in the report and is dropped.
+                self.assertIsNone(finding.unique_id_from_tool)
                 self.assertEqual("https://cwe.mitre.org/data/definitions/120.html", finding.references)
             with self.subTest(i=52):
                 finding = findings[52]
@@ -637,3 +636,26 @@ add_core(ptr, offset, val);
             parser = SarifParser()
             findings = parser.get_findings(testfile, Test())
             self.assertEqual(77, len(findings))
+
+    def test_repeated_fingerprints_are_dropped(self):
+        """
+        A fingerprint carried by several findings in one report is not an identity.
+
+        Live shape: a scanner emitted the literal string "requires login" as every result's
+        fingerprint, and unique-id deduplication merged unrelated findings (SQL injection,
+        committed credentials, disabled TLS verification) into one cluster. A value that
+        repeats inside its own report is dropped so those findings deduplicate by hash code;
+        a fingerprint that is genuinely unique in the report is kept.
+        """
+        with (get_unit_tests_scans_path("sarif") / "sentinel_fingerprints.sarif").open(encoding="utf-8") as testfile:
+            parser = SarifParser()
+            findings = parser.get_findings(testfile, Test())
+        self.assertEqual(4, len(findings))
+        sentinel_carriers = [f for f in findings if f.unique_id_from_tool is None]
+        self.assertEqual(3, len(sentinel_carriers))
+        keeper = [f for f in findings if f.unique_id_from_tool is not None]
+        self.assertEqual(1, len(keeper))
+        self.assertEqual(
+            "5c1f36e0a9de13c3c96c26fa9a1a02a5d5be0c4a3ad9d0f27b3c4d2f8f4a91aa",
+            keeper[0].unique_id_from_tool,
+        )


### PR DESCRIPTION
### The defect

SARIF-family parsers copy a result's fingerprint into `unique_id_from_tool` verbatim, and SARIF, CodeQL Scan, and Flawfinder Scan deduplicate on `unique_id_from_tool` first. SARIF fingerprints are frequently not unique within a report:

- partial fingerprints (`primaryLocationLineHash`, `scanPrimaryLocationHash`...) hash line content, so identical lines in different files collide -- CodeQL's and flawfinder's own outputs in our sample set contain such collisions;
- some scanners emit a constant placeholder as every result's fingerprint (a live report carried the literal string "requires login" on eleven findings, which merged nine visibly different findings -- SQL injection, committed credentials, disabled TLS verification -- into one duplicate cluster);
- a multi-location result becomes one finding per location, each carrying the result's single fingerprint.

In every shape, unique-id deduplication silently merges findings that are visibly different. The importer test suite has been working around this for years: `bash-report-fabricated-no-internal-dupes.sarif` exists precisely because the raw report self-merges on import.

### The fix

A `unique_id_from_tool` value carried by more than one finding in the same report is dropped at parse time (`dojo.tools.utils.drop_repeated_unique_ids`). A unique id that repeats inside its own report is, definitionally, not unique. Applied by the SARIF parser (covering its subclasses: CodeQL, Flawfinder, Cppcheck, DevSkim, Mayhem, Dockle...) and by the Generic JSON parser, whose ids are stored and consumed as identities (an operator-configured unique-id algorithm, downstream consumers) even though its shipped algorithm is hash-only. Findings whose id is dropped deduplicate by hash code, exactly like findings the scanner gave no id. Genuinely unique ids behave exactly as before.

No rehash is needed: stored hash codes are unchanged, and reimport continuity holds because a unique-id comparison against a now-absent id falls through to the same hash match it previously ended at. Findings previously merged this way are not modified.

### Tests

- New: `test_repeated_fingerprints_are_dropped` (SARIF, new `sentinel_fingerprints.sarif` sample) and `test_parse_json_repeated_unique_ids_are_dropped` (Generic, new sample) -- the repeated value is dropped, the unique one is kept.
- Updated: three assertions that pinned a repeated fingerprint's value now assert the drop (each annotated with why); bash-report importer-dedupe counts move from the 18 uid-driven internal duplicates to the 15 hash-equal ones (identical re-imports still mark all 27 second-import findings duplicates: 4 by kept uid, 23 by equal hash).
- Ran locally against a real database: `test_sarif_parser.py` + `test_generic_parser.py` = 75 passed, 31 subtests passed.
- Upgrade notes: new section in `docs/content/releases/os_upgrading/3.3.md`.