### PR TITLE
fix(login): render login page when the Site row for SITE_ID is missing

### DIFF
--- a/dojo/user/ui/views.py
+++ b/dojo/user/ui/views.py
@@ -11,6 +11,9 @@ from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.auth.forms import AuthenticationForm, PasswordResetForm
 from django.contrib.auth.views import LoginView, PasswordResetConfirmView, PasswordResetView
 from django.contrib.humanize.templatetags.humanize import naturaltime
+from django.contrib.sites.models import Site
+from django.contrib.sites.requests import RequestSite
+from django.contrib.sites.shortcuts import get_current_site
 from django.core import serializers
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.core.mail import get_connection
@@ -58,6 +61,27 @@ labels = get_labels()
 class DojoLoginView(LoginView):
     template_name = "dojo/login.html"
     authentication_form = AuthenticationForm
+
+    def get_context_data(self, **kwargs):
+        # Django's LoginView.get_context_data() resolves the current Site via
+        # get_current_site(), which raises Site.DoesNotExist (surfacing as an
+        # HTTP 500 on the login page) when the django_site row referenced by
+        # SITE_ID is absent on an instance. Resolve the site defensively and
+        # fall back to a request-derived site -- mirroring what Django itself
+        # does when the sites framework is not installed -- so the login page
+        # always renders instead of 500ing.
+        try:
+            current_site = get_current_site(self.request)
+        except Site.DoesNotExist:
+            current_site = RequestSite(self.request)
+        context = super(LoginView, self).get_context_data(**kwargs)
+        context.update({
+            self.redirect_field_name: self.get_redirect_url(),
+            "site": current_site,
+            "site_name": current_site.name,
+            **(self.extra_context or {}),
+        })
+        return context
 
     def form_valid(self, form):
         last_login = None

--- a/unittests/test_login_view_missing_site.py
+++ b/unittests/test_login_view_missing_site.py
@@ -1,0 +1,32 @@
+from django.contrib.sites.models import Site
+from django.test import TestCase, override_settings
+
+
+# Regression: GET /login returned HTTP 500 (Site.DoesNotExist) on instances
+# whose django_site row referenced by SITE_ID was absent. Django's LoginView
+# resolves the current Site while building the login page context, and raises
+# when that row is missing; the login page must render regardless.
+@override_settings(SECURE_SSL_REDIRECT=False)
+class TestLoginViewMissingSite(TestCase):
+
+    def test_login_page_renders_when_site_present(self):
+        # Control case: the default Site row exists, login renders normally.
+        self.assertTrue(Site.objects.exists())
+        response = self.client.get("/login")
+        self.assertEqual(
+            response.status_code, 200,
+            msg=f"login GET returned {response.status_code} with a Site row present",
+        )
+
+    def test_login_page_renders_when_site_row_missing(self):
+        # Reproduce the reported condition: no django_site row matches SITE_ID.
+        Site.objects.all().delete()
+        self.assertFalse(Site.objects.exists())
+        response = self.client.get("/login")
+        self.assertEqual(
+            response.status_code, 200,
+            msg=(
+                f"login GET returned {response.status_code} when the Site row is "
+                "missing (expected 200, not a Site.DoesNotExist 500)"
+            ),
+        )


### PR DESCRIPTION
## Problem

`GET /login` returns an HTTP 500 on instances where the `django_site` row referenced by `SITE_ID` is absent from the database:

```
django.contrib.sites.models.Site.DoesNotExist: Site matching query does not exist.
  ...
  File ".../django/contrib/auth/views.py", line 113, in get_context_data
    current_site = get_current_site(self.request)
  File ".../django/contrib/sites/shortcuts.py", line 16, in get_current_site
    return Site.objects.get_current(request)
  File ".../django/contrib/sites/models.py", line 59, in get_current
    return self._get_site_by_id(site_id)
```

Django's `LoginView.get_context_data()` unconditionally resolves the current `Site` while building the login page context. `Site.objects.get_current()` looks the row up by `SITE_ID` and raises `Site.DoesNotExist` when that row is missing. Because this happens on the anonymous login page itself, the failure locks users out entirely — they cannot even reach the sign-in form.

## Root cause

`DojoLoginView` (`dojo/user/ui/views.py`) inherits Django's `LoginView.get_context_data`, which hard-depends on a `Site` row existing for `SITE_ID`. The `Site` object is only used to populate `site`/`site_name` in the template context, so a missing row should never take the whole page down.

## Fix

Override `get_context_data` on `DojoLoginView` to resolve the current site defensively, falling back to `RequestSite(request)` when `Site.DoesNotExist` is raised. This mirrors what Django itself does in `get_current_site()` when the sites framework is not installed, so the login page always renders. No schema change.

## Why no migration

Seeding the `Site` row via a data migration was considered and rejected:

- It would not help an instance whose row is later removed, or whose `SITE_ID` points at a different (missing) row — the page would 500 again.
- This is a code-robustness gap, not a schema gap: the login page must never 500 because an optional context row is missing.
- Migrations are one-way and heavier than a small defensive fallback that fixes every variant of the condition.

The defensive fallback resolves all cases with zero migrations.

## Tests

New `unittests/test_login_view_missing_site.py`:

- **Control**: `Site` row present → `GET /login` returns 200.
- **Regression**: all `Site` rows deleted → `GET /login` returns 200 (previously 500 with `Site.DoesNotExist`).

Verified locally: the regression test reproduces the exact `Site.DoesNotExist` traceback against the current code and passes with the fix; the control case and the existing login-touching test (`test_permission_policy_headers`) stay green.

## Downstream (commercial plugin) impact

The commercial plugin overrides the `/login` route with a `ProLoginView` that subclasses `DojoLoginView` and does not override `get_context_data`, so it inherits this fix directly. Its login template does not reference `site`/`site_name`, so no template change is required there. This change therefore resolves the reported errors on those instances without any additional downstream code.


---
_Generated by [Claude Code](https://claude.ai/code/session_014MhRZa88XXg3GHhpvz3pEk)_