### PR TITLE
fix(locations): use EXISTS subqueries in Location.all_related_products

### DIFF
--- a/dojo/location/models.py
+++ b/dojo/location/models.py
@@ -12,11 +12,13 @@ from django.db.models import (
     RESTRICT,
     CharField,
     DateTimeField,
+    Exists,
     ForeignKey,
     Index,
     JSONField,
     Model,
     OneToOneField,
+    OuterRef,
     Q,
     QuerySet,
     TextChoices,
@@ -245,10 +247,20 @@ class Location(BaseModel):
         return []
 
     def all_related_products(self) -> QuerySet[Product]:
-        return Product.objects.filter(
-            Q(locations__location=self)
-            | Q(engagement__test__finding__locations__location=self),
-        ).distinct()
+        direct_match = LocationProductReference.objects.filter(
+            product_id=OuterRef("pk"),
+            location=self,
+        )
+        finding_match = LocationFindingReference.objects.filter(
+            location=self,
+            finding__test__engagement__product_id=OuterRef("pk"),
+        )
+        return Product.objects.annotate(
+            _has_direct_location=Exists(direct_match),
+            _has_finding_location=Exists(finding_match),
+        ).filter(
+            Q(_has_direct_location=True) | Q(_has_finding_location=True),
+        )
 
     def iter_related_products(self) -> list[Product]:
         """
@@ -268,7 +280,7 @@ class Location(BaseModel):
 
         Use this method from bulk paths where many Locations are processed at
         once. The original `all_related_products()` still issues a single
-        DISTINCT JOIN query and is kept for per-instance signal paths where
+        EXISTS-based query and is kept for per-instance signal paths where
         prefetching is not possible.
         """
         seen: set[int] = set()

--- a/unittests/test_location_filter_join_scoping.py
+++ b/unittests/test_location_filter_join_scoping.py
@@ -126,6 +126,14 @@ class TestLocationFilterJoinScoping(DojoTestCase):
         self.assertEqual(related, {OWN_PRODUCT_NAME, VICTIM_PRODUCT_NAME})
         self.assertEqual(self._matches(self.alice), {self.shared.id, self.own.id})
 
+    def test_all_related_products_uses_exists_not_join(self):
+        sql = str(self.shared.all_related_products().query)
+        self.assertIn("EXISTS", sql)
+        self.assertNotIn('LEFT OUTER JOIN "dojo_locationproductreference"', sql)
+        self.assertNotIn('LEFT OUTER JOIN "dojo_locationfindingreference"', sql)
+        related = {p.name for p in self.shared.all_related_products()}
+        self.assertEqual(related, {OWN_PRODUCT_NAME, VICTIM_PRODUCT_NAME})
+
     def test_other_products_data_never_matches(self):
         for label, params in (
             ("finding tag, exact", {"findings__finding__tags__name_exact": VICTIM_FINDING_TAG}),


### PR DESCRIPTION
**Description**

`Location.all_related_products()` finds products for a location through an OR across two paths:

- direct: `LocationProductReference` -> Product
- indirect: `LocationFindingReference` -> Finding -> Test -> Engagement -> Product

The old query expressed that OR as chained `LEFT JOIN`s plus `DISTINCT`. Because those relations are one-to-many, PostgreSQL materialized the full combination of every row before applying the `location_id` filter and discarded almost everything to return a single product.

The OR is now expressed as two correlated `EXISTS` subqueries (`Exists`/`OuterRef`), so each product is only probed for the presence of a matching reference on either path. Both lookups are covered by the existing composite indexes `unique_location_and_product`, `unique_location_and_finding`), so no new indexes are required. The result set is identical to the previous query; the `DISTINCT` is no longer needed since `EXISTS` never duplicates rows.

**Test results**

- Added regression test
  `TestLocationFilterJoinScoping.test_all_related_products_uses_exists_not_join`   in `unittests/test_location_filter_join_scoping.py`, asserting the generated SQL uses `EXISTS` and no longer contains the fan-out `LEFT OUTER JOIN`s, and that both the direct and finding-mediated products still surface.
- Verified against a local stack:
  - `manage.py check` passes.
  - `EXPLAIN ANALYZE` of the generated query dropped from **~31,456 ms** to **~3.5 ms** in a DefectDojo install with 115 products, ~61,000 location-product references, and ~56,000 location-finding references.
  - Old and new queries return identical product sets for the affected location.

**Documentation**

No documentation changes needed.

**Checklist**

- [x] Bugfix submitted against the `bugfix` branch (branch cut from `origin/bugfix`).
- [x] No migrations required (no model change).
- [x] Regression test added.
- [x] Ruff compliant.
- [x] Label: `performance`