### PR TITLE
perf(locations): fix endpoints-to-locations backfill mega-join and unbounded memory

### DIFF
--- a/dojo/location/models.py
+++ b/dojo/location/models.py
@@ -425,7 +425,7 @@ class AbstractLocation(BaseModelWithoutTimeMeta):
         }
 
     @classmethod
-    def bulk_get_or_create(cls, locations: Iterable[Self]) -> list[Self]:
+    def bulk_get_or_create(cls, locations: Iterable[Self], *, created_out: list[Self] | None = None) -> list[Self]:
         """
         Get or create multiple locations in bulk.
 
@@ -433,6 +433,12 @@ class AbstractLocation(BaseModelWithoutTimeMeta):
         bulk_create for both the parent Location rows and the subtype rows.
         Returns the full list of saved instances (existing + newly created),
         in the same order as the input. Duplicate inputs map to the same saved instance.
+
+        If ``created_out`` is given, the instances created by THIS call (those absent
+        before it, deduplicated by identity_hash) are appended to it. A chunked backfill
+        can sum ``len(created_out)`` per chunk to report the distinct locations it created
+        without holding a set of every location id for the whole run — the accumulator
+        that otherwise grows with the corpus and OOMs a large migration.
 
         identity_hash is a global singleton, so two imports that reference the same
         package (Dependency) or endpoint (URL) race to create the same row. Creation
@@ -477,6 +483,13 @@ class AbstractLocation(BaseModelWithoutTimeMeta):
         # Create 'em (tolerating a concurrent writer that beats us to some rows)
         if to_create:
             existing_by_hash.update(cls._bulk_create_tolerating_races(to_create))
+            if created_out is not None:
+                # to_create holds one entry per hash absent at the start of this call,
+                # i.e. exactly the new distinct locations. Single-writer migrations see no
+                # races, so this is the set this run created. (A concurrent writer that
+                # beat us to a row would leave it counted here but resolved to the other
+                # writer's instance — immaterial to a single-threaded backfill.)
+                created_out.extend(to_create.values())
 
         # Return in input order
         return [existing_by_hash[h] for h in hashes]

--- a/dojo/management/commands/migrate_endpoints_to_locations.py
+++ b/dojo/management/commands/migrate_endpoints_to_locations.py
@@ -538,7 +538,9 @@ class Command(BaseCommand):
                 return []
 
             try:
-                saved = URL.bulk_get_or_create([url for _, url in pairs])
+                created: list[URL] = []
+                saved = URL.bulk_get_or_create([url for _, url in pairs], created_out=created)
+                self.location_count += len(created)
             except Exception:
                 logger.exception(
                     "Bulk location resolution failed for %d endpoint(s); "
@@ -634,7 +636,6 @@ class Command(BaseCommand):
         )
 
         chunk_location_ids = {location.id for _, location in resolved}
-        self.migrated_location_ids.update(chunk_location_ids)
         self._reconcile_product_statuses(list(chunk_location_ids))
 
         # Inheritance runs per chunk (bounded memory, converging) — see the
@@ -737,20 +738,24 @@ class Command(BaseCommand):
             return f"{m}m {s}s"
         return f"{s}s"
 
-    def _emit_progress(self, processed: int, total: int) -> None:
+    def _emit_progress(self, processed: int, total: int, checkpoint_id: int | None = None) -> None:
         """
         Publish chunk-level progress to an optional programmatic callback.
 
-        Pro's migration suite passes ``progress_callback`` (a stealth option) so
-        it can persist processed/total for a progress bar and ETA. A callback
-        failure must never abort a multi-hour migration, so it is swallowed with
-        a logged warning. CLI runs pass no callback and are unaffected.
+        Pro's migration suite passes ``progress_callback`` (a stealth option) so it can
+        persist processed/total for a progress bar and ETA, and ``checkpoint_id`` — the
+        last endpoint id committed so far — so an interrupted run can resume from it via
+        ``--start-after-id``. The callback is invoked as
+        ``callback(processed, total, checkpoint_id)``; ``checkpoint_id`` is None on the
+        initial 0-tick, before any chunk has committed. A callback failure must never
+        abort a multi-hour migration, so it is swallowed with a logged warning. CLI runs
+        pass no callback and are unaffected.
         """
         callback = self.progress_callback
         if callback is None:
             return
         try:
-            callback(processed, total)
+            callback(processed, total, checkpoint_id)
         except Exception:
             logger.warning("progress_callback raised; continuing migration", exc_info=True)
 
@@ -939,9 +944,13 @@ class Command(BaseCommand):
         self.failed_endpoints: list[tuple[int | None, str]] = []
         self.failed_endpoint_ids: set[int | None] = set()
 
-        # Distinct Location ids this run resolved, so the caller can report how many
-        # Locations the endpoints collapsed onto (many endpoints can share one URL).
-        self.migrated_location_ids: set[int] = set()
+        # Count of new distinct Locations this run created, summed per chunk from
+        # bulk_get_or_create's created_out (see _resolve_locations). A per-chunk count
+        # rather than a whole-run set of ids: that set grew with the corpus and was the
+        # accumulator that OOM'd large migrations at ~75%. On a first run this equals the
+        # distinct Locations the endpoints collapsed onto; a resume counts only what it
+        # newly created.
+        self.location_count: int = 0
 
         if self.query_count:
             connection.force_debug_cursor = True
@@ -975,9 +984,10 @@ class Command(BaseCommand):
             #   - `product` is select_related so we don't lazy-load it for the
             #     no-findings branch
             #   - `tags` and `endpoint_meta` are prefetched managers
-            #   - `status_endpoint` is prefetched together with the FK chain
-            #     `finding -> test -> engagement -> product` and `mitigated_by`
-            #     so the reference rows can be built without queries.
+            #   - `status_endpoint` is prefetched with `mitigated_by` inline; the
+            #     finding -> test -> engagement -> product chain is prefetched per
+            #     level (NOT select_related) so the reference rows can be built
+            #     without queries and without the whole-table join below.
             # Explicit id ordering makes the scan deterministic across runs,
             # which is what gives the progress lines' "last id" its meaning as
             # a resume cursor for --start-after-id.
@@ -988,13 +998,20 @@ class Command(BaseCommand):
                 .prefetch_related(
                     "tags",
                     "endpoint_meta",
+                    # mitigated_by is a single narrow FK on the status row: join it inline.
                     Prefetch(
                         "status_endpoint",
-                        queryset=Endpoint_Status.objects.select_related(
-                            "finding__test__engagement__product",
-                            "mitigated_by",
-                        ),
+                        queryset=Endpoint_Status.objects.select_related("mitigated_by"),
                     ),
+                    # The finding chain is prefetched, NOT select_related. As one
+                    # `finding__test__engagement__product` join it folds into the status
+                    # query, and on a large corpus the planner mis-estimates the status
+                    # IN-list (~180x) and seq-scans every finding/test/product to hash
+                    # them down to the chunk's handful of rows — the 76-194s chunks behind
+                    # the ~75% stall. Prefetching resolves each FK level with a PK-driven
+                    # IN query scoped to the chunk, which the planner answers by index
+                    # lookup. `_collect_references` reads the same cached objects either way.
+                    "status_endpoint__finding__test__engagement__product",
                 )
             )
             if self.start_after_id is not None:
@@ -1040,7 +1057,9 @@ class Command(BaseCommand):
 
                     # Programmatic progress at every chunk boundary (independent
                     # of the throttled stdout line below), for the migration suite.
-                    self._emit_progress(i, endpoint_count)
+                    # last_id (this chunk's final endpoint id, set above) is the resume
+                    # cursor for everything committed so far.
+                    self._emit_progress(i, endpoint_count, checkpoint_id=last_id)
 
                     # Cancellation checkpoint. Chunks are separately committed and the
                     # tag queue was just flushed, so stopping here leaves a consistent,
@@ -1099,16 +1118,18 @@ class Command(BaseCommand):
             connection.force_debug_cursor = False
 
         # Summary for programmatic callers (the Pro Locations migration suite). CLI runs
-        # pass no summary_callback and are unaffected. ``locations`` is the distinct-
-        # Location count the endpoints collapsed onto (<= processed); ``failures`` are the
-        # per-endpoint errors isolated during the run so the suite can surface "N skipped";
+        # pass no summary_callback and are unaffected. ``locations`` is the count of new
+        # distinct Locations this run created (<= processed; on a first run, the number the
+        # endpoints collapsed onto — a resume counts only what it newly created);
+        # ``failures`` are the per-endpoint errors isolated during the run so the suite can
+        # surface "N skipped";
         # ``cancelled`` tells the suite the run stopped early (processed < total) rather
         # than finishing, so it can land the run on "cancelled" instead of "completed".
         self._emit_summary(
             {
                 "processed": i,
                 "total": endpoint_count,
-                "locations": len(self.migrated_location_ids),
+                "locations": self.location_count,
                 "failures": [{"id": endpoint_id, "error": error} for endpoint_id, error in self.failed_endpoints],
                 "cancelled": self.cancelled,
             },

--- a/unittests/test_migrate_endpoints_to_locations.py
+++ b/unittests/test_migrate_endpoints_to_locations.py
@@ -494,12 +494,12 @@ class MigrateEndpointsToLocationsTest(TestCase):
         original = URL.bulk_get_or_create
         calls = []
 
-        def fail_first_chunk(locations):
+        def fail_first_chunk(locations, *, created_out=None):
             calls.append(len(locations))
             if len(calls) == 1:
                 msg = "simulated bulk location write failure"
                 raise RuntimeError(msg)
-            return original(locations)
+            return original(locations, created_out=created_out)
 
         stdout = StringIO()
         with (
@@ -720,3 +720,46 @@ class MigrateEndpointsToLocationsTest(TestCase):
             sorted(tag.name for tag in location.inherited_tags.all()),
             ["tag-product-one", "tag-product-two"],
         )
+
+    def test_progress_callback_receives_checkpoint_id(self):
+        # The suite passes a 3-arg progress_callback so a lost run can resume from the last
+        # committed endpoint id. The initial 0-tick carries no cursor; the final tick's
+        # checkpoint is the max (last committed) endpoint id.
+        endpoints = [self._make_endpoint(f"cb-{i}.example.com", []) for i in range(3)]
+        records = []
+
+        def rec(processed, total, checkpoint_id=None):
+            records.append((processed, total, checkpoint_id))
+
+        self._run(progress_every=1, batch_size=1, progress_callback=rec)
+
+        self.assertEqual(records[0], (0, 3, None), msg=records)
+        last = max(endpoint.id for endpoint in endpoints)
+        self.assertEqual(records[-1][0], 3, msg=records)
+        self.assertEqual(records[-1][2], last, msg=records)
+
+    def test_summary_locations_counts_created_locations_only(self):
+        # ``locations`` is the count of Locations this run CREATED (a memory-bounded count,
+        # not a whole-run set of ids). A full rerun creates nothing, so it reports 0.
+        self._make_endpoint("rerun.example.com", [])
+        self._run()
+        summaries = []
+        self._run(summary_callback=summaries.append)
+        self.assertEqual(summaries[0]["locations"], 0, msg=summaries[0])
+
+    def test_bulk_get_or_create_created_out_appends_only_new(self):
+        # created_out receives only the instances this call created (absent beforehand),
+        # so a chunked backfill can sum a per-chunk count without a whole-run set.
+        def make(host):
+            return URL.from_parts(
+                protocol="https", user_info="", host=host,
+                port=None, path="", query="", fragment="",
+            )
+
+        URL.bulk_get_or_create([make("only-new.example.com")])  # pre-create one Location
+        created = []
+        saved = URL.bulk_get_or_create(
+            [make("only-new.example.com"), make("brand-new.example.com")], created_out=created,
+        )
+        self.assertEqual(len(saved), 2)
+        self.assertEqual([url.host for url in created], ["brand-new.example.com"])


### PR DESCRIPTION
[sc-15222]

## Description

The `migrate_endpoints_to_locations` backfill could crawl and OOM on a large corpus.

**Query:** the per-chunk status prefetch used `select_related("finding__test__engagement__product")`, folding a four-table join into the `Endpoint_Status` query. On a large corpus the planner mis-estimated the endpoint-id `IN`-list (measured ~180× over) and seq-scanned every finding, test and product to hash them down to the chunk's handful of rows — per-chunk times of 76–194s, with throughput collapsing from ~90/s to ~5/s in the middle of a run.

**Memory:** a whole-run `set` of migrated location ids grew with the corpus and OOM-ed large runs.

### Changes
- Prefetch the `finding → test → engagement → product` chain per level (PK-driven `IN` queries the planner answers by index lookup) instead of one whole-table join. `_collect_references` reads the same cached objects, so behavior is unchanged.
- Replace the whole-run `migrated_location_ids` set with a per-chunk created-count via a new `AbstractLocation.bulk_get_or_create(created_out=...)` out-parameter. `summary["locations"]` now reports distinct locations *created* by the run (equal to distinct-touched on a first run; lower on a resume).
- Report the last committed endpoint id to `progress_callback` as a third argument, so an interrupted run can resume from it via `--start-after-id`.

### Testing
`unittests/test_migrate_endpoints_to_locations.py`: 21 tests pass, including new coverage for the progress checkpoint id, the created-count semantics, and `created_out`. The existing tests (tag copy, reference building, product-status reconciliation, cross-chunk inheritance) exercise the prefetched chain and confirm the restructure preserves semantics.
