### PR TITLE
fix(url): parse a bare (unbracketed) IPv6 host

### DIFF
--- a/dojo/url/models.py
+++ b/dojo/url/models.py
@@ -56,8 +56,47 @@ class HyperlinkParser:
         except (URLParseError, ValueError) as e:
             raise ValidationError(str(e))
 
+    @staticmethod
+    def _normalize_ipv6_authority(value: str) -> str:
+        """Bracket a bare IPv6 authority so hyperlink can parse it.
+
+        RFC 3986 requires an IPv6 literal in a URL authority to be wrapped in "[...]",
+        and hyperlink only recognises an authority after "//" or a scheme. Scanners and
+        connectors routinely emit a bare IPv6 host (``fe80::1``) or a bracketed one with
+        no scheme (``[fe80::1]``); left as-is, hyperlink reads the tail as a port or the
+        leading group as a scheme and raises. Both are normalised to ``//[fe80::1]`` so
+        the host is parsed. Anything that is not a bare IPv6 authority -- hostnames,
+        IPv4, ``host:port``, userinfo, and already-schemed IPv6 URLs -- is returned
+        unchanged.
+        """
+        if not value:
+            return value
+        remainder, prefix = value, ""
+        scheme_separator = remainder.find("://")
+        if scheme_separator != -1:
+            prefix, remainder = remainder[: scheme_separator + 3], remainder[scheme_separator + 3 :]
+        elif remainder.startswith("//"):
+            prefix, remainder = "//", remainder[2:]
+        # The authority ends at the first path/query/fragment delimiter.
+        authority_end = len(remainder)
+        for delimiter in ("/", "?", "#"):
+            index = remainder.find(delimiter)
+            if index != -1:
+                authority_end = min(authority_end, index)
+        authority, rest = remainder[:authority_end], remainder[authority_end:]
+        # userinfo (and any port riding on it) makes a bare IPv6 authority ambiguous.
+        if "@" in authority:
+            return value
+        literal = authority[1:-1] if authority.startswith("[") and authority.endswith("]") else authority
+        try:
+            ipaddress.IPv6Address(literal)
+        except ValueError:
+            return value
+        # A scheme-less IPv6 authority needs "//" for hyperlink to treat it as a host.
+        return f"{prefix or '//'}[{literal}]{rest}"
+
     def parse(self, value: str) -> ParsedUrl:
-        parsed_url = self.from_text(value)
+        parsed_url = self.from_text(self._normalize_ipv6_authority(value))
 
         # A host value is required by the URL class. If we're not provided one, it's possible we can coerce things if
         # no scheme was included by making it a scheme-relative URL.

--- a/dojo/url/models.py
+++ b/dojo/url/models.py
@@ -58,7 +58,8 @@ class HyperlinkParser:
 
     @staticmethod
     def _normalize_ipv6_authority(value: str) -> str:
-        """Bracket a bare IPv6 authority so hyperlink can parse it.
+        """
+        Bracket a bare IPv6 authority so hyperlink can parse it.
 
         RFC 3986 requires an IPv6 literal in a URL authority to be wrapped in "[...]",
         and hyperlink only recognises an authority after "//" or a scheme. Scanners and

--- a/unittests/test_location_models.py
+++ b/unittests/test_location_models.py
@@ -60,6 +60,45 @@ class TestURLModel(DojoTestCase):
         url = URL(host="127.0.0.1")
         self.assertEqual(url.host, "127.0.0.1")
 
+    # Regression: a bare (unbracketed) IPv6 endpoint -- infra scanners such as
+    # Tenable emit fe80::... -- raised ValidationError("No host provided") out of
+    # URL.from_value, which failed an entire connector reimport chunk. RFC 3986
+    # requires an IPv6 literal in a URL authority to be bracketed, so the parser now
+    # normalises a bare (or scheme-less bracketed) IPv6 host to //[...] before it
+    # reaches hyperlink.
+    def test_ipv6(self):
+        cases = [
+            # (input, expected host, expected port, expected protocol)
+            ("fe80::0250:56ff:febb:0000", "fe80::0250:56ff:febb:0000", None, ""),  # the reported bug
+            ("[fe80::1]", "fe80::1", None, ""),                                    # bracketed, no scheme
+            ("2001:db8::1", "2001:db8::1", None, ""),                              # bare, no scheme
+            ("http://[fe80::1]:8080/path", "fe80::1", 8080, "http"),              # already-schemed, unchanged
+        ]
+        for value, host, port, protocol in cases:
+            with self.subTest(value=value):
+                url = URL.from_value(value)
+                self.assertEqual(url.host, host, msg=f"{value!r} -> host={url.host!r}")
+                self.assertEqual(url.port, port, msg=f"{value!r} -> port={url.port!r}")
+                self.assertEqual(url.protocol, protocol, msg=f"{value!r} -> protocol={url.protocol!r}")
+
+        # A bracketed IPv6 host round-trips through str() with its brackets intact.
+        self.assertEqual(
+            str(URL.from_value("http://[fe80::1]:8080/path")),
+            "http://[fe80::1]:8080/path",
+        )
+
+        # A bare IPv6 host is canonicalised (compressed) at clean() time.
+        url = URL(host="fe80::0250:56ff:febb:0000")
+        url.full_clean()
+        self.assertEqual(url.host, "fe80::250:56ff:febb:0")
+
+    def test_host_with_port_is_not_treated_as_ipv6(self):
+        # Control: the bare-IPv6 normalisation must not disturb a scheme-relative
+        # host:port -- a single colon is not an IPv6 literal.
+        url = URL.from_value("//example.com:8080")
+        self.assertEqual(url.host, "example.com")
+        self.assertEqual(url.port, 8080)
+
     def test_less_standard_hosts(self):
         url = URL.from_value("http://123_server/")
         url.full_clean()


### PR DESCRIPTION
## Description

Per RFC 3986, an IPv6 literal in a URL authority must be bracketed (`[fe80::1]`). Security
scanners and other integrations, however, routinely emit a **bare** IPv6 host such as
`fe80::0250:56ff:febb:0000`, or a bracketed one with no scheme (`[fe80::1]`). Given either,
`hyperlink` reads the text after the last colon as a port (and fails the `int()` conversion), or
treats the leading group as a scheme, and raises `URLParseError`, which `HyperlinkParser.from_text`
re-wraps as a Django `ValidationError`. As a result, `URL.from_value("fe80::...")` rejected valid
IPv6 endpoints.

## Fix

A new `HyperlinkParser._normalize_ipv6_authority` normalises a bare IPv6 authority to `//[fe80::1]`
before it reaches hyperlink, so the host parses. It:

- splits off an optional `scheme://` or leading `//`, then takes the authority up to the first
  `/`, `?`, or `#`;
- returns the value unchanged if the authority contains `@` (userinfo), since a bare IPv6 with
  userinfo or a port is ambiguous;
- validates the candidate literal with `ipaddress.IPv6Address`, so it fires only on a real IPv6
  literal (and strips existing brackets before validating so `[fe80::1]` is recognised too);
- returns the value with the literal wrapped in `[...]`, adding a `//` prefix only when there was
  no scheme.

Hostnames, IPv4, `host:port`, userinfo, and already-schemed IPv6 URLs are untouched, so only
previously-failing bare or bracketed-scheme-less IPv6 input changes behaviour. `unparse` already
brackets an IPv6 host on output, so `str(url)` round-trips (`http://[fe80::1]:8080/path`).

## Tests

`unittests/test_location_models.py::TestURLModel`:

- `test_ipv6`: a bare IPv6 (`fe80::0250:56ff:febb:0000`), a bracketed-no-scheme IPv6 (`[fe80::1]`),
  a second bare IPv6 (`2001:db8::1`), and an already-schemed `http://[fe80::1]:8080/path`. Asserts
  host, port, and protocol for each; the `str()` round-trip keeps the brackets; and a bare IPv6 is
  compressed by `clean()`.
- `test_host_with_port_is_not_treated_as_ipv6`: a control that a scheme-relative `host:port`
  (`//example.com:8080`) still parses to host and port unchanged.

## Acceptance criteria

- `URL.from_value` accepts a bare IPv6 host and stores it as the IPv6 host with no spurious port.
- Bracketed IPv6 and `host:port` inputs are unchanged.
