### PR TITLE
docs(engagements): explain the locked Asset field and its copy button

### DIFF
--- a/docs/content/asset_modelling/engagements_tests/PRO__engagements.md
+++ b/docs/content/asset_modelling/engagements_tests/PRO__engagements.md
@@ -98,6 +98,13 @@ Every Engagement must have the following fields defined:
 - Asset 
 - Status 
 
+When you start from an Asset — the gear icon, the “+ New Engagement” button, or a
+link that already names the Asset — the Asset field arrives filled in and locked, so
+it cannot be pointed at a different Asset by mistake. A locked field cannot be opened
+or selected with the mouse, so it carries a copy button on its right-hand edge that
+puts the value on your clipboard. The same applies anywhere a field is pre-filled from
+context, such as the Engagement and Scan Type fields when adding a Test.
+
 #### Engagement Statuses 
 
 Engagements can be tagged with different statuses upon creation. The status can also be changed afterward in the Engagement’s settings. 


### PR DESCRIPTION
[sc-15114]

## Description

Documentation for a Pro change that ships on the same release line: fields on the Vue create
forms that arrive pre-filled from context are locked, and a locked field now carries a
copy-to-clipboard button on its right-hand edge.

The Engagements page already told the reader they would "have to select the Asset to which to
attribute the Engagement when completing the New Engagement form", but never mentioned that
arriving from an Asset fills that field in and locks it. A locked field also cannot be opened
or text-selected, so without the note the copy button is the only visible clue about how to
read the value, and the locked state itself reads like a bug.

Adds a short paragraph to the "Create Engagements" section of
`docs/content/asset_modelling/engagements_tests/PRO__engagements.md` covering both: why the
field is locked, and that the copy button is how you get the value out. It also points at the
other place the same thing happens, the Engagement and Scan Type fields when adding a Test.

Docs only — no code change.
