### PR TITLE
chore(ui): improve readability of the version in the footer

### DIFF
--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -967,7 +967,7 @@
                                 <img src="{% static "dojo/img/chop.png" %}" alt="{% trans "DefectDojo Chop" %}" style="height:45px;width:auto;display:inline-block"/>
                             </a>
                         </p>
-                        <p class="mt-2">{% dojo_version %} ( {% dojo_current_hash %} )</p>
+                        <p class="mt-2">{% dojo_version %} ({% dojo_current_hash %})</p>
                         <p>
                             Detailed DefectDojo documentation can be found in our <a href="{% dojo_docs_url %}" class="text-blue-600 hover:underline">GitHub Pages</a>.
                         </p>

--- a/dojo/templatetags/display_tags.py
+++ b/dojo/templatetags/display_tags.py
@@ -142,7 +142,7 @@ def dojo_version():
     version = __version__
     if settings.FOOTER_VERSION:
         version = settings.FOOTER_VERSION
-    return f"v. {version}"
+    return f"Version {version}"
 
 
 @register.simple_tag


### PR DESCRIPTION
**Description**

This PR fixes the way the version is displayed in the footer: `v. x.y.z` isn't very elegant, and the spaces between the current hash and the parentheses are unnecessary. 

**Checklist**

- [X] Make sure to rebase your PR against the very latest `dev`.
- [X] Features/Changes should be submitted against the `dev`.
- [X] Give a meaningful name to your PR, as it may end up being used in the release notes.
- [X] Your code is Ruff compliant (see [ruff.toml](../ruff.toml)).
- [X] Your code is python 3.13 compliant.
- [x] Add the proper label to categorize your PR.