### PR TITLE
fix(questionnaires): correct the share note on the general questionnaire list

### DIFF
--- a/dojo/templates/defectDojo-engagement-survey/list_surveys.html
+++ b/dojo/templates/defectDojo-engagement-survey/list_surveys.html
@@ -137,8 +137,9 @@
             <div class="modal-body">
                 <p id="questionnaireURL"></p>
                 <div class="alert alert-info" role="alert">
-                    <b>Note:</b> Only users that are authorized for {{ eng.product}} will be allowed to answer
-                    this questionnaire.
+                    <b>Note:</b> Anyone who can sign in to this instance may answer this questionnaire.
+                    If "Allow Anonymous Survey Responses" is enabled in System Settings, anyone with
+                    the link may answer without signing in.
                 </div>
 
             </div>


### PR DESCRIPTION
The Share Questionnaire dialog on the general questionnaire list page told the
operator that only users authorized for a product can answer. Two things were
wrong with that.

The page renders without an engagement in the template context, so the product
name came out as an empty string. The rendered sentence read "Only users that are
authorized for  will be allowed to answer this questionnaire."

A general questionnaire also has no product to authorize against. The model has
no product field, the route is login exempt on purpose, and it accepts anonymous
responses when the system setting turns that on. So the note described a check
that does not exist.

The note now says who can actually answer, and it mentions the anonymous setting.

The engagement page has its own copy of the same sentence. That one is correct,
because an engagement is in context there and that dialog shares the
engagement-scoped route, which does check the engagement. I left it alone.

Text only, one hunk, no code change.