### PR TITLE
docs(connectors): document sync/discovery frequency options

### DIFF
--- a/docs/content/connectors/upstream/add_edit.md
+++ b/docs/content/connectors/upstream/add_edit.md
@@ -26,7 +26,7 @@ You can also edit an existing Connector under the **Configured Connectors** head
 ​
 5. Set a **Label** for this connection to help you identify it in DefectDojo.  
 ​
-6. Schedule the Connector's automatic discovery and sync using the **Discovery Configuration** and **Synchronization Configuration** schedules. These can be changed later.  
+6. Schedule the Connector's automatic discovery and sync under the **Discovery Configuration** and **Synchronization Configuration** sections. For each, pick a **Frequency** (every 6, 12, or 24 hours) and a **Time**. At *Every 24 hours* the connector runs once a day at that time; at *Every 6 hours* or *Every 12 hours* the time sets when the first run of the day happens, and the connector repeats from there. Times are shown in your browser's local timezone. You can change any of this later.  
 ​
 7. Select whether you wish to **Enable Auto\-Mapping**. Enable Auto\-Mapping will create a new Asset in DefectDojo to store the data from this connector. Auto\-Mapping can be turned on or off at any time.  
 ​


### PR DESCRIPTION
[sc-15243]

### What

Documents the new upstream connector schedule options on the add/edit page: a **Frequency** control (every 6, 12, or 24 hours) alongside the time, and that schedule times are shown in the viewer's browser-local timezone.

### Why

The connector add/edit form gained a Frequency selector so a connector can sync and discover more often than once a day. The setup steps referenced only the schedule "time", so step 6 is updated to describe the Frequency and Time controls and the timezone display.

Companion to the Pro change that adds the control. Docs-only, no code changes.