### PR TITLE
fix(importers): accept .spdx files for scan import

### DIFF
--- a/dojo/settings/settings.dist.py
+++ b/dojo/settings/settings.dist.py
@@ -259,7 +259,7 @@ env = environ.FileAwareEnv(
                                  ".sarif", ".xlsx", ".doc", ".html", ".js", ".nessus", ".zip", ".fpr"]),
     # List of acceptable file types that can be (re)imported
     DD_FILE_IMPORT_TYPES=(list, [".xml", ".csv", ".nessus", ".json", ".jsonl", ".html", ".js", ".zip",
-                                 ".xlsx", ".txt", ".sarif", ".fpr", ".md", ".log", ".fvdl"]),
+                                 ".xlsx", ".txt", ".sarif", ".fpr", ".md", ".log", ".fvdl", ".spdx"]),
     # Max file size for scan added via API in MB
     DD_SCAN_FILE_MAX_SIZE=(int, 100),
     # When disabled, existing user tokens will not be removed but it will not be

--- a/unittests/test_validators.py
+++ b/unittests/test_validators.py
@@ -1,6 +1,8 @@
 from django.core.exceptions import ValidationError
+from django.core.files.uploadedfile import SimpleUploadedFile
+from parameterized import parameterized
 
-from dojo.validators import clean_tags
+from dojo.validators import ImporterFileExtensionValidator, clean_tags
 from unittests.dojo_test_case import DojoTestCase
 
 
@@ -30,3 +32,22 @@ class TestCleanTags(DojoTestCase):
     def test_clean_tags_invalid_type_raises(self):
         with self.assertRaises(ValidationError):
             clean_tags(42)
+
+
+class TestImporterFileExtensionValidator(DojoTestCase):
+    # Regression: .spdx reports were rejected by the import extension allowlist
+    # even though the SPDX parser and a .spdx test fixture support the format.
+
+    @parameterized.expand([
+        ("report.spdx",),
+        ("report.json",),
+    ])
+    def test_accepted_import_extensions(self, filename):
+        upload = SimpleUploadedFile(filename, b"data")
+        # Should not raise for a supported import extension.
+        ImporterFileExtensionValidator()(upload)
+
+    def test_rejected_import_extension_raises(self):
+        upload = SimpleUploadedFile("report.exe", b"data")
+        with self.assertRaises(ValidationError):
+            ImporterFileExtensionValidator()(upload)


### PR DESCRIPTION
[sc-15143]

## Description

`.spdx` files are rejected by the scan import even though the SPDX Scan type ships a parser for the tag-value `.spdx` format, a committed `.spdx` test fixture (`unittests/scans/spdx/spdx_one_vuln.spdx`), and the docs list SPDX as supported.

### Root cause

`.spdx` was missing from `DD_FILE_IMPORT_TYPES` (`dojo/settings/settings.dist.py`). The shared `ImporterFileExtensionValidator` (`dojo/validators.py`) derives its allowlist from that setting, and it guards the `file` field on:

- the API import/reimport serializers (`dojo/api_v2/serializers.py`), and
- the classic UI import/reimport forms (`dojo/forms.py`), whose file picker `accept=` attribute is built from the same setting.

So a `.spdx` upload was rejected at the form/serializer layer before the parser was ever reached, while the same report saved as `.json` imported fine (`.json` was already in the list). `SpdxTagValueParser` explicitly handles the non-JSON `.spdx` case, so nothing but the extension gate was blocking it.

### Fix

- Add `.spdx` to the `DD_FILE_IMPORT_TYPES` default list. The validator, API serializers, and classic UI forms all derive from this, so one change covers every import path.
- Add a regression test for `ImporterFileExtensionValidator` (`unittests/test_validators.py`): `.spdx` and `.json` are accepted; an unsupported extension still raises `ValidationError`.

### Testing

New test run against the unit-test stack:

```
test_accepted_import_extensions_0_report.spdx ... ok
test_accepted_import_extensions_1_report.json ... ok
test_rejected_import_extension_raises ... ok
```

Before the change, the `.spdx` case failed with:

```
ValidationError: File extension "spdx" is not allowed. Allowed extensions are: xml, csv, nessus, json, jsonl, html, js, zip, xlsx, txt, sarif, fpr, md, log, fvdl.
```

Also verified a live `POST /api/v2/import-scan/` of the `.spdx` fixture returns 201 and imports the finding.

Reported via a customer support ticket.

## Test Commands
- `/test all` — run all tests

