### PR TITLE
fix(importers): accept scan severities case-insensitively

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -908,7 +908,10 @@ class BaseImporter(ImporterOptions):
         There is a simple conversion process to convert any of the following
         to a value of Info
         - info, informational, Informational, None, none
-        If not, raise a ValidationError explaining as such
+        Severity matching is case-insensitive, so values such as "medium" or
+        "CRITICAL" are normalized to their supported form ("Medium", "Critical").
+        If the severity is still not recognized, raise a ValidationError
+        explaining as such
         """
         # Checks around Informational/Info severity
         starts_with_info = finding.severity.lower().startswith("info")
@@ -918,6 +921,11 @@ class BaseImporter(ImporterOptions):
         if not_info and (starts_with_info or lower_none):
             # Correct the severity
             finding.severity = "Info"
+        # Normalize the case of any remaining severity so that a value like
+        # "medium" is accepted as the supported "Medium" instead of rejected
+        if finding.severity not in SEVERITIES:
+            canonical_severities = {severity.lower(): severity for severity in SEVERITIES}
+            finding.severity = canonical_severities.get(finding.severity.lower(), finding.severity)
         # Ensure the final severity is one of the supported options
         if finding.severity not in SEVERITIES:
             msg = (

--- a/unittests/test_importers_importer.py
+++ b/unittests/test_importers_importer.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 from django.utils import timezone
+from parameterized import parameterized
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 
@@ -1607,3 +1608,52 @@ class TestDojoImporterBatchPushToJira(DojoTestCase):
             flags[ungrouped_db.id],
             msg=f"ungrouped finding must be pushed individually, dispatched with push_to_jira={flags[ungrouped_db.id]}",
         )
+
+
+class TestSanitizeSeverity(DojoTestCase):
+
+    """Unit tests for BaseImporter.sanitize_severity severity normalization."""
+
+    # Regression: findings imported with a lowercase severity such as "medium"
+    # (e.g. via Generic Findings Import) were rejected with
+    # 'Finding severity "medium" is not supported' because only info/none
+    # variants were case-normalized. Severity matching must be case-insensitive.
+
+    def setUp(self):
+        # sanitize_severity does not use importer state, so it is exercised on a
+        # bare importer instance to keep this a pure unit test with no DB setup.
+        self.importer = DefaultImporter.__new__(DefaultImporter)
+
+    @parameterized.expand([
+        # Failing cases before the fix (wrong-case supported severities)
+        ("medium", "Medium"),
+        ("MEDIUM", "Medium"),
+        ("high", "High"),
+        ("HIGH", "High"),
+        ("critical", "Critical"),
+        ("low", "Low"),
+        # Control cases (already-correct values must be preserved)
+        ("Medium", "Medium"),
+        ("Critical", "Critical"),
+        ("Info", "Info"),
+        # Existing info/none normalization must keep working
+        ("info", "Info"),
+        ("informational", "Info"),
+        ("none", "Info"),
+    ])
+    def test_sanitize_severity_is_case_insensitive(self, submitted, expected):
+        finding = Finding(severity=submitted)
+        result = self.importer.sanitize_severity(finding)
+        self.assertEqual(
+            result.severity, expected,
+            msg=f"expected severity={expected} for input {submitted!r}, got {result.severity!r}",
+        )
+        self.assertEqual(
+            result.numerical_severity, Finding.get_numerical_severity(expected),
+            msg=f"numerical_severity not set for normalized severity {expected}",
+        )
+
+    def test_sanitize_severity_rejects_genuinely_unsupported(self):
+        finding = Finding(severity="bogus")
+        with self.assertRaises(ValidationError):
+            self.importer.sanitize_severity(finding)


### PR DESCRIPTION
**Description**

Scan imports fail with a hard `ValidationError` when a finding's severity is supplied in the wrong letter case — for example a Generic Findings Import whose findings carry `"severity": "medium"`:

```
django.core.exceptions.ValidationError: ['Finding severity "medium" is not supported.
Any of the following are supported: ['Info', 'Low', 'Medium', 'High', 'Critical'].']
```

The whole async import task aborts, so a single lowercase severity value stops the entire report from being ingested.

**Root cause**

`BaseImporter.sanitize_severity` (`dojo/importers/base_importer.py`) only normalized case for the `Info`/`Informational`/`None` family. Every other severity was matched **case-sensitively** against `SEVERITIES` (`['Info', 'Low', 'Medium', 'High', 'Critical']`), so `"medium"`, `"high"`, `"critical"` and `"low"` fell straight through to the "not supported" `ValidationError`. Several parsers (Generic Findings Import among them) pass a user-provided severity string through untouched, which is how a wrong-case value reaches the sanitizer.

**Fix**

Normalize the severity's case against the supported set before the membership check: a value whose lowercase form matches a supported severity is mapped to the canonical spelling (`"medium"` → `"Medium"`). Genuinely unsupported values still raise `ValidationError`, and the existing `Info`/`None` handling is unchanged. This makes severity matching consistently case-insensitive, matching the leniency already applied to the `Info` family. No migration — this is pure importer-validation logic.

**Impact on DefectDojo Pro**

`sanitize_severity` is inherited unchanged by the Pro importers: Pro's importer goes through the OSS `process_findings`/`_process_findings_internal` path, and Pro's Smart Upload importer calls `self.sanitize_severity` directly. Neither overrides it, so the fix flows through to Pro's importers and Smart Upload with no Pro-side change and no override to update.

**Test results**

Added `TestSanitizeSeverity` in `unittests/test_importers_importer.py`:

- A parameterized case-insensitivity test covering the failing inputs (`medium`, `MEDIUM`, `high`, `HIGH`, `critical`, `low`) alongside control inputs already in canonical case (`Medium`, `Critical`, `Info`) and the existing `info`/`informational`/`none` normalization. It asserts both the normalized `severity` and that `numerical_severity` is set correctly.
- A test that a genuinely unsupported value (`bogus`) still raises `ValidationError`, locking in that the sanitizer stays strict for real garbage.

Verified locally against a PostgreSQL test database: the six wrong-case cases fail before the fix with the exact `ValidationError` above and pass after; the full `test_importers_importer.py` module is green (63 passed, 23 subtests) with no collateral damage.

**Documentation**

No documentation change needed — this restores acceptance of a value users already reasonably expect to work; there is no new setting or user-facing behavior to document.

**Checklist**

- [x] Bugfix submitted against the `bugfix` branch.
- [x] Meaningful PR name for release notes.
- [x] Code is Ruff compliant.
- [x] Code is Python 3.13 compliant.
- [x] No model changes / no migration required.
- [x] Added unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUqP65vyMekyL3ZgTBCkmw

---
_Generated by [Claude Code](https://claude.ai/code/session_01DUqP65vyMekyL3ZgTBCkmw)_