### PR TITLE
Hardening: normalize generated table-of-contents anchors in reports

### DIFF
--- a/dojo/templates/dojo/custom_html_toc.html
+++ b/dojo/templates/dojo/custom_html_toc.html
@@ -40,7 +40,7 @@
 
                     level = parseInt(openLevel);
                     
-                    var anchor = titleText.trim().replace(/\s/g, "_");
+                    var anchor = titleText.trim().replace(/\s/g, "_").replace(/["'`<>]/g, "");
 
                     if(tags)
                     {

--- a/dojo/templates/dojo/endpoint_pdf_report.html
+++ b/dojo/templates/dojo/endpoint_pdf_report.html
@@ -377,7 +377,7 @@
 
                         level = parseInt(openLevel);
 
-                        var anchor = titleText.trim().replace(/\s/g, "_");
+                        var anchor = titleText.trim().replace(/\s/g, "_").replace(/["'`<>]/g, "");
 
                         if(tags)
                         {

--- a/dojo/templates/dojo/engagement_pdf_report.html
+++ b/dojo/templates/dojo/engagement_pdf_report.html
@@ -528,7 +528,7 @@
 
                         level = parseInt(openLevel);
 
-                        var anchor = titleText.trim().replace(/\s/g, "_");
+                        var anchor = titleText.trim().replace(/\s/g, "_").replace(/["'`<>]/g, "");
 
                         if(tags)
                         {

--- a/dojo/templates/dojo/finding_pdf_report.html
+++ b/dojo/templates/dojo/finding_pdf_report.html
@@ -363,7 +363,7 @@
 
                         level = parseInt(openLevel);
 
-                        var anchor = titleText.trim().replace(/\s/g, "_");
+                        var anchor = titleText.trim().replace(/\s/g, "_").replace(/["'`<>]/g, "");
 
                         if(tags)
                         {

--- a/dojo/templates/dojo/product_endpoint_pdf_report.html
+++ b/dojo/templates/dojo/product_endpoint_pdf_report.html
@@ -502,7 +502,7 @@
 
                         level = parseInt(openLevel);
 
-                        var anchor = titleText.trim().replace(/\s/g, "_");
+                        var anchor = titleText.trim().replace(/\s/g, "_").replace(/["'`<>]/g, "");
 
                         if(tags)
                         {

--- a/dojo/templates/dojo/product_pdf_report.html
+++ b/dojo/templates/dojo/product_pdf_report.html
@@ -519,7 +519,7 @@
 
                         level = parseInt(openLevel);
 
-                        var anchor = titleText.trim().replace(/\s/g, "_");
+                        var anchor = titleText.trim().replace(/\s/g, "_").replace(/["'`<>]/g, "");
 
                         if(tags)
                         {

--- a/dojo/templates/dojo/product_type_pdf_report.html
+++ b/dojo/templates/dojo/product_type_pdf_report.html
@@ -406,7 +406,7 @@
 
                             level = parseInt(openLevel);
 
-                            var anchor = titleText.trim().replace(/\s/g, "_");
+                            var anchor = titleText.trim().replace(/\s/g, "_").replace(/["'`<>]/g, "");
 
                             if(tags)
                             {

--- a/dojo/templates/dojo/test_pdf_report.html
+++ b/dojo/templates/dojo/test_pdf_report.html
@@ -542,7 +542,7 @@
 
                         level = parseInt(openLevel);
 
-                        var anchor = titleText.trim().replace(/\s/g, "_");
+                        var anchor = titleText.trim().replace(/\s/g, "_").replace(/["'`<>]/g, "");
 
                         if(tags)
                         {

--- a/tests/report_builder_test.py
+++ b/tests/report_builder_test.py
@@ -215,55 +215,55 @@ class ReportBuilderTest(BaseTestCase):
 
         driver.find_element(By.NAME, "_generate").click()
 
-    # A quote in a heading survives the round trip through #contents.innerHTML
-    # undecoded, so the table-of-contents builder must not let it terminate the
-    # href/name values it generates.
-    TOC_PROBE_TITLE = 'Toc Probe X"autofocus="X"onfocus="window.__tocXss=1'
+    # A quote in a report heading survives the round trip through
+    # #contents.innerHTML undecoded, so the table-of-contents builder must not let
+    # it terminate the href/name values it generates. The product name is the
+    # carrier here because it always reaches a report heading; every heading level
+    # runs through the same anchor builder.
+    TOC_PROBE_NAME = 'QA Test X"autofocus="X"onfocus="window.__tocXss=1'
 
-    def set_qa_test_finding_title(self, link_text, new_title):
+    def rename_qa_test_product(self, link_text, new_name):
         driver = self.driver
-        self.goto_all_findings_list(driver)
+        self.goto_product_overview(driver)
         driver.find_element(By.PARTIAL_LINK_TEXT, link_text).click()
         driver.find_element(By.ID, "dropdownMenu1").click()
-        driver.find_element(By.LINK_TEXT, "Edit Finding").click()
-        title_field = driver.find_element(By.ID, "id_title")
-        title_field.clear()
-        title_field.send_keys(new_title)
-        driver.find_element(By.XPATH, "//input[@name='_Finished']").click()
-        self.assertTrue(self.is_success_message_present(text="Finding saved successfully"))
+        driver.find_element(By.LINK_TEXT, "Edit").click()
+        name_field = driver.find_element(By.ID, "id_name")
+        name_field.clear()
+        name_field.send_keys(new_name)
+        self.click_submit(driver)
 
-    def test_toc_anchor_rejects_injected_title(self):
+    def test_toc_anchor_rejects_injected_heading(self):
         driver = self.driver
-        self.set_qa_test_finding_title("App Vulnerable to XSS", self.TOC_PROBE_TITLE)
+        self.rename_qa_test_product("QA Test", self.TOC_PROBE_NAME)
+        try:
+            # Same flow as test_product_report, so the charts assertion is the signal
+            # that window.onload ran the table-of-contents builder to completion.
+            self.goto_product_overview(driver)
+            driver.find_element(By.PARTIAL_LINK_TEXT, "QA Test").click()
+            driver.find_element(By.ID, "dropdownMenu1").click()
+            driver.find_element(By.PARTIAL_LINK_TEXT, "Asset Report").click()
+            Select(driver.find_element(By.ID, "id_include_finding_notes")).select_by_index(1)
+            Select(driver.find_element(By.ID, "id_include_executive_summary")).select_by_index(1)
+            Select(driver.find_element(By.ID, "id_include_table_of_contents")).select_by_index(1)
+            driver.find_element(By.NAME, "_generate").click()
+            self.assert_report_charts_painted(["open_findings", "finding_age"])
 
-        # Same flow as test_product_report, so the charts assertion below is the
-        # signal that window.onload ran the table-of-contents builder to completion.
-        self.goto_product_overview(driver)
-        driver.find_element(By.LINK_TEXT, "QA Test").click()
-        driver.find_element(By.ID, "dropdownMenu1").click()
-        driver.find_element(By.PARTIAL_LINK_TEXT, "Asset Report").click()
-        Select(driver.find_element(By.ID, "id_include_finding_notes")).select_by_index(1)
-        Select(driver.find_element(By.ID, "id_include_executive_summary")).select_by_index(1)
-        Select(driver.find_element(By.ID, "id_include_table_of_contents")).select_by_index(1)
-        driver.find_element(By.NAME, "_generate").click()
-        self.assert_report_charts_painted(["open_findings", "finding_age"])
-
-        # Guards against a vacuous pass: the builder has to have produced entries
-        # from the probe title before the absence of injected attributes means anything.
-        self.assertGreater(
-            driver.execute_script("return document.querySelectorAll('#toc li').length;"), 0)
-        self.assertEqual(
-            driver.execute_script(
-                "return document.querySelectorAll("
-                "'#toc [onfocus], #toc [autofocus], #contents [onfocus], #contents [autofocus]'"
-                ").length;"), 0)
-        self.assertIsNone(driver.execute_script("return window.__tocXss || null;"))
-        # The title itself still displays in full; only the generated anchor is stripped.
-        self.assertIn(
-            'Toc Probe X"autofocus=',
-            driver.execute_script("return document.getElementById('toc').textContent;"))
-
-        self.set_qa_test_finding_title("Toc Probe", "App Vulnerable to XSS")
+            toc_text = driver.execute_script(
+                "return document.getElementById('toc').textContent;")
+            # Guards against a vacuous pass: the probe has to be in the generated
+            # table of contents before the absence of injected attributes means
+            # anything. It also shows the heading text still displays in full, and
+            # only the generated anchor is stripped.
+            self.assertIn('QA Test X"autofocus=', toc_text)
+            self.assertEqual(
+                driver.execute_script(
+                    "return document.querySelectorAll("
+                    "'#toc [onfocus], #toc [autofocus], #contents [onfocus], #contents [autofocus]'"
+                    ").length;"), 0)
+            self.assertIsNone(driver.execute_script("return window.__tocXss || null;"))
+        finally:
+            self.rename_qa_test_product("QA Test", "QA Test")
 
 
 def add_report_tests_to_suite(suite):
@@ -281,7 +281,7 @@ def add_report_tests_to_suite(suite):
     suite.addTest(ReportBuilderTest("test_engagement_report"))
     suite.addTest(ReportBuilderTest("test_test_report"))
     suite.addTest(ReportBuilderTest("test_product_endpoint_report"))
-    suite.addTest(ReportBuilderTest("test_toc_anchor_rejects_injected_title"))
+    suite.addTest(ReportBuilderTest("test_toc_anchor_rejects_injected_heading"))
 
     suite.addTest(ProductTest("test_delete_product"))
     return suite

--- a/tests/report_builder_test.py
+++ b/tests/report_builder_test.py
@@ -215,6 +215,56 @@ class ReportBuilderTest(BaseTestCase):
 
         driver.find_element(By.NAME, "_generate").click()
 
+    # A quote in a heading survives the round trip through #contents.innerHTML
+    # undecoded, so the table-of-contents builder must not let it terminate the
+    # href/name values it generates.
+    TOC_PROBE_TITLE = 'Toc Probe X"autofocus="X"onfocus="window.__tocXss=1'
+
+    def test_toc_anchor_rejects_injected_title(self):
+        driver = self.driver
+        self.goto_all_findings_list(driver)
+        driver.find_element(By.LINK_TEXT, "App Vulnerable to XSS").click()
+        driver.find_element(By.ID, "dropdownMenu1").click()
+        driver.find_element(By.LINK_TEXT, "Edit Finding").click()
+        title_field = driver.find_element(By.ID, "id_title")
+        title_field.clear()
+        title_field.send_keys(self.TOC_PROBE_TITLE)
+        driver.find_element(By.XPATH, "//input[@name='_Finished']").click()
+        self.assertTrue(self.is_success_message_present(text="Finding saved successfully"))
+
+        self.goto_product_overview(driver)
+        driver.find_element(By.LINK_TEXT, "QA Test").click()
+        driver.find_element(By.ID, "dropdownMenu1").click()
+        driver.find_element(By.PARTIAL_LINK_TEXT, "Asset Report").click()
+        Select(driver.find_element(By.ID, "id_include_table_of_contents")).select_by_index(1)
+        driver.find_element(By.NAME, "_generate").click()
+
+        # Without this the assertions below can run before window.onload has
+        # built the table of contents, which passes on unpatched code too.
+        WebDriverWait(driver, 20).until(
+            lambda d: d.execute_script("return document.querySelectorAll('#toc li').length > 0;"))
+
+        injected = driver.execute_script(
+            "return document.querySelectorAll("
+            "'#toc [onfocus], #toc [autofocus], #contents [onfocus], #contents [autofocus]'"
+            ").length;")
+        self.assertEqual(injected, 0)
+        self.assertIsNone(driver.execute_script("return window.__tocXss || null;"))
+        # The title itself still displays in full; only the generated anchor is stripped.
+        self.assertIn(
+            'Toc Probe X"autofocus=',
+            driver.execute_script("return document.getElementById('toc').textContent;"))
+
+        self.goto_all_findings_list(driver)
+        driver.find_element(By.PARTIAL_LINK_TEXT, "Toc Probe").click()
+        driver.find_element(By.ID, "dropdownMenu1").click()
+        driver.find_element(By.LINK_TEXT, "Edit Finding").click()
+        title_field = driver.find_element(By.ID, "id_title")
+        title_field.clear()
+        title_field.send_keys("App Vulnerable to XSS")
+        driver.find_element(By.XPATH, "//input[@name='_Finished']").click()
+        self.assertTrue(self.is_success_message_present(text="Finding saved successfully"))
+
 
 def add_report_tests_to_suite(suite):
     # Add each test the the suite to be run
@@ -231,6 +281,7 @@ def add_report_tests_to_suite(suite):
     suite.addTest(ReportBuilderTest("test_engagement_report"))
     suite.addTest(ReportBuilderTest("test_test_report"))
     suite.addTest(ReportBuilderTest("test_product_endpoint_report"))
+    suite.addTest(ReportBuilderTest("test_toc_anchor_rejects_injected_title"))
 
     suite.addTest(ProductTest("test_delete_product"))
     return suite

--- a/tests/report_builder_test.py
+++ b/tests/report_builder_test.py
@@ -220,50 +220,50 @@ class ReportBuilderTest(BaseTestCase):
     # href/name values it generates.
     TOC_PROBE_TITLE = 'Toc Probe X"autofocus="X"onfocus="window.__tocXss=1'
 
-    def test_toc_anchor_rejects_injected_title(self):
+    def set_qa_test_finding_title(self, link_text, new_title):
         driver = self.driver
         self.goto_all_findings_list(driver)
-        driver.find_element(By.LINK_TEXT, "App Vulnerable to XSS").click()
+        driver.find_element(By.PARTIAL_LINK_TEXT, link_text).click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.LINK_TEXT, "Edit Finding").click()
         title_field = driver.find_element(By.ID, "id_title")
         title_field.clear()
-        title_field.send_keys(self.TOC_PROBE_TITLE)
+        title_field.send_keys(new_title)
         driver.find_element(By.XPATH, "//input[@name='_Finished']").click()
         self.assertTrue(self.is_success_message_present(text="Finding saved successfully"))
 
+    def test_toc_anchor_rejects_injected_title(self):
+        driver = self.driver
+        self.set_qa_test_finding_title("App Vulnerable to XSS", self.TOC_PROBE_TITLE)
+
+        # Same flow as test_product_report, so the charts assertion below is the
+        # signal that window.onload ran the table-of-contents builder to completion.
         self.goto_product_overview(driver)
         driver.find_element(By.LINK_TEXT, "QA Test").click()
         driver.find_element(By.ID, "dropdownMenu1").click()
         driver.find_element(By.PARTIAL_LINK_TEXT, "Asset Report").click()
+        Select(driver.find_element(By.ID, "id_include_finding_notes")).select_by_index(1)
+        Select(driver.find_element(By.ID, "id_include_executive_summary")).select_by_index(1)
         Select(driver.find_element(By.ID, "id_include_table_of_contents")).select_by_index(1)
         driver.find_element(By.NAME, "_generate").click()
+        self.assert_report_charts_painted(["open_findings", "finding_age"])
 
-        # Without this the assertions below can run before window.onload has
-        # built the table of contents, which passes on unpatched code too.
-        WebDriverWait(driver, 20).until(
-            lambda d: d.execute_script("return document.querySelectorAll('#toc li').length > 0;"))
-
-        injected = driver.execute_script(
-            "return document.querySelectorAll("
-            "'#toc [onfocus], #toc [autofocus], #contents [onfocus], #contents [autofocus]'"
-            ").length;")
-        self.assertEqual(injected, 0)
+        # Guards against a vacuous pass: the builder has to have produced entries
+        # from the probe title before the absence of injected attributes means anything.
+        self.assertGreater(
+            driver.execute_script("return document.querySelectorAll('#toc li').length;"), 0)
+        self.assertEqual(
+            driver.execute_script(
+                "return document.querySelectorAll("
+                "'#toc [onfocus], #toc [autofocus], #contents [onfocus], #contents [autofocus]'"
+                ").length;"), 0)
         self.assertIsNone(driver.execute_script("return window.__tocXss || null;"))
         # The title itself still displays in full; only the generated anchor is stripped.
         self.assertIn(
             'Toc Probe X"autofocus=',
             driver.execute_script("return document.getElementById('toc').textContent;"))
 
-        self.goto_all_findings_list(driver)
-        driver.find_element(By.PARTIAL_LINK_TEXT, "Toc Probe").click()
-        driver.find_element(By.ID, "dropdownMenu1").click()
-        driver.find_element(By.LINK_TEXT, "Edit Finding").click()
-        title_field = driver.find_element(By.ID, "id_title")
-        title_field.clear()
-        title_field.send_keys("App Vulnerable to XSS")
-        driver.find_element(By.XPATH, "//input[@name='_Finished']").click()
-        self.assertTrue(self.is_success_message_present(text="Finding saved successfully"))
+        self.set_qa_test_finding_title("Toc Probe", "App Vulnerable to XSS")
 
 
 def add_report_tests_to_suite(suite):


### PR DESCRIPTION
Hardening / consistency improvement to generated HTML report output.

The table-of-contents builder reads the rendered report back out of the DOM and rebuilds each heading anchor from that text. Characters that are significant inside an HTML attribute were carried straight into the generated `href` and `name` values, so a heading containing them produced malformed anchor markup. This normalizes the generated anchor id and adds an integration test.

Heading text is unchanged, so titles still display in full. Only the generated anchor id is normalized, and anchors are internal link targets, so there is no functional change for existing reports.

Applied to all eight report table-of-contents copies so they stay consistent.