### PR TITLE
fix(unittests): pin the rate-limit window in test_api_token_auth_is_rate_limited

### DIFF
--- a/unittests/test_apiv2_user.py
+++ b/unittests/test_apiv2_user.py
@@ -1,3 +1,6 @@
+import time
+from unittest.mock import patch
+
 from django.contrib.auth.models import Permission
 from django.core.cache import cache
 from django.test import override_settings
@@ -68,11 +71,19 @@ class UserTest(APITestCase):
         url = reverse("api-token-auth")
         creds = {"username": "ratelimit-probe", "password": "not-the-real-password"}
 
-        reached_auth_view = 0
-        for _ in range(8):
-            r = anon.post(url, creds, format="json")
-            if b"non_field_errors" in r.content:
-                reached_auth_view += 1
+        # django-ratelimit counts hits in fixed wall-clock windows (60s for a
+        # "/m" rate, jittered per key). Each failed login runs a full password
+        # hash, so on a slow runner this loop can take several seconds and
+        # straddle a window boundary, resetting the counter mid-loop: 3 allowed,
+        # then blocked, then 2 more allowed after the reset. Pin the window so
+        # all 8 requests deterministically land in the same bucket.
+        pinned_window = int(time.time()) + 3600
+        with patch("django_ratelimit.core._get_window", return_value=pinned_window):
+            reached_auth_view = 0
+            for _ in range(8):
+                r = anon.post(url, creds, format="json")
+                if b"non_field_errors" in r.content:
+                    reached_auth_view += 1
 
         self.assertEqual(reached_auth_view, 3, "api-token-auth should honor the configured rate limit")
 


### PR DESCRIPTION
**Description**

Fixes a flaky unit test that intermittently bounces PRs out of the `bugfix` merge queue: `unittests/test_apiv2_user.py::UserTest::test_api_token_auth_is_rate_limited` fails with `AssertionError: 5 != 3 : api-token-auth should honor the configured rate limit` (seen in merge_group run 34013892663 on linux/arm64).

The test fires 8 anonymous JSON POSTs at `api-token-auth` under `RATE_LIMITER_RATE="3/m"` and asserts exactly 3 reach the auth view. django-ratelimit counts hits in fixed wall-clock windows (`django_ratelimit.core._get_window`: `ts - (ts % period) + (zlib.crc32(value) % period)`, so 60 second windows for a "/m" rate, jittered per key). When the request loop straddles a window boundary, the counter resets mid-loop: 3 allowed, then blocked, then the boundary, then 2 more allowed. That is the observed 5.

Each failed login runs a full password hash (Django dummy-hashes nonexistent users to keep timing uniform), so on a loaded runner the 8-request loop takes several seconds and the straddle probability is roughly loop_duration / 60 per run. That is why it shows up on busy arm64 merge-queue runners and rarely elsewhere.

Ruled out: cross-worker cache interference (the unit test harness runs with `DD_CACHE_URL: ''`, so the rate counter lives in a per-process LocMem cache). The production decorator `dojo/decorators.py::dojo_ratelimit` behaves as designed; the bug is the test assuming the whole loop lands inside a single window.

The fix is test-only: patch `django_ratelimit.core._get_window` to a constant for the duration of the request loop, so all 8 requests deterministically land in the same bucket. In django-ratelimit 4.1.0 (the pinned version) the window value only feeds the cache key via `_make_cache_key`; cache expiry is `period + EXPIRATION_FUDGE`, independent of the window value, so pinning it changes nothing else.

**Test results**

Ran in the `unit_tests_cicd` compose harness on linux/arm64:

- The full `unittests.test_apiv2_user` module passes.
- Mechanism proof: a scratch test (not committed) that replicates the old loop but forces the window value to flip after the 6th request reproduces the exact CI failure count of 5. With this fix the test itself pins the window, so a wall-clock boundary can no longer split the loop by construction.
- The fixed test repeated in a loop stays stable at 3.

**Documentation**

No user-facing change; no documentation update needed.
