### PR TITLE
Add Aqua Supply Chain connector docs and dedup registration

### DIFF
--- a/docs/content/connectors/toolreference/aqua_supply_chain.md
+++ b/docs/content/connectors/toolreference/aqua_supply_chain.md
@@ -28,6 +28,8 @@ A repository's default branch is always imported. Two optional fields extend thi
 - **Branch**: an exact branch name, or a `*` wildcard family such as `release/*`. It adds matching branches on top of the default branch.
 - **Track Scanned Branches**: when enabled, each imported branch gets its own engagement on the mapped Record. A fix on one branch then cannot close another branch's findings. The default branch is imported first. When this is off, all selected branches import into the Record's default engagement.
 
+This setting also affects which branches are selected when **Branch** is blank. If **Track Scanned Branches** is off, only the default branch is imported. If it is on, every branch Aqua has scanned is imported.
+
 Aqua only stores results for a branch it has actually scanned. A Branch value that matches no scanned branch contributes no findings for that branch.
 
 #### Filing

--- a/docs/content/connectors/toolreference/aqua_supply_chain.md
+++ b/docs/content/connectors/toolreference/aqua_supply_chain.md
@@ -26,7 +26,7 @@ Each repository in the tenant becomes a Record. A repository that disappears fro
 A repository's default branch is always imported. Two optional fields extend this:
 
 - **Branch**: an exact branch name, or a `*` wildcard family such as `release/*`. It adds matching branches on top of the default branch.
-- **Track Scanned Branches**: when enabled, each imported branch gets its own engagement on the mapped Record. A fix on one branch then cannot close another branch's findings. The default branch is imported first, so the same finding recurring on another branch deduplicates against the default branch's original. When this is off, all selected branches import into the Record's default engagement.
+- **Track Scanned Branches**: when enabled, each imported branch gets its own engagement on the mapped Record. A fix on one branch then cannot close another branch's findings. The default branch is imported first. When this is off, all selected branches import into the Record's default engagement.
 
 Aqua only stores results for a branch it has actually scanned. A Branch value that matches no scanned branch contributes no findings for that branch.
 
@@ -40,4 +40,4 @@ Aqua can return several byte-identical rows for the same finding. One example is
 
 #### Sync cost
 
-A full sync pulls the whole tenant in a handful of requests. It sends roughly one request per 10,000 findings, plus one request for the repository list. The connector groups the results locally.
+A full sync pulls the whole tenant in a handful of requests. It sends roughly one request per 10,000 findings, plus the repository list, which takes two or three requests. The connector groups the results locally.

--- a/docs/content/connectors/toolreference/aqua_supply_chain.md
+++ b/docs/content/connectors/toolreference/aqua_supply_chain.md
@@ -12,7 +12,7 @@ An **admin-generated** Aqua **API key and secret**, created under **Account Mana
 
 #### Connector Mappings
 
-1. Enter your Aqua Supply Chain **edge** host in the **Location** field, for example `https://eu-central-1.edge.cloud.aquasec.com`. This is not the tenant URL the Aqua Security connector uses: Aqua Supply Chain Security answers on the region's **edge** host, not `<tenant>.cloud.aquasec.com`.
+1. Enter your Aqua Supply Chain **edge** host in the **Location** field, for example `https://eu-central-1.edge.cloud.aquasec.com`. This is not the tenant URL the Aqua Security connector uses. Aqua Supply Chain Security answers on the region's **edge** host, not `<tenant>.cloud.aquasec.com`.
 2. Enter the API key in the **API Key** field.
 3. Enter the API secret in the **API Secret** field.
 4. If your tenant is in the EU, set the **Auth Host** field to `https://eu-1.api.cloudsploit.com`. Leave it blank for the US host, `https://api.cloudsploit.com`. Aqua caps the issued authentication token at two hours, regardless of the validity the connector requests. The connector re-authenticates on its own when the token expires.
@@ -32,7 +32,7 @@ Aqua only stores results for a branch it has actually scanned. A Branch value th
 
 #### Filing
 
-Set **Filing Prefixes** to a comma-separated list of repository-name prefixes, for example `DIAI,DAAR,DCCP,TECS`. Each repository is filed under the prefix its name starts with. A repository that matches none of the configured prefixes is filed under **Fallback Filing Name**, which defaults to `Aqua Unmapped`. Leave **Filing Prefixes** blank to file each repository under the first hyphen- or underscore-delimited part of its name instead.
+Set **Filing Prefixes** to a comma-separated list of repository-name prefixes, for example `PAY,WEB,INFRA`. Each repository is filed under the prefix its name starts with. A repository that matches none of the configured prefixes is filed under **Fallback Filing Name**, which defaults to `Aqua Unmapped`. Leave **Filing Prefixes** blank to file each repository under the first hyphen- or underscore-delimited part of its name instead.
 
 #### Duplicate findings
 

--- a/docs/content/connectors/toolreference/aqua_supply_chain.md
+++ b/docs/content/connectors/toolreference/aqua_supply_chain.md
@@ -26,7 +26,7 @@ Each repository in the tenant becomes a Record. A repository that disappears fro
 A repository's default branch is always imported. Two optional fields extend this:
 
 - **Branch**: an exact branch name, or a `*` wildcard family such as `release/*`. It adds matching branches on top of the default branch.
-- **Track Scanned Branches**: when enabled, each imported branch gets its own engagement on the mapped Record. A fix on one branch then cannot close another branch's findings. The default branch is imported first. When this is off, all selected branches import into the Record's default engagement.
+- **Track Scanned Branches**: when enabled, each imported branch gets its own engagement on the mapped Record. A fix on one branch then cannot close another branch's findings. The default branch is imported first. A finding that also appears on another branch is marked a duplicate of the default branch's finding. When this is off, all selected branches import into the Record's default engagement.
 
 This setting also affects which branches are selected when **Branch** is blank. If **Track Scanned Branches** is off, only the default branch is imported. If it is on, every branch Aqua has scanned is imported.
 

--- a/docs/content/connectors/toolreference/aqua_supply_chain.md
+++ b/docs/content/connectors/toolreference/aqua_supply_chain.md
@@ -1,0 +1,43 @@
+---
+title: "Aqua Supply Chain"
+description: "How to set up the Aqua Supply Chain Upstream Connector for DefectDojo"
+weight: 18
+audience: pro
+---
+The Aqua Supply Chain connector imports **code-security findings from Aqua Supply Chain Security**. It covers five categories: vulnerabilities, secrets, infrastructure-as-code misconfigurations, SAST findings and pipeline misconfigurations. It imports these findings across every repository in your Aqua tenant. This is a different product from the [Aqua Security](/connectors/toolreference/aqua_security/) connector, which imports container image and workload vulnerabilities. The two connectors call different hosts, so do not point one at the other's URL. DefectDojo creates a Record for each repository.
+
+#### Prerequisites
+
+An **admin-generated** Aqua **API key and secret**, created under **Account Management \> API Keys** in the Aqua console. This is the same key and secret the Aqua Security connector uses. The secret is shown only once when the key is generated, so capture it at that point. Neither value is ever logged.
+
+#### Connector Mappings
+
+1. Enter your Aqua Supply Chain **edge** host in the **Location** field, for example `https://eu-central-1.edge.cloud.aquasec.com`. This is not the tenant URL the Aqua Security connector uses: Aqua Supply Chain Security answers on the region's **edge** host, not `<tenant>.cloud.aquasec.com`.
+2. Enter the API key in the **API Key** field.
+3. Enter the API secret in the **API Secret** field.
+4. If your tenant is in the EU, set the **Auth Host** field to `https://eu-1.api.cloudsploit.com`. Leave it blank for the US host, `https://api.cloudsploit.com`. Aqua caps the issued authentication token at two hours, regardless of the validity the connector requests. The connector re-authenticates on its own when the token expires.
+5. Optionally, set **Scan Categories** to a comma-separated list of the categories to import. The five values are `vulnerabilities` (SCA), `secrets`, `iacMisconfigurations` (IaC), `sast` and `pipelineMisconfigurations` (Pipeline). Leave it blank to import all five. Each finding carries a `category:<value>` tag naming the category it came from.
+6. Optionally, set a **Minimum Severity** to limit which findings are imported. Aqua reports severity as a 0-4 value, which DefectDojo maps to Info, Low, Medium, High and Critical.
+
+Each repository in the tenant becomes a Record. A repository that disappears from Aqua stops being returned by the API. DefectDojo reconciles it like any other connector's missing record. Enable **Skip Repositories With No Findings** to only create a Record for a repository that has at least one finding.
+
+#### Branch handling
+
+A repository's default branch is always imported. Two optional fields extend this:
+
+- **Branch**: an exact branch name, or a `*` wildcard family such as `release/*`. It adds matching branches on top of the default branch.
+- **Track Scanned Branches**: when enabled, each imported branch gets its own engagement on the mapped Record. A fix on one branch then cannot close another branch's findings. The default branch is imported first, so the same finding recurring on another branch deduplicates against the default branch's original. When this is off, all selected branches import into the Record's default engagement.
+
+Aqua only stores results for a branch it has actually scanned. A Branch value that matches no scanned branch contributes no findings for that branch.
+
+#### Filing
+
+Set **Filing Prefixes** to a comma-separated list of repository-name prefixes, for example `DIAI,DAAR,DCCP,TECS`. Each repository is filed under the prefix its name starts with. A repository that matches none of the configured prefixes is filed under **Fallback Filing Name**, which defaults to `Aqua Unmapped`. Leave **Filing Prefixes** blank to file each repository under the first hyphen- or underscore-delimited part of its name instead.
+
+#### Duplicate findings
+
+Aqua can return several byte-identical rows for the same finding. One example is a row per instantiation of a shared Terraform module. The connector keeps one copy and records how many rows it collapsed in the finding description.
+
+#### Sync cost
+
+A full sync pulls the whole tenant in a handful of requests. It sends roughly one request per 10,000 findings, plus one request for the repository list. The connector groups the results locally.

--- a/docs/content/connectors/toolreference/upstream.md
+++ b/docs/content/connectors/toolreference/upstream.md
@@ -45,6 +45,7 @@ Azure DevOps, Backstage, Bitbucket, GitHub, GitLab, JSM Assets, and ServiceNow C
 - [Anchore Enterprise](/connectors/toolreference/anchore_enterprise/)
 - [AppCheck](/connectors/toolreference/appcheck/)
 - [Aqua Security](/connectors/toolreference/aqua_security/)
+- [Aqua Supply Chain](/connectors/toolreference/aqua_supply_chain/)
 - [Automox](/connectors/toolreference/automox/)
 - [Azure DevOps](/connectors/toolreference/azure_devops/)
 - [Backstage](/connectors/toolreference/backstage/)

--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -1670,6 +1670,7 @@ DEDUPLICATION_ALGORITHM_PER_PARSER = {
     "Zimperium zScan": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
     "Group-IB ASM - Connectors Import": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
     "Quay - Connectors Import": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL_OR_HASH_CODE,
+    "Aqua Supply Chain - Connectors Import": DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL,
     "Anchore Engine Scan": DEDUPE_ALGO_HASH_CODE,
     "AnchoreCTL Vuln Report": DEDUPE_ALGO_HASH_CODE,
     "AnchoreCTL Policies Report": DEDUPE_ALGO_HASH_CODE,


### PR DESCRIPTION
**Description**

Adds the documentation page for the Aqua Supply Chain upstream connector (a DefectDojo Pro connector) and lists it on the connector index. Also registers its scan type, `Aqua Supply Chain - Connectors Import`, in `DEDUPLICATION_ALGORITHM_PER_PARSER` as `DEDUPE_ALGO_UNIQUE_ID_FROM_TOOL`, so reimports match on the connector's stable finding id instead of falling back to the legacy title-and-severity algorithm.

The page covers credentials, the region auth host, the five scan categories, branch handling, filing by repository-name prefix, and how the connector deduplicates. English only; translations regenerate from it.

**Test results**

- Hugo docs build passes (`npm run build -- --environment development` in `docs/`), and the new page renders at `/connectors/toolreference/aqua_supply_chain/`.
- `ruff check --config ruff.toml dojo/settings/settings.dist.py` passes.
- No unit test changes. The tests that read `DEDUPLICATION_ALGORITHM_PER_PARSER` use `.get()` or scoped overrides and do not pin the full key set.

**Documentation**

This PR is the documentation.

**Checklist**

- [x] Rebased on the latest `dev`
- [x] Submitted against `dev` (feature, not a bugfix)
- [x] Ruff compliant
- [x] Documentation included
- [ ] No model changes, no migrations needed
- [ ] No unit tests added (settings entry and docs only)

