### PR TITLE
fix(notifications): keep a failed alert save from aborting scan import

### DIFF
--- a/dojo/notifications/helper.py
+++ b/dojo/notifications/helper.py
@@ -197,19 +197,27 @@ class NotificationManagerHelpers:
         notification_type: str | None = None,
         **kwargs: dict,
     ) -> None:
-        # no try catch here, if this fails we need to show an error
+        # This is the last-resort error logger for every notification channel, so it must
+        # never raise: a failure to persist the Alert here would propagate out of the
+        # notification pipeline and abort whatever triggered it (e.g. a scan import). The
+        # persistence failure is logged and swallowed per superuser -- for instance when the
+        # dojo_alerts primary-key sequence reaches its maximum, every save() fails, and
+        # re-raising would take the import down with it.
         for user in Dojo_User.objects.filter(is_superuser=True):
-            alert = Alerts(
-                user_id=user,
-                url=kwargs.get("url", reverse("alerts")),
-                title=kwargs.get("title", "Notification issue")[:250],
-                description=kwargs.get("description", str(exception))[:2000],
-                icon="exclamation-triangle",
-                source=notification_type[:100] if notification_type else kwargs.get("source", "unknown")[:100],
-            )
-            # relative urls will fail validation
-            alert.clean_fields(exclude=["url"])
-            alert.save()
+            try:
+                alert = Alerts(
+                    user_id=user,
+                    url=kwargs.get("url", reverse("alerts")),
+                    title=kwargs.get("title", "Notification issue")[:250],
+                    description=kwargs.get("description", str(exception))[:2000],
+                    icon="exclamation-triangle",
+                    source=notification_type[:100] if notification_type else kwargs.get("source", "unknown")[:100],
+                )
+                # relative urls will fail validation
+                alert.clean_fields(exclude=["url"])
+                alert.save()
+            except Exception:
+                logger.exception("Unable to persist fallback Alert for user %s", user)
 
 
 class SlackNotificationManger(NotificationManagerHelpers):

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -6,9 +6,11 @@ from unittest.mock import Mock, patch
 import pghistory
 from auditlog.context import set_actor
 from crum import impersonate
+from django.db.utils import DataError
 from django.test import RequestFactory, override_settings
 from django.urls import reverse
 from django.utils import timezone
+from parameterized import parameterized
 from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient, APITestCase
 
@@ -1506,3 +1508,80 @@ class TestReviewRequestedWebhookTemplate(DojoTestCase):
         )
         self.assertNotEqual(rendered.strip(), fallback.strip())
         self.assertNotIn("finding:", fallback)
+
+
+class TestAlertNotificationResilience(DojoTestCase):
+
+    """
+    Regression: a failure to persist an in-app Alert (e.g. the ``dojo_alerts``
+    primary-key sequence reaching the PostgreSQL int4 maximum, 2147483647) must
+    not propagate out of the notification helper. Alert creation is a side
+    effect of operations like scan import, and ``send_alert_notification``
+    already guards its own ``alert.save()`` -- but its fallback ``_log_alert``
+    saved another Alert without a guard, so the same underlying DB failure
+    re-raised there and aborted the caller (customer-reported: reimport-scan
+    failing wholesale because the alert could not be written).
+    """
+
+    fixtures = ["dojo_testdata.json"]
+
+    SEQUENCE_EXHAUSTED_MESSAGE = (
+        'nextval: reached maximum value of sequence "dojo_alerts_id_seq" (2147483647)'
+    )
+
+    def _failing_save(self, *_args, **_kwargs):
+        raise DataError(self.SEQUENCE_EXHAUSTED_MESSAGE)
+
+    @parameterized.expand([
+        (True,),
+        (False,),
+    ])
+    def test_alert_persistence_failure_does_not_propagate(self, save_fails):
+        """
+        ``send_alert_notification`` must return normally whether the underlying
+        Alert save succeeds or fails; a persistence failure is swallowed and
+        logged, never raised to the caller (which would break scan import).
+        """
+        admin = Dojo_User.objects.get(username="admin")
+        manager = AlertNotificationManger()
+
+        if save_fails:
+            with patch.object(Alerts, "save", side_effect=self._failing_save):
+                # Must NOT raise, even though both the primary alert save and the
+                # ``_log_alert`` fallback save hit the same DB failure.
+                manager.send_alert_notification(
+                    "scan_added",
+                    user=admin,
+                    title="Regression alert persistence failure",
+                    url=reverse("alerts"),
+                )
+        else:
+            before = Alerts.objects.count()
+            manager.send_alert_notification(
+                "scan_added",
+                user=admin,
+                title="Regression alert persistence success",
+                url=reverse("alerts"),
+            )
+            after = Alerts.objects.count()
+            self.assertEqual(
+                after, before + 1,
+                msg=f"expected one Alert persisted, before={before} after={after}",
+            )
+
+    def test_log_alert_fallback_does_not_propagate_db_failure(self):
+        """
+        ``_log_alert`` is the last-resort error logger for every notification
+        channel. If persisting its own Alert fails, it must log and return, not
+        raise -- otherwise an infrastructure-level DB failure defeats the
+        per-channel error isolation of the whole notification pipeline.
+        """
+        manager = AlertNotificationManger()
+        with patch.object(Alerts, "save", side_effect=self._failing_save):
+            manager._log_alert(
+                DataError(self.SEQUENCE_EXHAUSTED_MESSAGE),
+                "Alert Notification",
+                title="Regression log_alert failure",
+                description=self.SEQUENCE_EXHAUSTED_MESSAGE,
+                url=reverse("alerts"),
+            )

--- a/unittests/test_notifications.py
+++ b/unittests/test_notifications.py
@@ -1510,6 +1510,7 @@ class TestReviewRequestedWebhookTemplate(DojoTestCase):
         self.assertNotIn("finding:", fallback)
 
 
+@versioned_fixtures
 class TestAlertNotificationResilience(DojoTestCase):
 
     """


### PR DESCRIPTION
**Description**

A production instance repeatedly failed `POST /api/v2/reimport-scan/` (and the async
import task) with:

```
django.db.utils.DataError: nextval: reached maximum value of sequence "dojo_alerts_id_seq" (2147483647)
```

The traceback originates in `dojo/notifications/helper.py` while creating an in-app
`Alerts` row as a side effect of the import. Creating that alert is *not* essential to the
import, and `AlertNotificationManger.send_alert_notification()` already wraps its own
`alert.save()` in try/except for exactly that reason.

The problem is the fallback: on failure `send_alert_notification()` calls `_log_alert()`,
which saved *another* `Alerts` row **without a guard** (its comment literally read "no try
catch here, if this fails we need to show an error"). When the failure is at the database
level — here the `dojo_alerts` primary-key sequence hitting the PostgreSQL int4 maximum —
the fallback save hits the same error and re-raises. That exception then propagates out of
the notification pipeline and aborts the caller, so the entire scan import fails even
though the findings themselves imported fine.

`_log_alert()` is the last-resort error logger for **every** notification channel (alert,
slack, msteams, mail, webhooks), so a raise there also defeats the per-channel error
isolation the other channels rely on.

**Fix**

Guard the per-superuser Alert creation in `_log_alert()` so a persistence failure is logged
(`logger.exception`) and swallowed instead of raised. Alert creation stays a non-fatal side
effect: imports and other operations complete even when the alert cannot be written. This is
a pure error-handling change — no schema change, no migration.

**Scope / root cause note (why no migration here)**

This PR intentionally does **not** change the `Alerts.id` column type. The underlying cause
of the observed failure is that the `dojo_alerts` id sequence is an int4/`AutoField` and, on
a very high-volume instance, its `nextval` has reached 2147483647 (the sequence keeps
advancing across the lifetime of the row churn even though old alerts are pruned). Fully
resolving *that* requires converting the primary key to `bigint`/`BigAutoField` and resetting
the sequence — a table rewrite on a multi-billion-row table that must be run as a coordinated,
online operation, not a routine `manage.py migrate`. That is out of scope for this hotfix and
is tracked separately for the ops/infra path. Avenues considered and rejected as the fix here:

- *int4 → bigint migration in this PR*: correct long-term, but a blocking rewrite of a
  multi-billion-row table; unsafe to ship as a standard migration and cannot be validated as
  part of a code change. Tracked as a separate remediation.
- *Resetting/altering the sequence operationally only*: a DBA action, not a code fix, and it
  does not prevent the import from breaking again on the next transient alert-write failure.

The change in this PR is the right code-level fix regardless of the sequence remediation: a
failure to persist an in-app alert must never take down a scan import.

**Pro impact**

The affected code path is open-source (`dojo/notifications/helper.py`, `Alerts`). DefectDojo
Pro does not override `_log_alert`, `send_alert_notification`, the `AlertNotificationManger`,
or the `Alerts` model; its importer (`pro/importers/...`) calls the same OSS
`create_notification`, so this fix resolves the cascade for Pro-driven imports as well without
any Pro-side change.

**Test results**

Added `unittests/test_notifications.py::TestAlertNotificationResilience` (TDD, failing-first):

- `test_alert_persistence_failure_does_not_propagate` — parameterized: `Alerts.save` patched
  to raise the sequence-exhausted `DataError`; asserts `send_alert_notification()` returns
  without raising. Passing control (`save` works) asserts exactly one `Alerts` row is still
  written.
- `test_log_alert_fallback_does_not_propagate_db_failure` — asserts `_log_alert()` swallows the
  same failure instead of re-raising.

Before the fix the failing cases raise `DataError` out of the helper; after the fix they
return normally. `ruff check --config ruff.toml` passes on both changed files.

**Documentation**

No user-facing documentation change — this is an internal error-handling fix.

**Checklist**

- [x] Bugfix submitted against the `bugfix` branch.
- [x] Code is Ruff compliant.
- [x] Added unit tests covering the fix (failing-first, with a passing control).
- [ ] No DB migration (deliberately — see the scope note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaB4z6ypeBoo6K48nYT9Ao

---
_Generated by [Claude Code](https://claude.ai/code/session_01SaB4z6ypeBoo6K48nYT9Ao)_