### PR TITLE
refactor(importers): extract the import-history write into an overridable hook

### DIFF
--- a/dojo/importers/base_importer.py
+++ b/dojo/importers/base_importer.py
@@ -561,6 +561,33 @@ class BaseImporter(ImporterOptions):
         import_settings["create_finding_groups_for_all_findings"] = self.create_finding_groups_for_all_findings
         if len(self.endpoints_to_add) > 0:
             import_settings.update(self.location_handler.serialize_extra_locations(self.endpoints_to_add))
+        # Persist through an overridable hook so a subclass can redirect the write (below).
+        return self._persist_import_history(
+            import_settings,
+            new_findings,
+            closed_findings,
+            reactivated_findings,
+            untouched_findings,
+        )
+
+    def _persist_import_history(
+        self,
+        import_settings: dict,
+        new_findings: list[int],
+        closed_findings: list[int],
+        reactivated_findings: list[int],
+        untouched_findings: list[int],
+    ) -> Test_Import:
+        """
+        Persist the import-history write: the Test_Import row plus one
+        Test_Import_Finding_Action per affected finding, and return the Test_Import.
+
+        Factored out of update_import_history as an OVERRIDABLE extension point. The default is
+        the Django ORM write; a subclass may redirect the write elsewhere (e.g. delegate it to
+        another service) without reimplementing the settings-building and list-normalization that
+        update_import_history has already done. update_import_history has also already applied the
+        TRACK_IMPORT_HISTORY gate, so this is only reached when history is being recorded.
+        """
         # Create the test import object
         test_import = Test_Import.objects.create(
             test=self.test,


### PR DESCRIPTION
## Description

Extract the import-history persistence in `BaseImporter.update_import_history` into a new overridable method, `_persist_import_history`.

`update_import_history` still builds `import_settings`, normalizes the four finding-id lists, and applies the `TRACK_IMPORT_HISTORY` gate; it then delegates the actual write — the `Test_Import` row plus one `Test_Import_Finding_Action` per affected finding — to `_persist_import_history(import_settings, new_findings, closed_findings, reactivated_findings, untouched_findings)`, and returns its result.

## Why

This is a pure extraction. The default `_persist_import_history` is the existing Django ORM write, moved verbatim, so behavior is unchanged and no new dependencies are introduced. Separating the write behind a small extension point lets a subclass redirect where import history is persisted without having to reimplement the settings-building and list-normalization that precede it.

## Behavior

No functional change. The Test_Import row and its finding-action rows are created exactly as before (same columns, same mapping order, same existence filtering, same `bulk_create(ignore_conflicts=True)` with the per-record IntegrityError fallback), and the return value is unchanged.

## Test

Covered by the existing import/reimport history tests, which exercise `update_import_history` end to end and assert the recorded `Test_Import` and finding-action rows.
