### PR TITLE
Point Pro links at the cloud sign-up page and read "Get Pro from $100/mo"

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ if running DefectDojo in detached mode via `docker compose up -d`, obtain admin 
 
 ## Supported Installation Options
 
-* Pro - SaaS or self-hosted (via K8s or docker compose). [Speak to our team](https://defectdojo.com/contact) or [sign-up for SaaS directly](https://cloud.defectdojo.com/accounts/onboarding/plg_step_1)
+* Pro - SaaS or self-hosted (via K8s or docker compose). [Speak to our team](https://defectdojo.com/contact) or [get Pro from $100/mo](https://cloud.defectdojo.com/onboarding?payg=1)
 * OS - [docker compose](readme-docs/DOCKER.md)
 
 

--- a/dojo/product_announcements.py
+++ b/dojo/product_announcements.py
@@ -12,10 +12,10 @@ class ProductAnnouncementManager:
 
     """Base class for centralized helper methods"""
 
-    base_try_free = "Try today for free"
+    base_try_free = "Get Pro from $100/mo"
     base_contact_us = "email us at"
     base_email_address = "hello@defectdojo.com"
-    ui_try_free = f'<b><a href="https://cloud.defectdojo.com/accounts/onboarding/plg_step_1" target="_blank">{base_try_free}</a></b>'
+    ui_try_free = f'<b><a href="https://cloud.defectdojo.com/onboarding?payg=1" target="_blank">{base_try_free}</a></b>'
     ui_contact_us = f'{base_contact_us} <b><a href="mailto:{base_email_address}">{base_email_address}</a></b>'
     ui_outreach = f"{ui_try_free} or {ui_contact_us}."
     api_outreach = f"{base_try_free} or {base_contact_us} {base_email_address}"

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -502,8 +502,8 @@
                             {% if request.user.is_authenticated %}
                                 <div class="border-t border-gray-200 my-1"></div>
                                 {% if SHOW_PLG_LINK %}
-                                    <a href="https://cloud.defectdojo.com/accounts/onboarding/plg_step_1" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
-                                        <i class="fa-solid fa-level-up fa-fw"></i> {% trans "Try Pro for Free!" %}
+                                    <a href="https://cloud.defectdojo.com/onboarding?payg=1" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                                        <i class="fa-solid fa-level-up fa-fw"></i> {% trans "Get Pro from $100/mo" %}
                                     </a>
                                 {% endif %}
                                 <a href="{% url 'logout' %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">

--- a/dojo/templates/dojo/support.html
+++ b/dojo/templates/dojo/support.html
@@ -57,7 +57,7 @@
                     <p><i class="fa-solid fa-lg fa-circle-check"></i> Support directly from the DefectDojo Team</p>
                     <p><i class="fa-solid fa-lg fa-circle-check"></i> Assistance with best practice and implementation</p>
                 </div>
-                <a href="https://cloud.defectdojo.com/accounts/onboarding/plg_step_1" target="_blank" class="btn btn-primary support commercial light">Try Pro for Free!</a>
+                <a href="https://cloud.defectdojo.com/onboarding?payg=1" target="_blank" class="btn btn-primary support commercial light">Get Pro from $100/mo</a>
             </div>
         </div>
     </div>

--- a/unittests/test_product_announcements.py
+++ b/unittests/test_product_announcements.py
@@ -52,7 +52,7 @@ class TestProductAnnouncementSessionBanner(SimpleTestCase):
         ErrorPageProductAnnouncement(request=request)
         message = request.session["_product_banners"][0]["message"]
         self.assertIn("cloud.defectdojo.com", message)
-        self.assertIn("Try today for free", message)
+        self.assertIn("Get Pro from $100/mo", message)
 
     def test_session_error_is_swallowed(self):
         request = HttpRequest()


### PR DESCRIPTION
The "Try Pro for Free!" links in the user menu (`dojo/templates/base.html`), the support page, the product announcement banners (`dojo/product_announcements.py`) and the README pointed at the old product-led onboarding URL (`/accounts/onboarding/plg_step_1`). They now open the cloud portal's sign-up wizard, `https://cloud.defectdojo.com/onboarding?payg=1`, and read **Get Pro from $100/mo**. The announcement outreach line becomes "Get Pro from $100/mo or email us at hello@defectdojo.com"; the matching unit test is updated.

The `SHOW_PLG_LINK` context variable keeps its name so custom templates that reference it keep working; it only gates whether the link is shown.

Translations: 28 locale catalogs carry the old menu string "Try Pro for Free!". The new string falls back to English until the catalogs pick it up in the next translation pass; the link itself works in every language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
