### PR TITLE
docs(sensei): keyless/federated cloud auth + setup scripts for CSPM

### DIFF
--- a/docs/content/sensei/cloud_posture.md
+++ b/docs/content/sensei/cloud_posture.md
@@ -65,7 +65,7 @@ The scan credential should be **read-only** — Sensei only needs to *read* post
 
 ### Keyless authentication (self-hosted only)
 
-A long-lived key is a liability, and some organizations forbid creating exportable service-account keys at all. On a **self-hosted** DefectDojo you can authenticate a scan with your DefectDojo host's own workload identity instead, so there is no key to create, store, or rotate. Choose a **keyless** authentication method when you onboard an account or a connection, and fill in the identifiers rather than pasting a key:
+A long-lived key is a liability, and some organizations forbid creating exportable service-account keys at all. On a **self-hosted** DefectDojo you can authenticate a scan with your DefectDojo host's own workload identity instead, so there is no key to create, store, or rotate. Choose a no-key method when you onboard an account or a connection, and fill in the identifiers rather than pasting a key. You do not need to know the term "federation": pick the method labelled **recommended**, and the wizard shows a copy-paste setup script for it (see [The wizard writes the setup script](#the-wizard-writes-the-setup-script)).
 
 | Provider | Keyless method | What DefectDojo does | What you set up |
 |----------|----------------|----------------------|-----------------|
@@ -75,6 +75,35 @@ A long-lived key is a liability, and some organizations forbid creating exportab
 | **AWS** | **Web identity (OIDC)** | Assumes an IAM role with the host's projected OIDC token (for example EKS IRSA), with no access keys; you enter the role ARN and the token-file location. | An IAM OIDC identity provider trusting your cluster's issuer, and a role with a web-identity trust policy carrying the read-only scan permissions. |
 
 > **🔒 Keyless authentication is self-hosted only.** These methods authenticate as your DefectDojo instance's *own* identity. On DefectDojo Cloud that identity belongs to DefectDojo rather than to your tenant, so keyless methods are offered and accepted only on a self-hosted install, and only when the operator sets `SENSEI_ALLOW_AMBIENT_CLOUD_AUTH=true` on the Sensei engine (the Helm chart sets it for you on self-hosted values). On DefectDojo Cloud, use one of the scan credentials from the table above.
+
+#### The wizard writes the setup script
+
+When you pick a no-key method, the onboarding form shows a ready-to-run **gcloud** or **Terraform** snippet that grants DefectDojo read-only access, with a **Copy** button. The recommended GCP method — a read-only service account DefectDojo uses without a key — produces this (run it in Cloud Shell as a project owner):
+
+```bash
+PROJECT_ID=<PROJECT_ID>
+DEFECTDOJO_IDENTITY=<DEFECTDOJO_SERVICE_ACCOUNT_EMAIL>   # the identity DefectDojo runs as
+
+# 1) Create a read-only service account for DefectDojo to scan as
+gcloud iam service-accounts create defectdojo-cspm \
+  --project="$PROJECT_ID" --display-name="DefectDojo CSPM (read-only)"
+SCAN_SA="defectdojo-cspm@$PROJECT_ID.iam.gserviceaccount.com"
+
+# 2) Give it read-only access to the project
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SCAN_SA" --role="roles/viewer"
+gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+  --member="serviceAccount:$SCAN_SA" --role="roles/iam.securityReviewer"
+
+# 3) Let DefectDojo use this account without a key
+gcloud iam service-accounts add-iam-policy-binding "$SCAN_SA" \
+  --member="serviceAccount:$DEFECTDOJO_IDENTITY" \
+  --role="roles/iam.serviceAccountTokenCreator"
+
+echo "$SCAN_SA"   # paste this into "Target service account"
+```
+
+`<DEFECTDOJO_SERVICE_ACCOUNT_EMAIL>` is the identity DefectDojo itself runs as (its GKE Workload Identity or attached GCE service account); ask whoever installed DefectDojo if you are unsure. To scan a whole organization or folder, grant the same two read-only roles at that level instead of per project. The AWS "read-only role" method produces the equivalent Terraform (an IAM role with a web-identity trust policy plus `SecurityAudit` + `ViewOnlyAccess`).
 
 The credential is stored as a small JSON document. The onboarding form assembles it for you from the keyless fields; if you drive the API directly, the shapes are:
 

--- a/docs/content/sensei/cloud_posture.md
+++ b/docs/content/sensei/cloud_posture.md
@@ -51,9 +51,11 @@ The **Cloud Accounts** list mirrors the AppSec repository list: the account iden
 
 ### Provider identity and scan credentials
 
+**Federation is the recommended way to authenticate a scan** — it uses your DefectDojo host's own identity, so there is no key to create, store, or rotate, and it needs no service-account-key org-policy exception. See [Keyless authentication](#keyless-authentication-self-hosted-only) below; it is the primary path on a self-hosted install. The static credentials in the table below (a GCP service-account key, AWS access keys) are the **backup**, and on multi-tenant DefectDojo Cloud they are the only option, since federation there would authenticate as DefectDojo's identity rather than yours.
+
 The scan credential should be **read-only** — Sensei only needs to *read* posture to scan. (Applying a *direct* fix uses a separate write credential; see [Fix in Cloud](#fix-in-cloud-direct-remediation).)
 
-| Provider | Account identity | Read-only scan credential |
+| Provider | Account identity | Read-only scan credential (backup) |
 |----------|------------------|---------------------------|
 | **AWS** | The 12-digit **account ID** (resource ARNs derive from it). | Access keys for a principal with `SecurityAudit` + `ViewOnlyAccess`. Base access keys are required; organization-wide scanning additionally assumes a role (`role_arn` / `organizations_role_arn`) on top of those keys. |
 | **Azure** | The **subscription ID**. | A **service principal** (client ID, client secret, tenant ID) with **Reader** + **Security Reader**, plus the Microsoft Graph read permissions Prowler needs (`Directory.Read.All`, `Policy.Read.All`, `UserAuthenticationMethod.Read.All`). |

--- a/docs/content/sensei/cloud_posture.md
+++ b/docs/content/sensei/cloud_posture.md
@@ -103,7 +103,7 @@ gcloud iam service-accounts add-iam-policy-binding "$SCAN_SA" \
 echo "$SCAN_SA"   # paste this into "Target service account"
 ```
 
-`<DEFECTDOJO_SERVICE_ACCOUNT_EMAIL>` is the identity DefectDojo itself runs as (its GKE Workload Identity or attached GCE service account); ask whoever installed DefectDojo if you are unsure. To scan a whole organization or folder, grant the same two read-only roles at that level instead of per project. The AWS "read-only role" method produces the equivalent Terraform (an IAM role with a web-identity trust policy plus `SecurityAudit` + `ViewOnlyAccess`).
+`<DEFECTDOJO_SERVICE_ACCOUNT_EMAIL>` is the identity DefectDojo itself runs as (its GKE Workload Identity or attached GCE service account). When DefectDojo runs in Google Cloud, the wizard **detects this automatically and fills it in** (it reads the runtime service account from the host metadata server); the placeholder only remains when it cannot be detected, in which case ask whoever installed DefectDojo. To scan a whole organization or folder, grant the same two read-only roles at that level instead of per project. The AWS "read-only role" method produces the equivalent Terraform (an IAM role with a web-identity trust policy plus `SecurityAudit` + `ViewOnlyAccess`); on AWS the wizard shows the account and identity DefectDojo runs as (from STS) as context.
 
 The credential is stored as a small JSON document. The onboarding form assembles it for you from the keyless fields; if you drive the API directly, the shapes are:
 

--- a/docs/content/sensei/cloud_posture.md
+++ b/docs/content/sensei/cloud_posture.md
@@ -61,6 +61,37 @@ The scan credential should be **read-only** — Sensei only needs to *read* post
 
 > **🔐 Credentials are encrypted at rest.** Every credential — connection or account, scan or write — is stored with DefectDojo's encrypted field storage. Enter it once; there is nothing to paste again.
 
+### Keyless authentication (self-hosted only)
+
+A long-lived key is a liability, and some organizations forbid creating exportable service-account keys at all. On a **self-hosted** DefectDojo you can authenticate a scan with your DefectDojo host's own workload identity instead, so there is no key to create, store, or rotate. Choose a **keyless** authentication method when you onboard an account or a connection, and fill in the identifiers rather than pasting a key:
+
+| Provider | Keyless method | What DefectDojo does | What you set up |
+|----------|----------------|----------------------|-----------------|
+| **GCP** | **Workload Identity Federation** | Authenticates with an `external_account` config whose token comes from the host's own identity. | A Workload Identity Pool and provider that trust your DefectDojo host's identity, the read-only scan roles granted to the federated principal, then paste the `external_account` config JSON. |
+| **GCP** | **Service-account impersonation** | The host's identity mints a short-lived token for a target service account; you enter only that SA's email, and no key is stored. | Grant your DefectDojo host's identity `roles/iam.serviceAccountTokenCreator` on the scan service account, and grant that SA the read-only scan roles. |
+| **GCP** | **Application Default Credentials** | Uses the host's ambient credentials directly (GKE Workload Identity or an attached GCE service account); nothing to enter. | Run DefectDojo with a workload identity that holds the read-only scan roles on the target project. |
+| **AWS** | **Web identity (OIDC)** | Assumes an IAM role with the host's projected OIDC token (for example EKS IRSA), with no access keys; you enter the role ARN and the token-file location. | An IAM OIDC identity provider trusting your cluster's issuer, and a role with a web-identity trust policy carrying the read-only scan permissions. |
+
+> **🔒 Keyless authentication is self-hosted only.** These methods authenticate as your DefectDojo instance's *own* identity. On DefectDojo Cloud that identity belongs to DefectDojo rather than to your tenant, so keyless methods are offered and accepted only on a self-hosted install, and only when the operator sets `SENSEI_ALLOW_AMBIENT_CLOUD_AUTH=true` on the Sensei engine (the Helm chart sets it for you on self-hosted values). On DefectDojo Cloud, use one of the scan credentials from the table above.
+
+The credential is stored as a small JSON document. The onboarding form assembles it for you from the keyless fields; if you drive the API directly, the shapes are:
+
+```json
+// GCP service-account impersonation (no key)
+{"auth_method": "gcp_impersonation", "impersonate_service_account": "scan-sa@my-project.iam.gserviceaccount.com"}
+
+// GCP Application Default Credentials (host identity)
+{"auth_method": "gcp_ambient"}
+
+// GCP Workload Identity Federation: the standard external_account config
+{"type": "external_account", "audience": "//iam.googleapis.com/projects/.../locations/global/workloadIdentityPools/...", "...": "..."}
+
+// AWS web identity (no access keys)
+{"auth_method": "aws_web_identity",
+ "role_arn": "arn:aws:iam::123456789012:role/defectdojo-cspm",
+ "web_identity_token_source": {"type": "file", "path": "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}}
+```
+
 ## Scan a cloud account
 
 Open a cloud account's row menu and choose **Scan now**. Sensei runs Prowler against the account and imports the results. A large account is scanned in **shards** (by service group) when a single scan would run long; the shards are reconciled into one set of findings.
@@ -133,3 +164,4 @@ CSPM meters against two quotas, both shown as cards at the top of the hub:
 - **The fix button shows "Fix" or "Configure Asset" on a cloud finding, not "Fix in Cloud."** The finding is not directly remediable — either the account has no write credential / remediation is not enabled, or the finding's check has no v1 direct action. It can still be fixed by an IaC pull request.
 - **A revert failed with a drift error.** The live resource changed out-of-band since the fix was applied, so the recorded prior state no longer matches. Reconcile the resource manually; Sensei refuses to overwrite an unexpected state.
 - **A direct fix says the credential lacks a permission.** The Apply Direct Fix dialog lists the permissions each action needs. Grant them to the account's write credential (not the read-only scan credential) and try again.
+- **Keyless authentication is not offered, or a keyless account will not scan.** Keyless methods (Workload Identity Federation, service-account impersonation, Application Default Credentials, AWS web identity) are self-hosted only. Confirm this is a self-hosted install, that the operator set `SENSEI_ALLOW_AMBIENT_CLOUD_AUTH=true` on the Sensei engine, and that the DefectDojo host's own identity is configured (a GKE/GCE workload identity or `GOOGLE_APPLICATION_CREDENTIALS` on GCP, a projected OIDC token on AWS) and granted the required access on the target (GCP: `roles/iam.serviceAccountTokenCreator` on the scan SA for impersonation; AWS: a role trust policy for web identity). On DefectDojo Cloud, use a scan credential instead.


### PR DESCRIPTION
[sc-15206]

## Description

Documentation for the DefectDojo Pro Sensei CSPM connector's new keyless/federated
cloud authentication, which ships in the same 3.3.0 release. Docs-only; the Pro code
lives in the companion Pro PR.

Updates `docs/content/sensei/cloud_posture.md`:

- A **keyless authentication (self-hosted only)** section covering the no-key methods
  per provider — GCP Workload Identity Federation, service-account impersonation, and
  Application Default Credentials; AWS web identity (OIDC) — with what DefectDojo does
  and what the customer sets up, the per-method credential JSON shapes, and a
  prominent callout that keyless is self-hosted only (on multi-tenant Cloud the host
  identity is the platform's) and requires `SENSEI_ALLOW_AMBIENT_CLOUD_AUTH` on the
  Sensei engine.
- Framing that **federation is the recommended path** and a service-account key is
  the backup (and the only option on multi-tenant Cloud).
- **"The wizard writes the setup script"** — the onboarding form shows a ready-to-run
  gcloud/Terraform snippet (with a Copy button) for each no-key method; includes the
  recommended GCP read-only-service-account gcloud script, and notes that DefectDojo's
  own runtime identity is auto-detected and filled in when it runs in a cloud.
- Troubleshooting entries for the keyless paths.

Text only; no images or external assets.

