### PR TITLE
fix(findings): store review-request notes public so reviewers can read them

### DIFF
--- a/docs/content/triage_findings/findings_workflows/PRO__peer_review.md
+++ b/docs/content/triage_findings/findings_workflows/PRO__peer_review.md
@@ -13,7 +13,7 @@ Open a Finding and choose **Request Review** from the Finding menu, or select se
 
 You can request a review from named users and groups, or tick **Allow Eligible Reviewers** to ask everyone who is eligible on that asset.
 
-Requesting a review sets the Finding to **Under Review** and notifies the reviewers.
+Requesting a review sets the Finding to **Under Review** and notifies the reviewers. The message you enter is added to the Finding as a regular note, so the reviewers can read what they are being asked to check.
 
 ## Claiming a review
 

--- a/dojo/db_migrations/0292_review_request_notes_public.py
+++ b/dojo/db_migrations/0292_review_request_notes_public.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+# The entry prefix written by request_finding_review since the feature was
+# introduced. Matching on it (together with private=True) is the only way to
+# identify historical review-request notes: the row carries no other marker.
+REVIEW_REQUEST_PREFIX = "Review Request: "
+
+
+def make_review_request_notes_public(apps, schema_editor):
+    """
+    Review-request notes used to be saved with private=True, which hid the
+    reviewer instructions from the assigned reviewers themselves (private
+    notes are visible to their author and superusers only). The view no
+    longer stores them private; this flips the rows it already wrote.
+    """
+    Notes = apps.get_model("dojo", "Notes")
+    Notes.objects.filter(private=True, entry__startswith=REVIEW_REQUEST_PREFIX).update(private=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("dojo", "0291_dojometa_location_product"),
+    ]
+
+    operations = [
+        migrations.RunPython(make_review_request_notes_public, migrations.RunPython.noop),
+    ]

--- a/dojo/finding/ui/views.py
+++ b/dojo/finding/ui/views.py
@@ -1565,8 +1565,9 @@ def request_finding_review(request, fid):
         if form.is_valid():
             now = timezone.now()
             new_note = Notes()
+            # The note must stay public: the reviewers it is addressed to
+            # cannot read a private note (author and superusers only).
             new_note.entry = "Review Request: " + form.cleaned_data["entry"]
-            new_note.private = True
             new_note.author = request.user
             new_note.date = now
             new_note.save()

--- a/unittests/test_review_request_note_visibility.py
+++ b/unittests/test_review_request_note_visibility.py
@@ -1,0 +1,153 @@
+"""
+Regression tests for the note created by a finding review request.
+
+Requesting a review stores the reviewer instructions as a note on the finding.
+That note used to be saved with ``private=True``, and ``visible_notes`` shows a
+private note only to its author and superusers, so the one person the message
+was written for (the assigned reviewer) could not read it. The note must be
+public; the review-request form offers no private option.
+"""
+
+# Regression: the review-request note was saved private, so the assigned
+# reviewer could not read the instructions they were asked to act on.
+
+import datetime
+import importlib
+
+from django.apps import apps
+from django.urls import reverse
+from django.utils import timezone
+from parameterized import parameterized
+
+from dojo.models import (
+    Dojo_User,
+    Engagement,
+    Finding,
+    Notes,
+    Product,
+    Product_Member,
+    Product_Type,
+    Test,
+    Test_Type,
+)
+from dojo.notes.helper import visible_notes
+
+from .dojo_test_case import DojoTestCase
+
+ENTRY = "please downgrade to medium, compensating control is in place"
+
+START = datetime.date(2026, 1, 1)
+END = datetime.date(2026, 1, 2)
+
+READERS = [("requester",), ("reviewer",)]
+
+
+class ReviewRequestNoteVisibilityTest(DojoTestCase):
+
+    """The review-request note is public, so the assigned reviewer can read it."""
+
+    def setUp(self):
+        self.requester = self._member("review-note-requester")
+        self.reviewer = self._member("review-note-reviewer")
+
+        product_type, _ = Product_Type.objects.get_or_create(name="review-note")
+        self.product, _ = Product.objects.get_or_create(
+            name="ReviewRequestNoteVisibilityTest", description="Test", prod_type=product_type,
+        )
+        for user in (self.requester, self.reviewer):
+            self.product.authorized_users.add(user)
+            Product_Member.objects.get_or_create(
+                product=self.product, user=user, defaults={"role_id": 4},
+            )
+
+        engagement = Engagement.objects.create(
+            name="review note", product=self.product, target_start=START, target_end=END,
+        )
+        test_type, _ = Test_Type.objects.get_or_create(name="review-note-tt")
+        test = Test.objects.create(
+            engagement=engagement, test_type=test_type,
+            target_start=self._aware(START), target_end=self._aware(END),
+        )
+        self.finding = Finding.objects.create(
+            title="review note finding", test=test, reporter=self.requester,
+            severity="Info", numerical_severity="S4",
+        )
+
+    @staticmethod
+    def _aware(day):
+        return timezone.make_aware(datetime.datetime.combine(day, datetime.time()))
+
+    def _member(self, username):
+        user, _ = Dojo_User.objects.get_or_create(
+            username=username, defaults={"is_superuser": False, "is_staff": False},
+        )
+        return user
+
+    def _request_review(self):
+        self.client.force_login(self.requester)
+        response = self.client.post(
+            reverse("request_finding_review", args=(self.finding.id,)),
+            {"reviewers": [str(self.reviewer.id)], "entry": ENTRY},
+            secure=True,
+        )
+        self.assertEqual(302, response.status_code)
+        return Notes.objects.get(entry=f"Review Request: {ENTRY}")
+
+    def test_review_request_note_is_stored_public(self):
+        note = self._request_review()
+        self.assertFalse(
+            note.private,
+            f"expected the review-request note to be public, persisted private={note.private}",
+        )
+
+    @parameterized.expand(READERS)
+    def test_review_request_note_is_readable_by(self, reader_role):
+        note = self._request_review()
+        reader = {"requester": self.requester, "reviewer": self.reviewer}[reader_role]
+        visible = visible_notes(self.finding.notes.all(), reader)
+        self.assertIn(
+            note, visible,
+            f"expected the review-request note to be readable by the {reader_role}, "
+            f"persisted private={note.private}",
+        )
+
+
+class ReviewRequestNoteMigrationTest(DojoTestCase):
+
+    """The 0292 data migration flips only historical private review-request notes."""
+
+    def test_migration_flips_only_private_review_request_notes(self):
+        migration = importlib.import_module("dojo.db_migrations.0292_review_request_notes_public")
+        author, _ = Dojo_User.objects.get_or_create(username="review-note-migration-author")
+        review_note = Notes.objects.create(
+            entry="Review Request: check the severity", author=author, private=True,
+        )
+        private_note = Notes.objects.create(
+            entry="INTERNAL: unrelated private note", author=author, private=True,
+        )
+        quoting_note = Notes.objects.create(
+            entry="Reply about the Review Request: keep this one private", author=author, private=True,
+        )
+        public_note = Notes.objects.create(
+            entry="Review Request: was already public", author=author, private=False,
+        )
+
+        migration.make_review_request_notes_public(apps, None)
+
+        review_note.refresh_from_db()
+        private_note.refresh_from_db()
+        quoting_note.refresh_from_db()
+        public_note.refresh_from_db()
+        self.assertFalse(
+            review_note.private,
+            f"expected the private review-request note to become public, private={review_note.private}",
+        )
+        self.assertTrue(
+            private_note.private,
+            "a private note without the review prefix must stay private",
+        )
+        self.assertTrue(
+            quoting_note.private,
+            "a private note merely containing the prefix mid-text must stay private",
+        )
+        self.assertFalse(public_note.private)


### PR DESCRIPTION
**Description**

Requesting a review of a finding stores the reviewer instructions as a note on the finding. Since 2019 (b59bc7a5e1) that note has been saved with `private=True`, and `visible_notes` shows a private note only to its author and superusers, so the assigned reviewers (the people the message is addressed to) could not read what they were asked to do. Product-level permissions make no difference.

This PR:

- stores the review-request note public again: `request_finding_review` no longer sets `private=True`. The review form has never offered a private option, so no user-facing choice is removed.
- adds data migration `0292_review_request_notes_public`, which repairs the rows the old code wrote: notes with `private=True` whose entry starts with `"Review Request: "`, the exact prefix this view has written since the feature landed in 2016 (4e51ac00d). Notes that merely contain that string mid-text stay private, as do private notes without the prefix. Clear-review notes were never private and are untouched.
- adds one sentence to the peer-review docs page stating that the request message becomes a note the reviewers can read.

**Test results**

New `unittests/test_review_request_note_visibility.py`:

- posting `request_finding_review` as one member with a second member as reviewer creates a note that is stored public and is returned by `visible_notes` for both the reviewer and the author. Before the fix these tests fail with the reported symptom: the reviewer's visible-notes queryset is empty while the persisted note has `private=True`.
- the migration function flips a seeded private `"Review Request: "` note, and leaves untouched: a private note without the prefix, a private note containing the prefix mid-text, and an already-public note.

The migration was additionally exercised end to end on a live database (migrate back to 0291, re-apply 0292): the legacy review note flipped to public and an unrelated private note stayed private.

**Documentation**

`docs/content/triage_findings/findings_workflows/PRO__peer_review.md` now says the request message is added to the finding as a regular note the reviewers can read. No existing page documented the old private behavior.
