### PR TITLE
Pin outbound connections to an already-checked address

### DIFF
--- a/dojo/utils_ssrf.py
+++ b/dojo/utils_ssrf.py
@@ -53,8 +53,8 @@ def _check_ip(ip_str: str) -> None:
         raise SSRFError(msg)
 
 
-def _resolve_and_check(hostname: str, port: int) -> None:
-    """Resolve hostname and verify every returned address is publicly routable."""
+def _resolve_and_check(hostname: str, port: int) -> str:
+    """Resolve hostname, verify every returned address is publicly routable, and return one."""
     try:
         addr_infos = socket.getaddrinfo(
             hostname, port, socket.AF_UNSPEC, socket.SOCK_STREAM,
@@ -69,6 +69,8 @@ def _resolve_and_check(hostname: str, port: int) -> None:
 
     for _family, _type, _proto, _canon, sockaddr in addr_infos:
         _check_ip(sockaddr[0])
+
+    return addr_infos[0][4][0]
 
 
 def validate_url_for_ssrf(url: str) -> None:
@@ -107,22 +109,31 @@ def validate_url_for_ssrf(url: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# urllib3 connection subclasses — validation runs at socket-creation time.
-# Overriding _new_conn() (called immediately before the OS connect() syscall)
-# minimises the TOCTOU window to microseconds, making DNS rebinding attacks
-# impractical in practice.
+# urllib3 connection subclasses — the hostname is resolved once, every address
+# it returns is checked, and the socket is then opened against one of those
+# checked addresses. urllib3 never resolves the name a second time, so there is
+# no window in which the answer can change.
 # ---------------------------------------------------------------------------
 
-class _SSRFSafeHTTPConnection(urllib3.connection.HTTPConnection):
+class _SSRFSafePinnedConnection:
     def _new_conn(self) -> socket.socket:
-        _resolve_and_check(self._dns_host, self.port)
-        return super()._new_conn()
+        checked_address = _resolve_and_check(self._dns_host, self.port)
+        hostname = self._dns_host
+        self._dns_host = checked_address
+        try:
+            return super()._new_conn()
+        finally:
+            # urllib3 reads self.host for the Host header, TLS SNI and certificate
+            # verification after this returns, so put the hostname back.
+            self._dns_host = hostname
 
 
-class _SSRFSafeHTTPSConnection(urllib3.connection.HTTPSConnection):
-    def _new_conn(self) -> socket.socket:
-        _resolve_and_check(self._dns_host, self.port)
-        return super()._new_conn()
+class _SSRFSafeHTTPConnection(_SSRFSafePinnedConnection, urllib3.connection.HTTPConnection):
+    pass
+
+
+class _SSRFSafeHTTPSConnection(_SSRFSafePinnedConnection, urllib3.connection.HTTPSConnection):
+    pass
 
 
 class _SSRFSafeHTTPConnectionPool(urllib3.connectionpool.HTTPConnectionPool):

--- a/unittests/test_utils_ssrf.py
+++ b/unittests/test_utils_ssrf.py
@@ -2,8 +2,15 @@ import socket
 from unittest.mock import patch
 
 import requests
+import urllib3.connection
 
-from dojo.utils_ssrf import SSRFError, _SSRFSafeAdapter, make_ssrf_safe_session, validate_url_for_ssrf  # noqa: PLC2701
+from dojo.utils_ssrf import (
+    SSRFError,
+    _SSRFSafeAdapter,  # noqa: PLC2701
+    _SSRFSafeHTTPConnection,  # noqa: PLC2701
+    make_ssrf_safe_session,
+    validate_url_for_ssrf,
+)
 from unittests.dojo_test_case import DojoTestCase
 
 
@@ -73,3 +80,37 @@ class TestMakeSsrfSafeSession(DojoTestCase):
         session = make_ssrf_safe_session()
         self.assertIsInstance(session.get_adapter("http://example.com"), _SSRFSafeAdapter)
         self.assertIsInstance(session.get_adapter("https://example.com"), _SSRFSafeAdapter)
+
+
+class TestConnectionAddressPinning(DojoTestCase):
+
+    """The address the socket connects to must be the address that was checked."""
+
+    def _connect_with(self, addr_infos):
+        """Run _new_conn() and report the address urllib3 was handed."""
+        seen = {}
+
+        def capture(conn):
+            seen["dns_host"] = conn._dns_host
+
+        conn = _SSRFSafeHTTPConnection(host="example.com", port=80)
+        with patch("dojo.utils_ssrf.socket.getaddrinfo", side_effect=addr_infos), \
+             patch.object(urllib3.connection.HTTPConnection, "_new_conn", capture):
+            conn._new_conn()
+        return conn, seen["dns_host"]
+
+    def test_second_lookup_cannot_redirect_the_connection(self):
+        # A rebinding resolver answers public first, then loopback. Only the
+        # first answer is checked, so only the first answer may be used.
+        _conn, dns_host = self._connect_with([_addr_info("8.8.8.8"), _addr_info("127.0.0.1")])
+        self.assertEqual(dns_host, "8.8.8.8")
+
+    def test_hostname_restored_after_connecting(self):
+        conn, _dns_host = self._connect_with([_addr_info("8.8.8.8")])
+        self.assertEqual(conn.host, "example.com")
+
+    @patch("dojo.utils_ssrf.socket.getaddrinfo", return_value=_addr_info("127.0.0.1"))
+    def test_private_address_blocked_at_socket_creation(self, mock_getaddrinfo):
+        conn = _SSRFSafeHTTPConnection(host="rebind.invalid", port=80)
+        with self.assertRaisesRegex(SSRFError, "non-public address"):
+            conn._new_conn()


### PR DESCRIPTION
Hardening / consistency improvement to outbound HTTP connection handling in the SSRF-safe session. The destination is now resolved once and the socket is opened against an address that was already checked, rather than allowing a second lookup to supply a different one. Adds a regression test.

No functional change for correctly-configured destinations.