### PR TITLE
docs(connectors): add the Palo Alto Cortex connectors to the supported list

### DIFF
--- a/docs/content/connectors/toolreference/palo_alto_cortex_cloud.md
+++ b/docs/content/connectors/toolreference/palo_alto_cortex_cloud.md
@@ -1,0 +1,22 @@
+---
+title: "Palo Alto Cortex Cloud"
+description: "How to set up the Palo Alto Cortex Cloud Upstream Connector for DefectDojo"
+weight: 102
+audience: pro
+---
+The Cortex Cloud connector (formerly **Prisma Cloud**) imports **cloud\-posture alerts** as findings (`Cortex Cloud:Posture`). DefectDojo creates a Record for each onboarded **cloud account**.
+
+#### Prerequisites
+
+A Prisma Cloud **Access Key** — an **Access Key ID** and a **Secret Key** — created under **Settings \> Access Control \> Access Keys**, and left **enabled** (the connector exchanges it at `/login` for a short\-lived token).
+
+An access key inherits the **Role** of the user that created it, so that user's role must grant **View** access to **Cloud Accounts** (required, for account discovery) and **Alerts** (for the posture findings). A built\-in **Account Group Read Only** role, or a custom permission group with those two view permissions, is the minimum.
+
+#### Connector Mappings
+
+1. Enter your Prisma Cloud **API URL** in the **Location** field, matching your tenant's region — for example `https://api.prismacloud.io`, `https://api2.prismacloud.io`, or `https://api.eu.prismacloud.io`.
+2. Enter the **Access Key ID**.
+3. Enter the **Secret Key**.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each cloud account becomes a Record; only **open** posture alerts are imported.

--- a/docs/content/connectors/toolreference/palo_alto_cortex_xdr.md
+++ b/docs/content/connectors/toolreference/palo_alto_cortex_xdr.md
@@ -1,0 +1,22 @@
+---
+title: "Palo Alto Cortex XDR"
+description: "How to set up the Palo Alto Cortex XDR Upstream Connector for DefectDojo"
+weight: 102
+audience: pro
+---
+The Cortex XDR connector imports **alerts** from your Cortex XDR tenant as findings (`Cortex XDR:Alerts`). DefectDojo creates a Record for each Cortex **endpoint**.
+
+#### Prerequisites
+
+A Cortex XDR **API Key** and its **API Key ID**, created in the Cortex console under **Settings \> Configurations \> Integrations \> API Keys**. Use a **Standard** security\-level key — the connector signs each request with the `Authorization` and `x-xdr-auth-id` headers.
+
+Assign the key a **Role** that grants read access to the data the connector reads: **Endpoints** (required, for endpoint discovery via `get_endpoints`) and **Alerts and Incidents** (for the imported alerts). A built\-in **Viewer** role, or a custom role with those two **View** permissions, is the minimum.
+
+#### Connector Mappings
+
+1. Enter your tenant's API base URL in the **Location** field — the FQDN shown on the API Keys page, for example `https://api-\<your-tenant\>.xdr.us.paloaltonetworks.com` (the region segment varies by tenant).
+2. Enter the **API Key ID** (the integer shown beside the key).
+3. Enter the **API Key** secret.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+Each Cortex endpoint becomes a Record, named for its hostname and OS.

--- a/docs/content/connectors/toolreference/palo_alto_cortex_xsiam.md
+++ b/docs/content/connectors/toolreference/palo_alto_cortex_xsiam.md
@@ -1,0 +1,22 @@
+---
+title: "Palo Alto Cortex XSIAM"
+description: "How to set up the Palo Alto Cortex XSIAM Upstream Connector for DefectDojo"
+weight: 102
+audience: pro
+---
+The Cortex XSIAM connector imports **alerts** from your Cortex XSIAM tenant as findings (`Cortex XSIAM:Alerts`). Because XSIAM alerts span endpoints, cloud, network and identity, DefectDojo creates a single Record for the whole **tenant** rather than one per asset.
+
+#### Prerequisites
+
+A Cortex XSIAM **API Key** and its **API Key ID**, created in the XSIAM console under **Settings \> Configurations \> Integrations \> API Keys**. Use a **Standard** security\-level key — the connector signs each request with the `Authorization` and `x-xdr-auth-id` headers.
+
+Assign the key a **Role** with read access to **Alerts and Incidents** (for the imported alerts); the credential check also reads **Endpoints**. A built\-in **Viewer** role, or a custom role with those **View** permissions, is the minimum.
+
+#### Connector Mappings
+
+1. Enter your tenant's API base URL in the **Location** field — the FQDN shown on the API Keys page, for example `https://api-\<your-tenant\>.xdr.us.paloaltonetworks.com`.
+2. Enter the **API Key ID**.
+3. Enter the **API Key** secret.
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
+
+All of the tenant's alerts import under the single XSIAM tenant Record.

--- a/docs/content/connectors/toolreference/palo_alto_cortex_xsoar.md
+++ b/docs/content/connectors/toolreference/palo_alto_cortex_xsoar.md
@@ -17,5 +17,6 @@ The key's **Role** must grant **read access to incidents** — used to search in
 1. Enter your XSOAR API base URL in the **Location** field — for a Cortex\-hosted tenant this is the FQDN from the API Keys page, for example `https://api-\<your-tenant\>.xsoar.paloaltonetworks.com`; for a self\-hosted XSOAR use your server's base URL.
 2. Enter the **API Key**.
 3. Optionally, enter the **API Key ID** (XSOAR 8 / Cortex multi\-tenant only).
+4. Optionally, set a **Minimum Severity** to limit which findings are imported.
 
 Each XSOAR incident becomes a finding under the tenant Record.

--- a/docs/content/connectors/toolreference/palo_alto_cortex_xsoar.md
+++ b/docs/content/connectors/toolreference/palo_alto_cortex_xsoar.md
@@ -1,0 +1,21 @@
+---
+title: "Palo Alto Cortex XSOAR"
+description: "How to set up the Palo Alto Cortex XSOAR Upstream Connector for DefectDojo"
+weight: 102
+audience: pro
+---
+The Cortex XSOAR connector imports **incidents** from your XSOAR tenant as findings (`Cortex XSOAR`). DefectDojo creates a single Record for the **tenant**.
+
+#### Prerequisites
+
+An XSOAR **API Key**, created in the console under **Settings \> Integrations \> API Keys**. For **Cortex XSOAR 8** / Cortex multi\-tenant, also copy the **API Key ID** (sent as the `x-xdr-auth-id` header); leave it blank for XSOAR 6.
+
+The key's **Role** must grant **read access to incidents** — used to search incidents. A read\-only role is the minimum.
+
+#### Connector Mappings
+
+1. Enter your XSOAR API base URL in the **Location** field — for a Cortex\-hosted tenant this is the FQDN from the API Keys page, for example `https://api-\<your-tenant\>.xsoar.paloaltonetworks.com`; for a self\-hosted XSOAR use your server's base URL.
+2. Enter the **API Key**.
+3. Optionally, enter the **API Key ID** (XSOAR 8 / Cortex multi\-tenant only).
+
+Each XSOAR incident becomes a finding under the tenant Record.

--- a/docs/content/connectors/upstream/about.md
+++ b/docs/content/connectors/upstream/about.md
@@ -114,6 +114,10 @@ We currently support Upstream Connectors for the following tools, with more on t
 * **OpenVAS / Greenbone**
 * **Orca Security**
 * **Ostorlab**
+* **Palo Alto Cortex Cloud**
+* **Palo Alto Cortex XDR**
+* **Palo Alto Cortex XSIAM**
+* **Palo Alto Cortex XSOAR**
 * **Parasoft DTP**
 * **Picus Security**
 * **PingCastle**


### PR DESCRIPTION
[sc-15334]

## What

Adds the four Palo Alto Cortex connectors — **Cortex XDR**, **Cortex XSIAM**, **Cortex XSOAR**, and **Cortex Cloud** — to the upstream Connectors documentation:

- Added to the supported-tools list in `connectors/upstream/about.md`.
- A per-connector setup page for each (`connectors/toolreference/palo_alto_cortex_{xdr,xsiam,xsoar,cloud}.md`) documenting the **minimum API-key role / permissions** required and the connection field mappings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
