### PR TITLE
docs(dashboards): document collaborative shared dashboards

### DIFF
--- a/docs/content/metrics_reports/dashboards/PRO__custom_dashboards.md
+++ b/docs/content/metrics_reports/dashboards/PRO__custom_dashboards.md
@@ -63,7 +63,8 @@ Widgets are placed on a **12-column grid**. In edit mode you drag widgets to mov
 
 - **Default** — one of your layouts is your **default**: the one that loads when you open the home page. You can change which layout is your default at any time.
 - **Clone** — copy any layout (one of yours, or a shared template) into your own space as a fresh, independent starting point. Cloning gives the copy its own widgets, so editing the clone never touches the original.
-- **Share** — publish one of your layouts to the whole team as a **shared layout**. Other users can see it and clone it, but only a team **Maintainer** can publish, edit, or unshare a shared layout. Sharing a layout shares only its *design* — every viewer still sees only the data their own permissions allow.
+- **Share** — publish one of your layouts to the whole team as a **shared layout**. Other users can see it and clone it, but only a team **Maintainer** can publish, edit, or unshare a shared layout (unless it is collaborative, below). Sharing a layout shares only its *design* — every viewer still sees only the data their own permissions allow.
+- **Collaborative** — a Maintainer can mark a shared layout as **collaborative** from **Manage Layouts** (**Make Collaborative**, reversed with **Stop Collaborating**). A collaborative layout is one live dashboard rather than a template to copy: it appears in every user's layout picker, anyone can set it as their default, and anyone can add, remove, rearrange, or configure its widgets. Every change is saved to the same layout, so everyone using it sees it. Renaming, unsharing, deleting, and the collaborative setting itself stay with a Maintainer. If a layout stops being collaborative (or is unshared), users who had it as their default fall back to their own layouts. Edits are saved as they are made, so two people editing at the same moment can overwrite each other's change; the layout re-syncs from the server when you enter edit mode.
 - **Starter & shared templates** — DefectDojo ships a set of curated **shared templates** you can clone as a head start (see [Shared templates](#shared-templates) below). The **Default Dashboard** is the special "starter" template that new users are given automatically.
 - **Global default**: a user who can share dashboards can mark a shared layout as the **global default** from **Manage Layouts** (**Set as Global Default**, cleared with **Clear Global Default**). It carries a "Global Default" badge, and it is the dashboard everyone is shown when dashboard customization is restricted (see below). It can also be chosen from a dropdown on the Layout Defaults settings page (Settings, then UI Defaults, then Layout Defaults).
 
@@ -75,7 +76,7 @@ An administrator can enable **Restrict Layout Customization** (Settings, then UI
 
 ### The dashboard toolbar
 
-The toolbar across the top of the home page is where you switch layouts and manage them. It includes a **layout picker** (with badges that mark your default layout and any shared layouts/templates), and buttons to create a **New Layout**, open **Manage Layouts**, **Refresh** all widgets, and toggle **Edit** mode.
+The toolbar across the top of the home page is where you switch layouts and manage them. It includes a **layout picker** (with badges that mark your default layout, any shared layouts/templates, and collaborative layouts shared with you), and buttons to create a **New Layout**, open **Manage Layouts**, **Refresh** all widgets, and toggle **Edit** mode.
 
 ![The dashboard toolbar (highlighted): the layout picker, plus New Layout, Manage Layouts, Refresh, and Edit](images/pro_dashboard_v2_home.png)
 
@@ -116,7 +117,7 @@ Drag widgets to rearrange them and drag a corner to resize. Use the gear icon on
 
 The **Manage Layouts** dialog (the gear button on the toolbar) is the hub for everything layout-level:
 
-- **Your Layouts** — rename, set as default, share/unshare, clone, or delete each layout you own.
+- **Your Layouts** — rename, set as default, share/unshare, clone, or delete each layout you own. Collaborative layouts shared with you are listed here too, tagged **Collaborative**, and can be set as your default or copied into a layout of your own; a Maintainer also sees **Make Collaborative** / **Stop Collaborating** on shared layouts.
 - **Create New** — start a fresh, empty layout to build from scratch.
 - **Shared Templates** — browse curated and team-published layouts grouped by category, and click **Use Layout** to clone one into your own space.
 
@@ -133,7 +134,7 @@ DefectDojo ships four ready-to-use shared templates you can clone as a starting 
 | **Mitigation Layout** | A remediation-velocity board (closure trends, MTTR/MTTD, aging). |
 | **Tool Layout** | A scanner-effectiveness board built around test types and recent scan activity. |
 
-> **💡 Tip:** Cloning a template makes an independent copy. Customize the clone freely — you will not affect the template or anyone else who clones it.
+> **💡 Tip:** Cloning a template makes an independent copy. Customize the clone freely — you will not affect the template or anyone else who clones it. A **collaborative** layout is the exception by design: it is used live rather than copied, so edits made to it are visible to everyone. Take your own copy of a collaborative layout only when you want a private version that no longer follows the shared one.
 
 ### The empty state
 

--- a/docs/content/metrics_reports/dashboards/PRO__custom_dashboards_api.md
+++ b/docs/content/metrics_reports/dashboards/PRO__custom_dashboards_api.md
@@ -228,18 +228,22 @@ curl -s -X POST \
   }'
 ```
 
-The response echoes the saved layout including its new `id`, plus read-only helper fields (`is_default`, `is_owned`, `is_catalog`, `category`, `icon`, and timestamps).
+The response echoes the saved layout including its new `id`, plus read-only helper fields (`is_default`, `is_owned`, `can_edit`, `can_manage`, `is_catalog`, `category`, `icon`, and timestamps). `can_edit` reports whether the caller may change the layout's `widgets`, `layout`, and `settings`; `can_manage` whether they may rename, share, unshare, flag, or delete it.
 
 ### Custom actions
 
 | Action | Call | What it does |
 |--------|------|--------------|
-| Set default | `POST /dashboards/layouts/{id}/set_default/` | Makes this layout the one your home page loads. You can only default a layout you own. |
+| Set default | `POST /dashboards/layouts/{id}/set_default/` | Makes this layout the one your home page loads. You can default a layout you own, or any collaborative shared layout. |
 | Clone | `POST /dashboards/layouts/{id}/clone/` (optional body `{"name": "..."}`) | Copies a layout (yours or a shared template) into your space with fresh widget IDs. Defaults to `"Copy of <name>"`. |
 | List shared | `GET /dashboards/layouts/shared/` | Lists every shared layout — curated templates plus team-published ones. |
-| Bootstrap | `GET /dashboards/layouts/for_current_user/` | Returns `{"results": [...your layouts...], "default_id": <id>}`. On a first call, it auto-clones the starter template so you always get at least one layout back. |
+| Bootstrap | `GET /dashboards/layouts/for_current_user/` | Returns `{"results": [...your layouts, then any collaborative shared layouts...], "default_id": <id>}`. On a first call, it auto-clones the starter template so you always get at least one layout back. |
 
 Publishing a shared layout (`"is_shared": true` on create or update) requires the global **Maintainer** role.
+
+### Collaborative layouts
+
+A shared layout can also be flagged `"is_collaborative": true` (same Maintainer requirement; only a shared layout can carry the flag, and unsharing clears it). A collaborative layout is one live dashboard for everyone rather than a template to clone: it is included in every user's `for_current_user/` results, any user may make it their default, and any authenticated user may `PATCH` its `widgets`, `layout`, and `settings`. Changing its `name`, `is_shared`, or `is_collaborative`, or deleting it, still requires the Maintainer role; a collaborator attempting that receives `403`. The `clone` action on a collaborative layout produces an ordinary personal copy. Writes are last-write-wins, so clients that edit collaborative layouts should re-read the row before saving.
 
 ## Step 3: Render widget data (optional)
 

--- a/docs/content/metrics_reports/dashboards/PRO__custom_dashboards_llm.md
+++ b/docs/content/metrics_reports/dashboards/PRO__custom_dashboards_llm.md
@@ -64,7 +64,11 @@ It is created/updated under /api/v2/dashboards/ with these resources:
         POST {id}/clone/        copy a layout (fresh widget IDs)
         POST {id}/set_default/  make a layout my home-page default
         GET  shared/            list curated + team-shared templates
-        GET  for_current_user/  my layouts + my default_id (bootstrap)
+        GET  for_current_user/  my layouts (+ collaborative shared ones) + my default_id (bootstrap)
+        A shared layout with is_collaborative=true is one live dashboard anyone may
+        edit (widgets/layout/settings) and default to; flipping is_shared or
+        is_collaborative needs the Maintainer role, and only a shared layout can
+        be collaborative.
   /api/v2/dashboards/widget_catalog/  GET: every widget type + a config example
   /api/v2/dashboards/widget_data/<action>/  render a widget's data on demand
 


### PR DESCRIPTION
## Docs: collaborative shared dashboards

Documents the new **Collaborative** setting on shared Dashboards 2.0 layouts, which pairs with the Pro change for [sc-15071](https://app.shortcut.com/defectdojo/story/15071/collaborative-shared-dashboard).

A shared layout has until now been a template: other users clone it, and the clone stops following the original. A Maintainer can now mark a shared layout collaborative, which makes it one live dashboard instead. It appears in every user's layout picker, anyone can set it as their default, and anyone can change its widgets. Renaming, sharing, deleting, and the setting itself stay with a Maintainer.

Changes, all under `docs/content/metrics_reports/dashboards/`:

- **Custom Dashboards**: a new Collaborative bullet in "Sharing, cloning, and defaults", a qualification of the Share bullet and of the cloning tip (a collaborative layout is used live rather than copied), and updates to the toolbar and Manage Layouts descriptions.
- **Customizable Dashboards API**: `is_collaborative` and the new read-only `can_edit` / `can_manage` fields, the widened Set default rule, the bootstrap response, and a section on what a collaborative layout permits over REST.
- **Building Dashboards with an LLM**: the endpoint cheat sheet notes the flag.

Text only, English pages.
