### PR TITLE
fix(migrations): make the ui_use_tailwind removal idempotent

### DIFF
--- a/dojo/db_migrations/0293_remove_usercontactinfo_ui_use_tailwind.py
+++ b/dojo/db_migrations/0293_remove_usercontactinfo_ui_use_tailwind.py
@@ -1,15 +1,45 @@
+"""
+Remove the ``ui_use_tailwind`` UI opt-in from UserContactInfo.
+
+Drops the classic-vs-Tailwind opt-in added in 0267. The database drop is made
+idempotent (``DROP COLUMN IF EXISTS``): an instance can reach this migration
+without the column physically present — the OSS->Pro upgrade fixtures, and any
+database whose recorded migration history skews from its physical schema, hit
+exactly that — and a plain ``RemoveField`` emits an unconditional
+``ALTER TABLE ... DROP COLUMN`` that then fails with
+``column "ui_use_tailwind" ... does not exist``. Splitting the state removal
+from an ``IF EXISTS`` database drop keeps Django's model state correct while
+tolerating the absent column. UserContactInfo is not pghistory-tracked, so no
+event table carries the column and a raw ``ALTER TABLE`` is sufficient.
+"""
+
 from django.db import migrations
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dojo', '0292_review_request_notes_public'),
+        ("dojo", "0292_review_request_notes_public"),
     ]
 
     operations = [
-        migrations.RemoveField(
-            model_name='usercontactinfo',
-            name='ui_use_tailwind',
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name="usercontactinfo",
+                    name="ui_use_tailwind",
+                ),
+            ],
+            database_operations=[
+                migrations.RunSQL(
+                    sql="ALTER TABLE dojo_usercontactinfo DROP COLUMN IF EXISTS ui_use_tailwind;",
+                    # Reverse re-adds the column with its original definition (0267:
+                    # BooleanField(default=False)) so a downgrade restores a working schema.
+                    reverse_sql=(
+                        "ALTER TABLE dojo_usercontactinfo "
+                        "ADD COLUMN IF NOT EXISTS ui_use_tailwind boolean NOT NULL DEFAULT false;"
+                    ),
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
Shortcut: [sc-14995](https://app.shortcut.com/defectdojo/story/14995)

## Description

`0293_remove_usercontactinfo_ui_use_tailwind` removes the `ui_use_tailwind` opt-in (added in `0267`) with a plain `RemoveField`. That emits an unconditional `ALTER TABLE dojo_usercontactinfo DROP COLUMN ui_use_tailwind`, which fails when the column is not physically present at the moment the migration runs:

```
django.db.utils.ProgrammingError: column "ui_use_tailwind" of relation "dojo_usercontactinfo" does not exist
```

This is reachable on the upgrade path — a database can arrive at `0293` without the column present when its recorded migration history skews from its physical schema (e.g. the column addition never materialized in that DB even though later history is applied). A plain `RemoveField` cannot tolerate that, and the whole migrate run aborts.

## Fix

Split the operation into `SeparateDatabaseAndState`:

- **state** keeps the `RemoveField`, so Django's model state is unchanged — no new migration is generated, and the model no longer defines the field.
- **database** does an idempotent `ALTER TABLE ... DROP COLUMN IF EXISTS`, so the drop is a no-op when the column is already gone instead of an error.

`UserContactInfo` is not pghistory-tracked, so no event table carries the column and a raw `ALTER TABLE` is sufficient. This mirrors the existing `SeparateDatabaseAndState` removal pattern in `0266_remove_credential_manager`. The reverse re-adds the column with its original `0267` definition (`BooleanField(default=False)`) so a downgrade restores a working schema.

## Validation

- Reproduced the exact failure against Postgres: a plain `ALTER TABLE ... DROP COLUMN` on an absent column raises `column "ui_use_tailwind" ... does not exist`, while `DROP COLUMN IF EXISTS` emits a skip `NOTICE` and succeeds.
- `state_operations` is an identical `RemoveField`, so the model-state result is unchanged (no `makemigrations` drift).
- The module lives under `dojo/db_migrations`, which is excluded from the ruff lint config.