### PR TITLE
docs(connectors): document the YesWeHack severity fallback and status mapping

### DIFF
--- a/docs/content/connectors/toolreference/yeswehack.md
+++ b/docs/content/connectors/toolreference/yeswehack.md
@@ -19,4 +19,17 @@ You will need a YesWeHack **Personal Access Token (PAT)**. Read access to your p
 2. Enter your Personal Access Token in the **Secret** field.
 3. Optionally, set a **Minimum Severity** to limit which findings are imported. Findings below the selected severity will not be imported.
 
-DefectDojo creates a separate Record for each program your token can access, and imports each report as a finding. The finding's severity is taken from the report's CVSS rating (falling back to the triage priority), and its status reflects the report's workflow state — for example, resolved reports are imported as mitigated, and reports marked invalid or out of scope are imported as inactive.
+DefectDojo creates a separate Record for each program your token can access, and imports each report as a finding. The finding's severity is taken from the report's CVSS rating, falling back to the triage priority, and then to the report's numeric CVSS score.
+
+The finding's status reflects the report's workflow state:
+
+| YesWeHack workflow state | Finding status |
+|--------------------------|----------------|
+| New, Under Review, Reopen Under Review, Need More Info | Active |
+| Accepted, Ask for fix verification | Active, Verified |
+| Resolved, Auto Close | Inactive, Mitigated |
+| Won't Fix | Inactive, Risk Accepted |
+| Invalid, Not Applicable, Spam | Inactive, False Positive |
+| Duplicate | Inactive, Duplicate |
+| Out Of Scope, RTFS | Inactive, Out of Scope |
+| Informative | Inactive |


### PR DESCRIPTION
## Description

Documentation for two YesWeHack connector fixes shipping on this release line (paired Pro/connectors change):

- The finding severity now resolves from the report's CVSS band, falling back to the triage priority, and then to the numeric CVSS score. Previously reports whose payload carried no recognizable band imported as Info.
- Every YesWeHack workflow state now maps to an explicit finding status, so the tool page gains a mapping table: RTFS and Out Of Scope land as inactive/out of scope, Duplicate as an inactive duplicate, Invalid/Not Applicable/Spam as false positives, Won't Fix as risk accepted, Resolved/Auto Close as mitigated, and the open conversation states stay active.

English page only; translated pages are regenerated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)