### PR TITLE
fix(unittests): stop leaking a crum current-user override across tests

### DIFF
--- a/unittests/test_user_ui_identity_authz.py
+++ b/unittests/test_user_ui_identity_authz.py
@@ -1,4 +1,4 @@
-from crum import set_current_user
+from crum import get_current_user, impersonate
 from django.contrib.auth.models import Permission
 from django.urls import reverse
 
@@ -28,7 +28,14 @@ class UserUIIdentityFieldAuthzTest(DojoTestCase):
         cls.target = Dojo_User.objects.create(username="ui_identity_target", email="target@example.com", is_active=True)
 
     def tearDown(self):
-        set_current_user(None)
+        # Regression: leaving a live user (or None) in crum's thread-local outranks
+        # request.user for the next request on this worker thread, so an unrelated
+        # API test later in the same process 404s on an object it is authorized for.
+        # crum's "unset" sentinel is False; anything else here is a leak.
+        self.assertIs(
+            get_current_user(_return_false=True), False,  # noqa: FBT003 crum's explicit "unset" sentinel
+            msg="test leaked a crum current-user override into the next test",
+        )
         super().tearDown()
 
     def _edit_data(self, **overrides):
@@ -39,27 +46,27 @@ class UserUIIdentityFieldAuthzTest(DojoTestCase):
     # form-level guard
 
     def test_form_blocks_delegate_changing_another_email(self):
-        set_current_user(self.delegate)
-        form = EditDojoUserForm(self._edit_data(email="attacker@evil.example"), instance=self.target)
-        self.assertFalse(form.is_valid())
+        with impersonate(self.delegate):
+            form = EditDojoUserForm(self._edit_data(email="attacker@evil.example"), instance=self.target)
+            self.assertFalse(form.is_valid())
         self.assertIn("email", form.errors)
 
     def test_form_blocks_delegate_changing_another_username(self):
-        set_current_user(self.delegate)
-        form = EditDojoUserForm(self._edit_data(username="hijacked"), instance=self.target)
-        self.assertFalse(form.is_valid())
+        with impersonate(self.delegate):
+            form = EditDojoUserForm(self._edit_data(username="hijacked"), instance=self.target)
+            self.assertFalse(form.is_valid())
         self.assertIn("username", form.errors)
 
     def test_form_allows_superuser_changing_another_email(self):
-        set_current_user(self.superuser)
-        form = EditDojoUserForm(self._edit_data(email="newby-admin@example.com"), instance=self.target)
-        self.assertTrue(form.is_valid(), form.errors)
+        with impersonate(self.superuser):
+            form = EditDojoUserForm(self._edit_data(email="newby-admin@example.com"), instance=self.target)
+            self.assertTrue(form.is_valid(), form.errors)
 
     def test_form_allows_delegate_changing_own_email(self):
-        set_current_user(self.delegate)
-        data = {"username": self.delegate.username, "email": "mynew@example.com", "is_active": "on"}
-        form = EditDojoUserForm(data, instance=self.delegate)
-        self.assertTrue(form.is_valid(), form.errors)
+        with impersonate(self.delegate):
+            data = {"username": self.delegate.username, "email": "mynew@example.com", "is_active": "on"}
+            form = EditDojoUserForm(data, instance=self.delegate)
+            self.assertTrue(form.is_valid(), form.errors)
 
     # end-to-end: the reported PoC no longer changes the victim's email
 


### PR DESCRIPTION
## Description

Fixes the unit-test flake that has been ejecting entries from the bugfix merge queue since 2026-09-04: `V3AliasAuthorizedUsersApiPermissionTest.test_asset_edit_cannot_add_authorized_users` intermittently fails with `403 != 404: No Product matches the given query`.

**Root cause.** `unittests/test_user_ui_identity_authz.py` (added in #15616) sets `crum.set_current_user(<user>)` in its form-level tests and "cleans up" with `set_current_user(None)` in `tearDown`. In crum, `get_current_user()` polls two signal receivers: the thread-local user at priority 10 and `request.user` at priority -10, and any thread-local value that is not `False` wins, `None` included. crum's "unset" sentinel is `False`, so `set_current_user(None)` leaves a live `None` override on the worker thread.

The next HTTP request on that thread then resolves `get_current_user()` to `None` even though DRF authenticated a real user, so `get_authorized_products("view")` returns `Product.objects.none()` and DRF's `get_object()` 404s an object the requester is authorized for. crum's middleware resets the thread-local to `False` on `process_response`, so exactly one request eats the poison and everything afterwards heals, which is why only the first test of the victim class fails.

The victim is whichever test class issues the first HTTP request after the identity class in the same `--parallel` worker; that pairing depends on worker timing, which is why the failure was intermittent, hit the arm64 cells far more often than amd64, and never showed on amd64-only pull-request runs while the merge queue (which adds arm64) kept failing. The `ASYNC_DELETE: giving up` ERROR lines that appear near the failures are unrelated noise: they come from `TestAsyncDeleteTransientConflictRetry` deliberately exercising the retries-exhausted branch, and appear in green runs too.

**Fix.** Replace the bare `set_current_user(...)` calls with `crum.impersonate(...)` context managers, which snapshot with `get_current_user(_return_false=True)` and restore the `False` sentinel correctly. `tearDown` becomes a regression guard asserting the class leaks no crum override, so any future bare `set_current_user` in this file fails immediately in its own module instead of 404ing an unrelated test.

**Reproduction and verification.**
- Deterministic reproduction pre-fix: `python3 manage.py test unittests.test_user_ui_identity_authz unittests.test_v3_alias_authorized_users_api_authz --keepdb` (single process) fails with the exact CI signature; forensics at the point of failure show the product row exists, the member row exists, and an immediate second identical request returns the correct 403.
- The new tearDown guard fails on all four form tests before the fix (each leaks a live user) and passes after.
- Post-fix, the same pairing is green, and the full phase-1 suite (`--parallel=4 --exclude-tag non-parallel --exclude-tag transactional --exclude-tag performance`, 5379 tests) is green on linux/arm64, the platform with the highest CI failure rate.

Failing merge-group runs for reference: 33900725161, 33901985707, 33903843175, 33924599236, 33936648275 (the same single test in every one).
