### PR TITLE
docs(connectors): Rapid7 InsightVM - Cloud Instance connector reference

### DIFF
--- a/docs/content/connectors/toolreference/rapid7_insightvm_cloud.de.md
+++ b/docs/content/connectors/toolreference/rapid7_insightvm_cloud.de.md
@@ -1,0 +1,23 @@
+---
+title: "Rapid7 InsightVM - Cloud Instance"
+description: "Einrichtung des Rapid7 InsightVM - Cloud Instance Upstream-Connectors für DefectDojo"
+weight: 113
+audience: pro
+---
+Der Rapid7-InsightVM-Cloud-Instance-Connector importiert Asset-Schwachstellenbefunde aus InsightVM, das auf der **Rapid7-Insight-Plattform** gehostet wird (Cloud Integrations API v4), angereichert mit dem Schwachstellenkatalog der Plattform. DefectDojo erstellt für jede InsightVM-**Site** einen Eintrag.
+
+**Bitte beachten Sie:** Dieser Connector ist für InsightVM auf der Rapid7-Insight-Cloud-Plattform. Wenn Ihre Befunde aus Ihrer eigenen **Security Console** (on\-premises) stammen, verwenden Sie stattdessen den Connector [Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/), der sich mit Console-Anmeldedaten statt mit einem Platform-API-Schlüssel authentifiziert.
+
+#### Voraussetzungen
+
+Ein Insight-Platform-Konto mit InsightVM sowie ein Platform-**API-Schlüssel**: Öffnen Sie in der [Rapid7-Insight-Plattform](https://insight.rapid7.com) das Einstellungsmenü (Zahnrad) \> **API Keys** und generieren Sie einen **User Key** (beliebige Rolle) oder einen **Organization Key** (Platform-Admins). Kopieren Sie den Schlüssel, wenn er angezeigt wird: Er wird nur einmal angezeigt.
+
+Sie benötigen außerdem Ihre Platform-**Region**, sichtbar in Ihrer Insight-URL (zum Beispiel `us`, `us2`, `us3`, `eu`, `ca`, `au` oder `ap`).
+
+#### Connector-Zuordnungen
+
+1. Geben Sie Ihren regionalen API-Endpunkt in das Feld **Location** ein, zum Beispiel `https://us.api.insight.rapid7.com` (ersetzen Sie `us` durch Ihre Region). Dieses Feld ist mit dem US-Endpunkt vorausgefüllt.
+2. Geben Sie den API-Schlüssel der Insight-Plattform in das Feld **API Key** ein.
+3. Legen Sie optional einen **Minimum Severity**-Wert fest, um einzuschränken, welche Befunde importiert werden.
+
+Jede InsightVM-Site wird zu einem Eintrag; der Connector liest die Integrations-Assets der Plattform und importiert deren anfällige Befunde, angereichert aus dem Schwachstellenkatalog. Befunde werden unter demselben Typ **Rapid7 InsightVM - Connectors Import** wie beim On\-premises-Connector importiert, sodass die Ergebnisse beider Connectoren gemeinsam dedupliziert werden.

--- a/docs/content/connectors/toolreference/rapid7_insightvm_cloud.es.md
+++ b/docs/content/connectors/toolreference/rapid7_insightvm_cloud.es.md
@@ -1,0 +1,23 @@
+---
+title: "Rapid7 InsightVM - Cloud Instance"
+description: "Cómo configurar el Conector Upstream de Rapid7 InsightVM - Cloud Instance para DefectDojo"
+weight: 113
+audience: pro
+---
+El conector de Rapid7 InsightVM - Cloud Instance importa hallazgos de vulnerabilidades de activos desde InsightVM alojado en la **plataforma Rapid7 Insight** (Cloud Integrations API v4), enriquecidos con el catálogo de vulnerabilidades de la plataforma. DefectDojo crea un Record para cada **site** de InsightVM.
+
+**Tenga en cuenta:** este conector es para InsightVM que se ejecuta en la plataforma en la nube Rapid7 Insight. Si sus hallazgos provienen de su propia **Security Console** on\-premises, use en su lugar el conector [Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/), que se autentica con credenciales de la consola en lugar de una API key de la plataforma.
+
+#### Requisitos previos
+
+Una cuenta de la plataforma Insight con InsightVM, y una **API key** de la plataforma: en [Rapid7 Insight platform](https://insight.rapid7.com), abra el menú de configuración (el ícono de engranaje) > **API Keys** y genere una **User Key** (cualquier rol) o una **Organization Key** (administradores de la plataforma). Copie la clave cuando se muestre: solo se muestra una vez.
+
+También necesitará la **región** de su plataforma, visible en su URL de Insight (por ejemplo, `us`, `us2`, `us3`, `eu`, `ca`, `au` o `ap`).
+
+#### Asignaciones del conector
+
+1. Ingrese el endpoint de API de su región en el campo **Location**, por ejemplo `https://us.api.insight.rapid7.com` (reemplace `us` por su región). Este campo viene pre\-rellenado con el endpoint de EE. UU.
+2. Ingrese la API key de la plataforma Insight en el campo **API Key**.
+3. Opcionalmente, establezca una **Minimum Severity** para limitar qué hallazgos se importan.
+
+Cada site de InsightVM se convierte en un Record; el conector lee los activos de integración de la plataforma e importa sus hallazgos de vulnerabilidades, enriquecidos con el catálogo de vulnerabilidades. Los hallazgos se importan bajo el mismo tipo **Rapid7 InsightVM - Connectors Import** que el conector on\-premises, por lo que los resultados de ambos conectores se deduplican juntos.

--- a/docs/content/connectors/toolreference/rapid7_insightvm_cloud.fr.md
+++ b/docs/content/connectors/toolreference/rapid7_insightvm_cloud.fr.md
@@ -1,0 +1,23 @@
+---
+title: "Rapid7 InsightVM - Cloud Instance"
+description: "Comment configurer le Connecteur Upstream Rapid7 InsightVM - Cloud Instance pour DefectDojo"
+weight: 113
+audience: pro
+---
+Le connecteur Rapid7 InsightVM - Cloud Instance importe les constatations de vulnérabilités d'actifs depuis InsightVM hébergé sur la **plateforme Rapid7 Insight** (Cloud Integrations API v4), enrichies avec le catalogue de vulnérabilités de la plateforme. DefectDojo crée un Record pour chaque **site** InsightVM.
+
+**Remarque :** ce Connecteur concerne InsightVM exécuté sur la plateforme cloud Rapid7 Insight. Si vos constatations proviennent de votre propre **Security Console** on\-premises, utilisez plutôt le connecteur [Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/), qui s'authentifie avec des identifiants de console plutôt qu'avec une clé API de plateforme.
+
+#### Prérequis
+
+Un compte de la plateforme Insight avec InsightVM, et une **clé API** de plateforme : dans la [plateforme Rapid7 Insight](https://insight.rapid7.com), ouvrez le menu des paramètres (icône d'engrenage) \> **API Keys** et générez une **User Key** (n'importe quel rôle) ou une **Organization Key** (administrateurs de la plateforme). Copiez la clé lorsqu'elle s'affiche : elle n'est affichée qu'une seule fois.
+
+Vous avez également besoin de votre **région** de plateforme, visible dans votre URL Insight (par exemple `us`, `us2`, `us3`, `eu`, `ca`, `au`, ou `ap`).
+
+#### Correspondances du connecteur
+
+1. Saisissez votre endpoint API régional dans le champ **Location**, par exemple `https://us.api.insight.rapid7.com` (remplacez `us` par votre région). Ce champ est pré\-rempli avec l'endpoint des États\-Unis.
+2. Saisissez la clé API de la plateforme Insight dans le champ **API Key**.
+3. Optionnellement, définissez une **Minimum Severity** pour limiter les constatations importées.
+
+Chaque site InsightVM devient un Record ; le connecteur lit les actifs d'intégration de la plateforme et importe leurs constatations de vulnérabilités, enrichies à partir du catalogue de vulnérabilités. Les constatations sont importées sous le même type **Rapid7 InsightVM - Connectors Import** que le connecteur on\-premises, de sorte que les résultats des deux connecteurs sont dédupliqués ensemble.

--- a/docs/content/connectors/toolreference/rapid7_insightvm_cloud.ja.md
+++ b/docs/content/connectors/toolreference/rapid7_insightvm_cloud.ja.md
@@ -1,0 +1,23 @@
+---
+title: "Rapid7 InsightVM - Cloud Instance"
+description: "DefectDojo で Rapid7 InsightVM - Cloud Instance の Upstream Connector をセットアップする方法"
+weight: 113
+audience: pro
+---
+Rapid7 InsightVM - Cloud Instanceコネクタは、**Rapid7 Insightプラットフォーム**（Cloud Integrations API v4）でホストされているInsightVMからアセットの脆弱性検出事項をインポートし、プラットフォームの脆弱性カタログで情報を付加します。DefectDojoは各InsightVM**サイト**についてRecordを作成します。
+
+**ご注意ください:** このConnectorは、Rapid7 Insightクラウドプラットフォーム上で動作するInsightVM向けです。検出事項がお使いの**Security Console**（オンプレミス）から取得される場合は、代わりに[Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/)コネクタをご利用ください。こちらはプラットフォームのAPIキーではなくコンソールの認証情報で認証します。
+
+#### 前提条件
+
+InsightVMを利用するInsightプラットフォームのアカウントと、プラットフォームの**APIキー**が必要です: [Rapid7 Insightプラットフォーム](https://insight.rapid7.com)で設定（歯車）メニュー > **API Keys** を開き、**User Key**（任意のロール）または**Organization Key**（プラットフォーム管理者）を生成します。表示された時点でキーをコピーしてください。キーは一度しか表示されません。
+
+また、Insight URLに表示されるプラットフォームの**リージョン**（例: `us`、`us2`、`us3`、`eu`、`ca`、`au`、`ap`）も必要です。
+
+#### Connector Mappings
+
+1. **Location** フィールドにリージョンのAPIエンドポイントを入力します。例: `https://us.api.insight.rapid7.com`（`us` をお使いのリージョンに置き換えてください）。このフィールドには米国のエンドポイントがあらかじめ入力されています。
+2. **API Key** フィールドにInsightプラットフォームのAPIキーを入力します。
+3. 必要に応じて、インポートする検出事項を絞り込むために **Minimum Severity** を設定します。
+
+各InsightVMサイトが1件のRecordになります。コネクタはプラットフォームの統合アセットを読み取り、その脆弱な検出事項を脆弱性カタログで情報を付加してインポートします。検出事項はオンプレミスのコネクタと同じ **Rapid7 InsightVM - Connectors Import** タイプでインポートされるため、両方のコネクタの結果はまとめて重複排除されます。

--- a/docs/content/connectors/toolreference/rapid7_insightvm_cloud.md
+++ b/docs/content/connectors/toolreference/rapid7_insightvm_cloud.md
@@ -1,0 +1,23 @@
+---
+title: "Rapid7 InsightVM - Cloud Instance"
+description: "How to set up the Rapid7 InsightVM - Cloud Instance Upstream Connector for DefectDojo"
+weight: 113
+audience: pro
+---
+The Rapid7 InsightVM - Cloud Instance connector imports asset vulnerability findings from InsightVM hosted on the **Rapid7 Insight platform** (Cloud Integrations API v4), enriched with the platform's vulnerability catalog. DefectDojo creates a Record for each InsightVM **site**.
+
+**Please note:** this Connector is for InsightVM running on the Rapid7 Insight cloud platform. If your findings come from your own on\-premises **Security Console**, use the [Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/) connector instead, which authenticates with console credentials rather than a platform API key.
+
+#### Prerequisites
+
+An Insight platform account with InsightVM, and a platform **API key**: in the [Rapid7 Insight platform](https://insight.rapid7.com), open the settings (gear) menu \> **API Keys** and generate a **User Key** (any role) or an **Organization Key** (platform admins). Copy the key when it is shown, because it is displayed only once.
+
+You also need your platform **region**, visible in your Insight URL (for example `us`, `us2`, `us3`, `eu`, `ca`, `au`, or `ap`).
+
+#### Connector Mappings
+
+1. Enter your regional API endpoint in the **Location** field, for example `https://us.api.insight.rapid7.com` (replace `us` with your region). This field is pre\-filled with the US endpoint.
+2. Enter the Insight platform API key in the **API Key** field.
+3. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each InsightVM site becomes a Record; the connector reads the platform's integration assets and imports their vulnerable findings, enriched from the vulnerability catalog. Findings import under the same **Rapid7 InsightVM - Connectors Import** type as the on\-premises connector, so results from both connectors deduplicate together.

--- a/docs/content/connectors/toolreference/upstream.de.md
+++ b/docs/content/connectors/toolreference/upstream.de.md
@@ -94,6 +94,7 @@ Azure DevOps, Backstage, Bitbucket, GitHub, GitLab, Jira Service Management Asse
 - [Quay](/connectors/toolreference/quay/)
 - [Rapid7 InsightAppSec](/connectors/toolreference/rapid7_insightappsec/)
 - [Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/)
+- [Rapid7 InsightVM - Cloud Instance](/connectors/toolreference/rapid7_insightvm_cloud/)
 - [runZero](/connectors/toolreference/runzero/)
 - [Semgrep](/connectors/toolreference/semgrep/)
 - [ServiceNow CMDB](/connectors/toolreference/servicenow_cmdb/)

--- a/docs/content/connectors/toolreference/upstream.es.md
+++ b/docs/content/connectors/toolreference/upstream.es.md
@@ -94,6 +94,7 @@ Azure DevOps, Backstage, Bitbucket, GitHub, GitLab, Jira Service Management Asse
 - [Quay](/connectors/toolreference/quay/)
 - [Rapid7 InsightAppSec](/connectors/toolreference/rapid7_insightappsec/)
 - [Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/)
+- [Rapid7 InsightVM - Cloud Instance](/connectors/toolreference/rapid7_insightvm_cloud/)
 - [runZero](/connectors/toolreference/runzero/)
 - [Semgrep](/connectors/toolreference/semgrep/)
 - [ServiceNow CMDB](/connectors/toolreference/servicenow_cmdb/)

--- a/docs/content/connectors/toolreference/upstream.fr.md
+++ b/docs/content/connectors/toolreference/upstream.fr.md
@@ -94,6 +94,7 @@ Azure DevOps, Backstage, Bitbucket, GitHub, GitLab, Jira Service Management Asse
 - [Quay](/connectors/toolreference/quay/)
 - [Rapid7 InsightAppSec](/connectors/toolreference/rapid7_insightappsec/)
 - [Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/)
+- [Rapid7 InsightVM - Cloud Instance](/connectors/toolreference/rapid7_insightvm_cloud/)
 - [runZero](/connectors/toolreference/runzero/)
 - [Semgrep](/connectors/toolreference/semgrep/)
 - [ServiceNow CMDB](/connectors/toolreference/servicenow_cmdb/)

--- a/docs/content/connectors/toolreference/upstream.ja.md
+++ b/docs/content/connectors/toolreference/upstream.ja.md
@@ -93,6 +93,7 @@ Azure DevOps、Backstage、Bitbucket、GitHub、GitLab、Jira Service Management
 - [Quay](/connectors/toolreference/quay/)
 - [Rapid7 InsightAppSec](/connectors/toolreference/rapid7_insightappsec/)
 - [Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/)
+- [Rapid7 InsightVM - Cloud Instance](/connectors/toolreference/rapid7_insightvm_cloud/)
 - [runZero](/connectors/toolreference/runzero/)
 - [Semgrep](/connectors/toolreference/semgrep/)
 - [ServiceNow CMDB](/connectors/toolreference/servicenow_cmdb/)

--- a/docs/content/connectors/toolreference/upstream.md
+++ b/docs/content/connectors/toolreference/upstream.md
@@ -134,6 +134,7 @@ Azure DevOps, Backstage, Bitbucket, GitHub, GitLab, JSM Assets, and ServiceNow C
 - [Qwiet AI](/connectors/toolreference/qwiet_ai/)
 - [Rapid7 InsightAppSec](/connectors/toolreference/rapid7_insightappsec/)
 - [Rapid7 InsightVM](/connectors/toolreference/rapid7_insightvm/)
+- [Rapid7 InsightVM - Cloud Instance](/connectors/toolreference/rapid7_insightvm_cloud/)
 - [Red Hat Satellite](/connectors/toolreference/red_hat_satellite/)
 - [runZero](/connectors/toolreference/runzero/)
 - [Scantist](/connectors/toolreference/scantist/)

--- a/docs/content/connectors/upstream/about.de.md
+++ b/docs/content/connectors/upstream/about.de.md
@@ -84,6 +84,7 @@ Wir unterstützen derzeit Upstream-Connectors für die folgenden Tools, weitere 
 * **Quay**
 * **Rapid7 InsightAppSec**
 * **Rapid7 InsightVM**
+* **Rapid7 InsightVM - Cloud Instance**
 * **runZero**
 * **Semgrep**
 * **ServiceNow CMDB**

--- a/docs/content/connectors/upstream/about.es.md
+++ b/docs/content/connectors/upstream/about.es.md
@@ -84,6 +84,7 @@ Actualmente admitimos Conectores ascendentes para las siguientes herramientas, c
 * **Quay**
 * **Rapid7 InsightAppSec**
 * **Rapid7 InsightVM**
+* **Rapid7 InsightVM - Cloud Instance**
 * **runZero**
 * **Semgrep**
 * **ServiceNow CMDB**

--- a/docs/content/connectors/upstream/about.fr.md
+++ b/docs/content/connectors/upstream/about.fr.md
@@ -84,6 +84,7 @@ Nous prenons actuellement en charge les Connecteurs en amont pour les outils sui
 * **Quay**
 * **Rapid7 InsightAppSec**
 * **Rapid7 InsightVM**
+* **Rapid7 InsightVM - Cloud Instance**
 * **runZero**
 * **Semgrep**
 * **ServiceNow CMDB**

--- a/docs/content/connectors/upstream/about.it.md
+++ b/docs/content/connectors/upstream/about.it.md
@@ -84,6 +84,7 @@ Attualmente supportiamo Connettori Upstream per i seguenti strumenti, con altri 
 * **Quay**
 * **Rapid7 InsightAppSec**
 * **Rapid7 InsightVM**
+* **Rapid7 InsightVM - Cloud Instance**
 * **runZero**
 * **Semgrep**
 * **ServiceNow CMDB**

--- a/docs/content/connectors/upstream/about.ja.md
+++ b/docs/content/connectors/upstream/about.ja.md
@@ -84,6 +84,7 @@ DefectDojo を使用すると、洗練された API 連携を構築でき、脆�
 * **Quay**
 * **Rapid7 InsightAppSec**
 * **Rapid7 InsightVM**
+* **Rapid7 InsightVM - Cloud Instance**
 * **runZero**
 * **Semgrep**
 * **ServiceNow CMDB**

--- a/docs/content/connectors/upstream/about.md
+++ b/docs/content/connectors/upstream/about.md
@@ -125,6 +125,7 @@ We currently support Upstream Connectors for the following tools, with more on t
 * **Qwiet AI**
 * **Rapid7 InsightAppSec**
 * **Rapid7 InsightVM**
+* **Rapid7 InsightVM - Cloud Instance**
 * **Red Hat Satellite**
 * **runZero**
 * **Scantist**

--- a/docs/content/connectors/upstream/about.pt-br.md
+++ b/docs/content/connectors/upstream/about.pt-br.md
@@ -85,6 +85,7 @@ Atualmente oferecemos suporte a Conectores Upstream para as seguintes ferramenta
 * **Quay**
 * **Rapid7 InsightAppSec**
 * **Rapid7 InsightVM**
+* **Rapid7 InsightVM - Cloud Instance**
 * **runZero**
 * **Semgrep**
 * **ServiceNow CMDB**

--- a/docs/content/connectors/upstream/about.zh-hans.md
+++ b/docs/content/connectors/upstream/about.zh-hans.md
@@ -84,6 +84,7 @@ DefectDojo 允许用户构建复杂的 API 集成，并让用户完全掌控其�
 * **Quay**
 * **Rapid7 InsightAppSec**
 * **Rapid7 InsightVM**
+* **Rapid7 InsightVM - Cloud Instance**
 * **runZero**
 * **Semgrep**
 * **ServiceNow CMDB**


### PR DESCRIPTION
[sc-15073]

**Description**

Documentation for the new **Rapid7 InsightVM - Cloud Instance** upstream connector (a DefectDojo Pro feature). It adds a per-tool reference page under `connectors/toolreference/` covering setup against the Rapid7 Insight platform Cloud Integrations API v4: generating a platform API key, entering the regional Location URL, and the site-based Records the connector creates. The page notes that this connector is distinct from the on-premises Rapid7 InsightVM connector, which uses Security Console credentials rather than a platform API key.

The new page ships with German, Spanish, French, and Japanese translations, matching the existing Rapid7 pages. The page is also linked from the upstream tool-reference index and added to the supported-connectors list, in English and every existing translation.

Documentation-only change: no code, models, settings, or migrations.

**Test results**

`hugo` builds the site cleanly and the new page renders in all five languages (en/de/es/fr/ja); the index link resolves to the page slug. No unit tests apply to a documentation-only change.

**Documentation**

This PR is the documentation.

**Checklist**

- [x] Submitted against `dev` (new feature documentation).
- [x] Meaningful PR name for release notes.
- [x] Documentation included (this PR).

