### PR TITLE
feat(api-v3): let a downstream distribution supply the assets router's write schemas

### DIFF
--- a/dojo/product/api_v3/routes.py
+++ b/dojo/product/api_v3/routes.py
@@ -56,6 +56,7 @@ from dojo.api_v3.filtering import (
 )
 from dojo.api_v3.include import apply_includes
 from dojo.api_v3.pagination import list_envelope, paginate
+from dojo.api_v3.writes import bind_payload, split_extras
 from dojo.authorization.authorization import user_has_permission
 from dojo.authorization.roles_permissions import Permissions
 from dojo.models import Dojo_User, Endpoint, Product, Product_Type, SLA_Configuration
@@ -167,6 +168,15 @@ def build_assets_router(
     detail_schema: type = AssetDetail,
     filter_spec: FilterSpec = ASSET_FILTER_SPEC,
     queryset_hook: Callable | None = None,
+    # Write payload schemas, parameterized exactly as the findings router's are (I4/I5): a
+    # downstream distribution subclasses them to accept its own columns. Anything the subclass adds
+    # beyond ``AssetWrite``/``AssetUpdate``/``AssetReplace`` is split out of the payload and handed
+    # to ``on_write`` instead of being applied to the ``Product`` row, so the OS write path is never
+    # passed a field it does not own. See dojo/api_v3/writes.py.
+    create_schema: type = AssetWrite,
+    update_schema: type = AssetUpdate,
+    replace_schema: type = AssetReplace,
+    on_write: Callable | None = None,
     auth=NOT_SET,
 ) -> Router:
     """Build the assets router (I5)."""
@@ -220,8 +230,9 @@ def build_assets_router(
         return json_response(apply_fields(serialize(obj, detail_schema, expand_tree), fields))
 
     @router.post("/assets", response=detail_schema, url_name="assets_create")
-    def create_asset(request: HttpRequest, payload: AssetWrite):
-        data = payload.dict()
+    @bind_payload(create_schema)
+    def create_asset(request: HttpRequest, payload):
+        data, extras = split_extras(payload.dict(), AssetWrite)
         tags = data.pop("tags")
         organization_id = data.pop("organization")
         # Mirror check_post_permission(request, Product_Type, "prod_type", "add"): 404 if the target
@@ -241,10 +252,13 @@ def build_assets_router(
             instance.save()
         except DjangoValidationError as exc:
             raise _validation_from_django(exc) from exc
+        if on_write is not None:
+            on_write(instance, extras, user=request.user, created=True)
         return json_response(serialize(instance, detail_schema, {}), status=201)
 
     @router.patch("/assets/{int:asset_id}", response=detail_schema, url_name="assets_update")
-    def update_asset(request: HttpRequest, asset_id: int, payload: AssetUpdate):
+    @bind_payload(update_schema)
+    def update_asset(request: HttpRequest, asset_id: int, payload):
         instance = _base_queryset(request, queryset_hook).filter(pk=asset_id).first()
         if instance is None:
             msg = f"Asset {asset_id} not found"
@@ -252,7 +266,7 @@ def build_assets_router(
         if not user_has_permission(request.user, instance, Permissions.Product_Edit):
             raise PermissionDenied  # 403: visible but not editable
 
-        data = payload.dict(exclude_unset=True)
+        data, extras = split_extras(payload.dict(exclude_unset=True), AssetUpdate)
         tags = data.pop("tags", _UNSET)
         if "organization" in data:
             new_org_id = data.pop("organization")
@@ -273,10 +287,13 @@ def build_assets_router(
             instance.save()
         except DjangoValidationError as exc:
             raise _validation_from_django(exc) from exc
+        if on_write is not None:
+            on_write(instance, extras, user=request.user, created=False)
         return json_response(serialize(instance, detail_schema, {}))
 
     @router.put("/assets/{int:asset_id}", response=detail_schema, url_name="assets_replace")
-    def replace_asset(request: HttpRequest, asset_id: int, payload: AssetReplace):
+    @bind_payload(replace_schema)
+    def replace_asset(request: HttpRequest, asset_id: int, payload):
         # Full replace (PUT). Validates against the create-shaped AssetReplace (required
         # name/description/organization, extra="forbid") and applies payload.dict() WITHOUT
         # exclude_unset, so omitted optionals reset to their schema defaults (§4.11). Permission
@@ -289,7 +306,7 @@ def build_assets_router(
         if not user_has_permission(request.user, instance, Permissions.Product_Edit):
             raise PermissionDenied  # 403: visible but not editable
 
-        data = payload.dict()
+        data, extras = split_extras(payload.dict(), AssetReplace)
         tags = data.pop("tags")
         new_org_id = data.pop("organization")
         if new_org_id != instance.prod_type_id:
@@ -307,6 +324,8 @@ def build_assets_router(
             instance.save()
         except DjangoValidationError as exc:
             raise _validation_from_django(exc) from exc
+        if on_write is not None:
+            on_write(instance, extras, user=request.user, created=False)
         return json_response(serialize(instance, detail_schema, {}))
 
     @router.delete("/assets/{int:asset_id}", url_name="assets_delete")


### PR DESCRIPTION
**Description**

`build_findings_router()` already accepts `create_schema` / `update_schema` / `replace_schema` / `on_write`, so a downstream distribution can subclass the write payloads and persist columns the open-source `Product` row does not own — `dojo/api_v3/writes.py` splits anything the base schema does not declare out of the payload before the write path sees it.

`build_assets_router()` did not. Its `POST` / `PATCH` / `PUT` handlers were pinned to `AssetWrite` / `AssetUpdate` / `AssetReplace`, so a downstream asset field could be served on reads but never accepted on writes.

This adds the same four parameters to the assets router and routes its three write handlers through `bind_payload()` + `split_extras()`, mirroring the findings router exactly.

**No behaviour change for open source.** Called with no arguments the router still binds `AssetWrite` / `AssetUpdate` / `AssetReplace`, and `on_write` stays `None`, so nothing extra runs. Verified by building the router both ways and inspecting the bound body model of each write operation:

- no arguments → `POST /assets` binds `AssetWrite`, `PATCH` binds `AssetUpdate`, `PUT` binds `AssetReplace`
- with overrides passed → the supplied subclasses instead

All seven asset routes still build (`GET` list, `GET` detail, `GET export.csv`, `POST`, `PATCH`, `PUT`, `DELETE`).

**Test results**

Honest caveat on scope: I was not able to run `unittests/api_v3` in a clean open-source environment. It was run inside a downstream-distribution container, where that distribution mounts its own v3 API ahead of the open-source one; a number of open-source contract tests fail there for reasons unrelated to this PR (different RBAC model, extra companion joins changing query counts, a different importer).

To separate that noise from this change, `unittests.api_v3.test_apiv3_assets` was run twice in the same environment — once with this commit applied and once with the working tree reset to a clean checkout. Both runs produced **the identical set of 4 failures**, so this change adds none. CI will exercise the suite properly in a clean open-source environment.

**Documentation**

No documentation change: this is an internal extension point, and the alpha API's public contract is unchanged.
