### PR TITLE
refactor(importers): one existence lookup for findings deleted mid-import

### DIFF
--- a/dojo/finding/helper.py
+++ b/dojo/finding/helper.py
@@ -186,17 +186,42 @@ def update_finding_status(new_state_finding, user, changed_fields=None):
     new_state_finding.last_status_update = now
 
 
-def filter_finding_ids_by_existence(finding_ids):
-    """
-    Return the subset of the given ids that still exist in the database.
+# Bounds the IN clause of the existence lookup below. An import's result set is not
+# bounded by anything else, so without this a large scan asks the database about tens of
+# thousands of ids in one statement.
+FINDING_EXISTENCE_CHUNK = 1000
 
-    Centralized helper used by importers to avoid FK violations during
-    bulk_create -- e.g. a background async_dupe_delete task removing a finding
-    between when an importer collected it and when it writes a history record.
+
+def deleted_finding_ids(finding_ids) -> set[int]:
     """
+    Of the given finding ids, the ones whose row is no longer in the database.
+
+    The single place that answers "which of these findings are gone", for every caller
+    holding finding references across a window in which a finding can be deleted --
+    import history records, the child-row buffers flushed at an import batch boundary,
+    and anything else that would otherwise insert a dangling reference or re-save a
+    deleted row. Those references are only rejected at COMMIT (Django declares its
+    foreign keys DEFERRABLE INITIALLY DEFERRED), far from the code that wrote them, so
+    the check has to happen before the write rather than around it.
+
+    Returns the missing ids rather than the survivors: it is the smaller set, and every
+    caller wants it to skip work rather than to drive it. Costs one indexed primary-key
+    lookup per FINDING_EXISTENCE_CHUNK ids, and no query at all for an empty input.
+
+    Note for callers that already read rows for these findings: existence falls out of
+    any such read for free (see _sync_close_old_finding_status_fields, which learns it
+    from the refresh it needs anyway). Do not route those through here -- it buys
+    consistency with an extra round trip.
+    """
+    finding_ids = {finding_id for finding_id in finding_ids if finding_id is not None}
     if not finding_ids:
         return set()
-    return set(Finding.objects.filter(id__in=finding_ids).values_list("id", flat=True))
+    live_finding_ids: set[int] = set()
+    for chunk in batched(finding_ids, FINDING_EXISTENCE_CHUNK, strict=False):
+        live_finding_ids.update(
+            Finding.objects.filter(pk__in=chunk).values_list("pk", flat=True),
+        )
+    return finding_ids - live_finding_ids
 
 
 def can_edit_mitigated_data(user):

--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -582,12 +582,11 @@ class BaseImporter(ImporterOptions):
 
         # In longer running imports it can happen that the async_dupe_delete task removes a finding before the history record is created
         # We filter out these findings here to avoid FK violations (IntegrityError)
-        all_finding_ids = []
-        for list_, _ in finding_action_mappings:
-            all_finding_ids.extend(list_)
-        existing_ids = finding_helper.filter_finding_ids_by_existence(all_finding_ids) if all_finding_ids else set()
+        dropped_finding_ids = self.deleted_finding_ids({
+            finding_id for list_, _ in finding_action_mappings for finding_id in list_
+        })
 
-        # Collect all import history records using the validated IDs
+        # Collect all import history records, skipping the findings that are gone
         import_history_records = []
         for finding_ids, action in finding_action_mappings:
             import_history_records.extend(
@@ -597,7 +596,7 @@ class BaseImporter(ImporterOptions):
                     action=action,
                 )
                 for finding_id in finding_ids
-                if finding_id in existing_ids
+                if finding_id is not None and finding_id not in dropped_finding_ids
             )
 
         # Bulk create all at once and let Django handle batching internally.
@@ -997,17 +996,14 @@ class BaseImporter(ImporterOptions):
 
     def deleted_finding_ids(self, finding_ids: set[int]) -> set[int]:
         """
-        Of the given buffered finding ids, the ones whose finding row is gone.
+        Of the given finding ids, the ones whose finding row is gone.
 
-        One indexed primary-key lookup for the whole set; see
-        drop_rows_for_deleted_findings() for why the buffers need this at all.
+        The importer's seam onto finding_helper.deleted_finding_ids -- kept as a method so
+        the flush paths and update_import_history share one lookup and a subclass has a
+        single place to override. See drop_rows_for_deleted_findings() for why the buffers
+        need this at all.
         """
-        if not finding_ids:
-            return set()
-        live_finding_ids = set(
-            Finding.objects.filter(pk__in=finding_ids).values_list("pk", flat=True),
-        )
-        return finding_ids - live_finding_ids
+        return finding_helper.deleted_finding_ids(finding_ids)
 
     def drop_rows_for_deleted_findings(self, rows: list, deleted_finding_ids: set[int] | None = None) -> list:
         """

--- a/dojo/importers/default_reimporter.py
+++ b/dojo/importers/default_reimporter.py
@@ -38,8 +38,10 @@ from dojo.validators import clean_tags
 logger = logging.getLogger(__name__)
 deduplicationLogger = logging.getLogger("dojo.specific-loggers.deduplication")
 
-# Bound IN-list size when bulk-loading status fields for close_old_findings.
-_CLOSE_OLD_FINDINGS_STATUS_FIELDS_CHUNK = 1000
+# Bound IN-list size when bulk-loading rows for close_old_findings. Same bound as the
+# existence lookup in finding_helper, so every id list this file sends to the database is
+# chunked the same way.
+_CLOSE_OLD_FINDINGS_STATUS_FIELDS_CHUNK = finding_helper.FINDING_EXISTENCE_CHUNK
 
 
 class DefaultReImporterOptions(ImporterOptions):
@@ -809,6 +811,11 @@ class DefaultReImporter(BaseImporter, DefaultReImporterOptions):
         earlier in the reimport can be gone by the time we get here (a concurrent delete of
         findings, for example): there is no row to refresh, and such a finding must not be
         closed either, because saving it would re-insert the deleted row.
+
+        That existence check deliberately does not go through finding_helper.deleted_finding_ids
+        like the other callers holding finding references across a delete window. A missing
+        row is already the absence of a row in the refresh this method has to do anyway, so
+        asking the shared helper would buy consistency with a second round trip per chunk.
 
         This really should be fixed differently, but for now we at least optimize it to be done in bulk.
         """

--- a/unittests/test_finding_helper.py
+++ b/unittests/test_finding_helper.py
@@ -12,6 +12,7 @@ from rest_framework.test import APIClient
 
 from dojo.finding.helper import (
     POST_PROCESS_BATCH_MAX_CONFLICT_RETRIES,
+    deleted_finding_ids,
     post_process_findings_batch,
     save_vulnerability_ids,
     save_vulnerability_ids_template,
@@ -220,6 +221,79 @@ class TestUpdateFindingStatusSignal(DojoTestCase):
                 # TODO: marking as false positive resets verified to False, possible bug / undesired behaviour?
                 (False, False, False, True, True, frozen_datetime, self.user_1, frozen_datetime),
             )
+
+
+@versioned_fixtures
+class TestDeletedFindingIds(DojoTestCase):
+
+    """
+    The one existence lookup every caller holding finding references across a delete window uses.
+
+    Importers buffer child rows and collect import-history candidates for a whole batch
+    before writing them, so a finding can be deleted while it is still referenced. Because
+    Django's foreign keys are DEFERRABLE INITIALLY DEFERRED, writing such a reference is
+    only rejected at COMMIT, so the reference has to be dropped before the write.
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    def setUp(self):
+        super().setUp()
+        # duplicate_finding is a self-FK with ON DELETE DO_NOTHING, so a fixture finding
+        # another one points at as its original cannot be deleted on its own. These tests
+        # are about the existence lookup, not about repairing that reference, so they work
+        # on findings nothing points at.
+        original_ids = set(
+            Finding.objects.exclude(duplicate_finding=None).values_list("duplicate_finding_id", flat=True),
+        )
+        self.findings = list(Finding.objects.exclude(id__in=original_ids).order_by("id")[:3])
+        self.assertEqual(3, len(self.findings), msg="fixture must supply at least 3 deletable findings")
+
+    def test_empty_input_costs_no_query(self):
+        with self.assertNumQueries(0):
+            self.assertEqual(set(), deleted_finding_ids([]))
+
+    def test_ids_that_are_none_are_ignored_and_cost_no_query(self):
+        """An unsaved finding has no row to be missing, so it is not a deleted one."""
+        with self.assertNumQueries(0):
+            self.assertEqual(set(), deleted_finding_ids([None, None]))
+
+    def test_all_live_findings_returns_empty_set(self):
+        live_ids = {finding.id for finding in self.findings}
+        with self.assertNumQueries(1):
+            self.assertEqual(set(), deleted_finding_ids(live_ids))
+
+    def test_returns_only_the_deleted_ids(self):
+        deleted_id = self.findings[0].id
+        surviving_ids = {finding.id for finding in self.findings[1:]}
+        Finding.objects.filter(id=deleted_id).delete()
+
+        self.assertEqual({deleted_id}, deleted_finding_ids({deleted_id, *surviving_ids}))
+
+    def test_an_id_that_never_existed_counts_as_deleted(self):
+        """A caller cannot tell the two apart and wants to skip the reference either way."""
+        never_existed = Finding.objects.order_by("-id").first().id + 1000
+
+        self.assertEqual({never_existed}, deleted_finding_ids({never_existed}))
+
+    def test_lookup_is_chunked_so_the_in_clause_stays_bounded(self):
+        """
+        An import's result set is unbounded, so the ids are asked about a chunk at a time.
+
+        Without this, a large scan puts every finding id it touched into a single IN clause.
+        """
+        live_ids = {finding.id for finding in self.findings}
+        with patch("dojo.finding.helper.FINDING_EXISTENCE_CHUNK", 2), self.assertNumQueries(2):
+            self.assertEqual(set(), deleted_finding_ids(live_ids))
+
+    def test_chunking_does_not_change_the_answer(self):
+        """Every chunk contributes its survivors, so a deleted id in any chunk is still reported."""
+        deleted_id = self.findings[1].id
+        all_ids = {finding.id for finding in self.findings}
+        Finding.objects.filter(id=deleted_id).delete()
+
+        with patch("dojo.finding.helper.FINDING_EXISTENCE_CHUNK", 1):
+            self.assertEqual({deleted_id}, deleted_finding_ids(all_ids))
 
 
 class TestSaveVulnerabilityIds(DojoTestCase):

--- a/unittests/test_importers_deleted_finding_child_rows.py
+++ b/unittests/test_importers_deleted_finding_child_rows.py
@@ -2,6 +2,7 @@ import base64
 import logging
 
 from django.db import connection
+from django.test import override_settings
 from django.utils import timezone
 
 from dojo.importers.default_importer import DefaultImporter
@@ -13,6 +14,7 @@ from dojo.models import (
     Finding,
     Product,
     Product_Type,
+    Test_Import_Finding_Action,
     User,
 )
 from dojo.vulnerability.models import FindingVulnerabilityReference
@@ -252,6 +254,41 @@ class TestImportersDeletedFindingChildRows(DojoTestCase):
                 self._buffered_request_response_count(finding),
                 msg=f"finding {finding.pk} lost its request/response pair",
             )
+
+    @override_settings(TRACK_IMPORT_HISTORY=True)
+    def test_update_import_history_skips_a_finding_deleted_during_the_import(self):
+        """
+        The import-history records go through the same existence lookup as the buffers.
+
+        Its own test class (UpdateImportHistoryTests) needs TransactionTestCase for the
+        IntegrityError fallback and is skipped, so the shared pre-check is asserted here.
+        """
+        importer = self._importer()
+        importer.test = self.test
+        deleted_finding, *surviving_findings = self.findings
+        deleted_pk = deleted_finding.pk
+        Finding.objects.filter(pk=deleted_pk).delete()
+
+        test_import = importer.update_import_history(
+            new_findings=[finding.pk for finding in self.findings],
+        )
+        connection.check_constraints()
+
+        recorded_finding_ids = set(
+            Test_Import_Finding_Action.objects.filter(
+                test_import=test_import,
+            ).values_list("finding_id", flat=True),
+        )
+        self.assertNotIn(
+            deleted_pk,
+            recorded_finding_ids,
+            msg=f"no history record may be written for deleted finding {deleted_pk}",
+        )
+        self.assertEqual(
+            {finding.pk for finding in surviving_findings},
+            recorded_finding_ids,
+            msg="every surviving finding must still get its history record",
+        )
 
 
 class TestReconcileBeforeFindingIsWritten(DojoTestCase):

--- a/unittests/test_update_import_history.py
+++ b/unittests/test_update_import_history.py
@@ -121,8 +121,8 @@ class UpdateImportHistoryTests(TransactionTestCase):
         new_findings = self._create_findings(9)
         bad = self._create_findings(1)[0]
 
-        # Patch the existence filter to return all findings as-if they exist, then delete to simulate race after check
-        with patch("dojo.finding.helper.filter_findings_by_existence", side_effect=lambda lst: lst):
+        # Patch the existence check to report nothing deleted, then delete to simulate race after check
+        with patch("dojo.finding.helper.deleted_finding_ids", return_value=set()):
             bad_id = bad.id
             Finding.objects.filter(id=bad_id).delete()
             test_import = self.importer.update_import_history(new_findings=[*new_findings, bad])
@@ -138,7 +138,7 @@ class UpdateImportHistoryTests(TransactionTestCase):
 
         # Delete a finding in the second batch (index 150) after the existence check
         bad = new_findings[150]
-        with patch("dojo.finding.helper.filter_findings_by_existence", side_effect=lambda lst: lst):
+        with patch("dojo.finding.helper.deleted_finding_ids", return_value=set()):
             Finding.objects.filter(id=bad.id).delete()
             test_import = self.importer.update_import_history(new_findings=new_findings)
 


### PR DESCRIPTION
**Summary**

Follow-up to #15512, which removed an existence `SELECT` from the test/engagement write-back by detecting the deleted row from `save(force_update=True)` instead. This does the same tidying one level down, on the existence lookups the importer still runs for findings.

- `filter_finding_ids_by_existence()` (import-history records) and `BaseImporter.deleted_finding_ids()` (child-row buffers, added by #15428) are the same query written in opposite directions, with one caller each. They become a single chunked `finding_helper.deleted_finding_ids()`; the importer method stays as a delegate so the flush paths keep their override seam.
- Unlike the write-back, these callers cannot let the write report the deletion. They are `bulk_create()` calls, and with `DEFERRABLE INITIALLY DEFERRED` foreign keys the violation only arrives at `COMMIT`, naming a constraint rather than a row. So the lookup stays here — it just stops being duplicated.
- It also gains a bound on its `IN` clause. `update_import_history()` was the one caller running unbounded: the buffer flushes ask about at most a batch, but it is called once per import with every finding it touched, so a large scan put tens of thousands of ids in one statement.
- `close_old_findings()` keeps its own query — existence already falls out of the refresh `_sync_close_old_finding_status_fields()` does anyway, so sharing the helper would only add a round trip. It now shares the chunk size, and the docstring says why.
- No behaviour change, and no query-count change: the pinned baselines in `test_importers_performance.py` and `test_tag_inheritance_perf.py` are untouched.

**Tests**

- New in `test_finding_helper.py`: `TestDeletedFindingIds`, 7 tests — the polarity in both directions, the cases that must cost no query (empty input, all-`None`), an id that never existed, and two on the chunking (query count with `FINDING_EXISTENCE_CHUNK` patched to 2, and the answer being chunk-size independent).
- New in `test_importers_deleted_finding_child_rows.py`: `test_update_import_history_skips_a_finding_deleted_during_the_import`, next to the buffer guards from #15428. It goes there because `UpdateImportHistoryTests` is skipped wholesale, so the import-history pre-check otherwise has no running coverage.
- Updated in `test_update_import_history.py`: 2 patch targets moved to `deleted_finding_ids`. They were already stale — #15600 renamed the function they named, so they would have raised `AttributeError` if that class were ever un-skipped.

Green on PostgreSQL: `test_finding_helper` (25), `test_importers_deleted_finding_child_rows` (11), `test_importers_performance` (11), `test_import_reimport` (132), `test_importers_importer` (50), `test_importers_deduplication` (50), `test_tag_inheritance_perf` (24), `test_importers_closeold` (7).
