### PR TITLE
docs(sensei): document Google Vertex AI as an on-prem LLM provider

### DIFF
--- a/docs/content/sensei/ai_model_settings.md
+++ b/docs/content/sensei/ai_model_settings.md
@@ -29,6 +29,7 @@ match the provider you choose.
 | **Claude (Anthropic)** | an Anthropic API key |
 | **OpenAI** | an OpenAI API key |
 | **Amazon Bedrock** | AWS credentials (see [How Bedrock access is determined](#how-bedrock-access-is-determined)) |
+| **Google Vertex AI** | a GCP service account, or the engine's ambient identity (see [Google Vertex AI](#google-vertex-ai)) |
 
 Every provider also accepts an optional **Model** override (leave blank to use the provider's
 default) and an optional **API Base URL** to point at an on-prem or self-hosted gateway.
@@ -92,6 +93,40 @@ to store or rotate.
 Either way, the identity used needs permission to invoke the Bedrock model (`bedrock:InvokeModel`)
 in the chosen region.
 
+### Google Vertex AI
+
+Google Vertex AI serves models from **your own GCP project's Model Garden**. It is a single,
+model-agnostic provider: the **Model** you enter selects the family, so one provider choice runs
+any Vertex model. A `gemini-*` model id runs a Google Gemini model; anything else — or a blank
+model, which defaults to a Claude model — runs an Anthropic Claude model on Vertex. Enable the
+model you intend to use in your project's Vertex Model Garden first.
+
+Its fields differ from the key-based providers:
+
+1. **Model (optional)** — any model enabled in your project's Model Garden, e.g.
+   `claude-sonnet-4-6` or `gemini-2.5-pro`. Blank uses the engine default (a Claude model).
+2. **Vertex Project ID** — **required**. The GCP project hosting Vertex AI.
+3. **Vertex Region** — the Vertex region, e.g. `global` (the default) or `us-east5`.
+4. **Service Account Key (JSON)** — **optional** (see below).
+
+#### How Vertex access is determined
+
+The project is always required, but the service-account key is optional because the Sensei engine
+resolves GCP credentials in this order:
+
+1. **The service-account key JSON you paste here, if any.** The engine uses it to authenticate as
+   that service account.
+2. **Otherwise, the engine's ambient GCP identity** (Application Default Credentials) — the
+   workload identity or attached service account of wherever the engine runs (for example a GKE
+   Workload Identity binding). This only exists when the engine runs on GCP with an attached
+   identity.
+
+Either way, the service account needs the **`roles/aiplatform.user`** role on the project, and the
+model must be enabled in that project's Model Garden.
+
+> **Running on-prem or outside GCP?** There is no ambient GCP identity to fall back on when the
+> engine does not run inside GCP. In those deployments, paste a service-account key above.
+
 ## Test connection
 
 **Test connection** validates the configuration before a scan relies on it:
@@ -102,6 +137,9 @@ in the chosen region.
 - For **Amazon Bedrock without static keys**, it reports that the engine's instance IAM role is
   used at runtime — DefectDojo can't validate that role on the engine's behalf, so confirm
   Bedrock access from the engine's own environment.
+- For **Google Vertex AI**, it makes a minimal call to the configured model (routed to the Claude
+  or Gemini client by the model id), surfacing an authorization or model-availability error if the
+  service account lacks access or the model is not enabled in the project's Model Garden.
 
 ## Save
 


### PR DESCRIPTION
[sc-15309]

## Description

Documents **Google Vertex AI** as an on-prem Sensei LLM provider on the AI Model Settings page.

Vertex is a single, model-agnostic provider: the Model field selects the family, so one provider choice runs any Vertex model. A `gemini*` model id runs a Gemini model, and anything else (or a blank model) runs a Claude model on Vertex. The page documents the Vertex Project ID / Region / optional Service Account Key fields, the ambient-GCP-identity (Application Default Credentials) fallback and the `roles/aiplatform.user` requirement, and the Test connection behavior for either family.

Docs-only change; the corresponding Pro feature ships on the same release line.
