### PR TITLE
docs: describe the two ways to start DefectDojo Cloud

### DIFF
--- a/docs/content/get_started/pro/cloud/additional-cloud-instance.md
+++ b/docs/content/get_started/pro/cloud/additional-cloud-instance.md
@@ -12,7 +12,7 @@ If you have not already requested an additional Cloud instance, please contact [
 
 ## Step 1: Open the New Subscription process
 
-You can start this process from the following link: <https://cloud.defectdojo.com/accounts/onboarding/step_1>, or by clicking 🛒 **New Subscription** from the Cloud Manager page (cloud.defectdojo.com).
+You can start this process from the following link: <https://cloud.defectdojo.com/onboarding>, or by clicking 🛒 **New Subscription** from the Cloud Manager page (cloud.defectdojo.com).
 
 ![image](images/request_a_trial.png)
 

--- a/docs/content/get_started/pro/cloud/using-cloud-manager.md
+++ b/docs/content/get_started/pro/cloud/using-cloud-manager.md
@@ -10,7 +10,7 @@ aliases:
 Logging into DefectDojo's Cloud Manager allows you to configure your account settings and manage your subscription with DefectDojo Cloud.
 
 ## **New Subscription**
-<https://cloud.defectdojo.com/accounts/onboarding/step_1>
+<https://cloud.defectdojo.com/onboarding>
 
 This page allows you to request a new, [or additional](../additional-cloud-instance/) Cloud instance from DefectDojo. 
 

--- a/docs/content/help/contact_sales.md
+++ b/docs/content/help/contact_sales.md
@@ -43,7 +43,7 @@ Pre-pay plans let you choose where your instance is hosted. Pick the location cl
 
 Review the details of your request. Once submitted, only firewall rules can be changed by your team without assistance from Support. To contact Support, email [support@defectdojo.com](mailto:support@defectdojo.com) or follow the instructions in [this article](/help/contact_support/).
 
-By continuing you agree to DefectDojo's Master Subscription Agreement and Privacy Policy.
+Clicking either action agrees to DefectDojo's Master Subscription Agreement and Privacy Policy.
 
 * **Pay as you go:** click **Checkout With Stripe** to enter your billing details, or **Contact Sales** if you would rather talk to us first.
 * **Annual plans:** click **Contact Sales**. Our Sales team will be in touch to agree pricing and terms and to finalize your subscription.

--- a/docs/content/help/contact_sales.md
+++ b/docs/content/help/contact_sales.md
@@ -1,68 +1,53 @@
 ---
 title: "Contact Sales"
-description: "How to request and work with a trial of DefectDojo Cloud"
+description: "How to start a DefectDojo Cloud subscription: pay as you go, or an annual plan through our sales team"
 draft: "false"
 weight: 6
 pro-feature: true
 aliases:
   - /en/about_defectdojo/request_a_trial
 ---
-If your team requires an on-premise DefectDojo installation, please connect with our Sales team by emailing → [hello@defectdojo.com](mailto:hello@defectdojo.com) . This trial setup process only applies to DefectDojo Cloud users.
+DefectDojo Cloud can be started in two ways:
 
-All DefectDojo plans include a free 2-week trial, which you can use to evaluate our software. DefectDojo Trial instances are fully-featured and can be immediately converted into paid instances by our team; no need to set everything up again, or reupload any data when your trial period ends.
+* **Pay as you go.** A monthly subscription billed to your card for what you process: a platform fee plus a per-finding rate, with Sensei AI billed per use. There is no annual commitment, and you can set a monthly spend limit. You check out with Stripe, and your instance is provisioned once checkout completes.
+* **Annual plans through our sales team.** Fixed-capacity tiers billed yearly, which save 40% or more compared with pay as you go, with pricing and agreement terms set with our team.
 
-At the end of this process, you'll be put in touch with our Sales team who will follow up to receive your billing information and authorize your company's trial instance.
+If your team requires an on-premise DefectDojo installation, please connect with our Sales team by emailing [hello@defectdojo.com](mailto:hello@defectdojo.com). The steps below apply to DefectDojo Cloud.
 
-# **Requesting your Trial**
+# Starting a subscription
 
-In order to sign up for a trial, you'll need to create an account on our [Cloud Portal](https://defectdojo.com/pricing), and then click the New Subscription menu option from the sidebar.
-
-![image](images/request_a_trial_mg.png)
+Create an account on the [Cloud Portal](https://cloud.defectdojo.com), then click **New Subscription** in the sidebar. You can also open the wizard directly at <https://cloud.defectdojo.com/onboarding>.
 
 ## Step 1: Welcome
-Click Continue to begin setting up your instance.
 
-![image](images/request_a_trial.png)
+Click **Continue** to begin setting up your instance.
 
-## Step 2: Enter your Company Information \& create your Domain
+## Step 2: Enter your Company Information and create your Domain
 
-Enter your company's **Name** and the **Server Label** you want to use with DefectDojo. You will then have a custom domain created for your DefectDojo instance on our servers.
+Enter your company's **Name** and the **Server Label** you want to use with DefectDojo. A domain for your instance is created on our servers from these two values.
 
-![image](images/request_a_trial_2.png)
+Normally, DefectDojo names your domain according to your company name. If you select **Include the server label in the domain**, the domain also carries the Server Label you chose. This approach may be preferred if you plan to use multiple DefectDojo instances (such as a Production instance and a Test instance). Please contact our Sales team at [hello@defectdojo.com](mailto:hello@defectdojo.com) if you require multiple instances.
 
-Normally, DefectDojo will name your domain according to your company name, but if you select "Use Server Label in Domain" DefectDojo will instead label your domain according to the Server Label you chose. This approach may be preferred if you plan to use multiple DefectDojo instances (such as a Production instance and a Test instance, for example). Please contact our Sales team → [hello@defectdojo.com](mailto:hello@defectdojo.com) if you require multiple instances.
+## Step 3: Choose how to buy
 
-## Step 3: Select a Server Location
+The Pricing Plans step has two tabs.
 
-Select a Server Location from the drop\-down menu. We recommend selecting a server that is geographically closest to the main DefectDojo team to reduce server latency.
+* **Pay as you go** shows the single self-serve plan. Expand **Full price list** to see every rate, and set an optional **Monthly spend limit**: once a month's charges reach the limit, new findings stop being accepted until the next month. You can change the limit at any time from your subscription page. Click **Choose pay as you go** to continue.
+* **Talk to sales** shows the annual tiers, each with its findings capacity. Choose the tier that fits and click **Talk to sales**. Tiers marked **Custom Pricing** are quoted individually and come with custom agreement terms and an annual commitment.
 
-![image](images/request_a_trial_3.png)
+## Step 4: Select a Server Location (annual plans only)
 
-## Step 4: Configure your Firewall Rules
+Annual plans let you choose where your instance is hosted. Pick the location closest to your team to reduce latency. Pay-as-you-go instances run in our shared US East region, so this step is skipped for them.
 
-Enter the IP address ranges, subnet mask and labels that you want to allow to access DefectDojo. Additional IP addresses and rules can be added or changed by your team after your instance is up and running.
+## Step 5: Verification
 
-![image](images/request_a_trial_4.png)
+Review the details of your request. Once submitted, only firewall rules can be changed by your team without assistance from Support. To contact Support, email [support@defectdojo.com](mailto:support@defectdojo.com) or follow the instructions in [this article](/help/contact_support/).
 
-If you want to use external services with DefectDojo (e.g., GitHub or JIRA), check the appropriate boxes listed under **Select External Services.** 
+By continuing you agree to DefectDojo's Master Subscription Agreement and Privacy Policy.
 
-## Step 5: Confirm your Plan type and Billing Frequency
+* **Pay as you go:** click **Checkout With Stripe** to enter your billing details, or **Contact Sales** if you would rather talk to us first.
+* **Annual plans:** click **Contact Sales**. Our Sales team will be in touch to agree pricing and terms and to finalize your subscription.
 
-Before you complete the process, please confirm the plan you want to use along with your billing frequency (monthly or annually).
+# Once your subscription is active
 
-![image](images/request_a_trial_5.png)
-
-## Step 6: Review and Submit your Request
-
-We'll prompt you to look over your request one more time. Once submitted, only Firewall rules can be changed by your team without assistance from Support. To contact Support, please email [support@defectdojo.com](mailto:support@defectdojo.com) or follow the instructions in [this article](/help/contact_support/).
-
-![image](images/request_a_trial_6.png)
-
-After reviewing and accepting DefectDojo's License and Support Agreement, you can click **Checkout With Stripe** or **Contact Sales**.
-
-* Checkout With Stripe will take you to a Stripe page where you can enter your billing information.
-* If you do not wish to enter your billing info at this time, you can click Contact Sales, and our Sales team will be in touch to help you finalize your trial subscription.
-
-# Once your trial has been approved
-
-Our Support team will send you a Welcome email with links and an initial password to access your DefectDojo instance. You can always reach out to [support@defectdojo.com](mailto:support@defectdojo.com) for DefectDojo Pro assistance once your trial begins.
+Our Support team sends a Welcome email with links and an initial password to access your DefectDojo instance. You can always reach out to [support@defectdojo.com](mailto:support@defectdojo.com) for DefectDojo Pro assistance.

--- a/docs/content/help/contact_sales.md
+++ b/docs/content/help/contact_sales.md
@@ -33,7 +33,7 @@ Normally, DefectDojo names your domain according to your company name. If you se
 The Pricing Plans step shows two tiles.
 
 * **Pay As You Go** is the self-serve plan. Expand **Full price list** to see every rate, and set an optional **Monthly spend limit**: once a month's charges reach the limit, new findings stop being accepted until the next month. You can change the limit at any time from your subscription page. Click **Choose pay as you go** to continue.
-* **Pre-Pay & Save** is the annual plan: billed yearly, with volume discounts when you pre-pay, capacity sized to your findings volume, custom agreement terms and an annual commitment. No tier or price is shown here; click **Choose Pre-Pay** and our team takes it from there.
+* **Pre-Pay & Save** is the annual plan: billed yearly, with volume discounts when you pre-pay, capacity sized to your findings volume, custom agreement terms and an annual commitment. The smallest plan starts at 250,000 findings a year. Drag the slider to the volume you process and the card estimates the price to start from and what it saves against pay as you go; your final price is confirmed with our team. Click **Choose Pre-Pay** and our team takes it from there.
 
 ## Step 4: Select a Server Location
 

--- a/docs/content/help/contact_sales.md
+++ b/docs/content/help/contact_sales.md
@@ -10,7 +10,7 @@ aliases:
 DefectDojo Cloud can be started in two ways:
 
 * **Pay as you go.** A monthly subscription billed to your card for what you process: a platform fee plus a per-finding rate, with Sensei AI billed per use. There is no annual commitment, and you can set a monthly spend limit. You check out with Stripe, and your instance is provisioned once checkout completes.
-* **Pre-pay & save, through our sales team.** An annual plan billed yearly, with capacity sized to your findings volume and pricing agreed with our team. Pre-paying for the year saves 40% or more compared with pay as you go.
+* **Pre-Pay & Save, through our sales team.** An annual plan billed yearly, with capacity sized to your findings volume and pricing agreed with our team. Pre-paying for the year saves 40% or more compared with pay as you go.
 
 If your team requires an on-premise DefectDojo installation, please connect with our Sales team by emailing [hello@defectdojo.com](mailto:hello@defectdojo.com). The steps below apply to DefectDojo Cloud.
 
@@ -32,8 +32,8 @@ Normally, DefectDojo names your domain according to your company name. If you se
 
 The Pricing Plans step shows two tiles.
 
-* **Pay as you go** is the self-serve plan. Expand **Full price list** to see every rate, and set an optional **Monthly spend limit**: once a month's charges reach the limit, new findings stop being accepted until the next month. You can change the limit at any time from your subscription page. Click **Choose pay as you go** to continue.
-* **Pre-pay & save** is the annual plan: billed yearly, with volume discounts when you pre-pay, capacity sized to your findings volume, custom agreement terms and an annual commitment. No tier or price is shown here; click **Choose pre-pay** and our team takes it from there.
+* **Pay As You Go** is the self-serve plan. Expand **Full price list** to see every rate, and set an optional **Monthly spend limit**: once a month's charges reach the limit, new findings stop being accepted until the next month. You can change the limit at any time from your subscription page. Click **Choose pay as you go** to continue.
+* **Pre-Pay & Save** is the annual plan: billed yearly, with volume discounts when you pre-pay, capacity sized to your findings volume, custom agreement terms and an annual commitment. No tier or price is shown here; click **Choose Pre-Pay** and our team takes it from there.
 
 ## Step 4: Select a Server Location
 

--- a/docs/content/help/contact_sales.md
+++ b/docs/content/help/contact_sales.md
@@ -35,9 +35,9 @@ The Pricing Plans step shows two tiles.
 * **Pay as you go** is the self-serve plan. Expand **Full price list** to see every rate, and set an optional **Monthly spend limit**: once a month's charges reach the limit, new findings stop being accepted until the next month. You can change the limit at any time from your subscription page. Click **Choose pay as you go** to continue.
 * **Pre-pay & save** is the annual plan: billed yearly, with volume discounts when you pre-pay, capacity sized to your findings volume, custom agreement terms and an annual commitment. No tier or price is shown here; click **Choose pre-pay** and our team takes it from there.
 
-## Step 4: Select a Server Location (annual plans only)
+## Step 4: Select a Server Location
 
-Annual plans let you choose where your instance is hosted. Pick the location closest to your team to reduce latency. Pay-as-you-go instances run in our shared US East region, so this step is skipped for them.
+Pre-pay plans let you choose where your instance is hosted. Pick the location closest to your team to reduce latency. Pay-as-you-go instances run in our shared US East region, so for them this step only tells you where the instance runs.
 
 ## Step 5: Verification
 

--- a/docs/content/help/contact_sales.md
+++ b/docs/content/help/contact_sales.md
@@ -10,7 +10,7 @@ aliases:
 DefectDojo Cloud can be started in two ways:
 
 * **Pay as you go.** A monthly subscription billed to your card for what you process: a platform fee plus a per-finding rate, with Sensei AI billed per use. There is no annual commitment, and you can set a monthly spend limit. You check out with Stripe, and your instance is provisioned once checkout completes.
-* **Annual plans through our sales team.** An annual plan billed yearly, with capacity sized to your findings volume and pricing agreed with our team. Pre-paying for the year saves 40% or more compared with pay as you go.
+* **Pre-pay, through our sales team.** An annual plan billed yearly, with capacity sized to your findings volume and pricing agreed with our team. Pre-paying for the year saves 40% or more compared with pay as you go.
 
 If your team requires an on-premise DefectDojo installation, please connect with our Sales team by emailing [hello@defectdojo.com](mailto:hello@defectdojo.com). The steps below apply to DefectDojo Cloud.
 
@@ -33,7 +33,7 @@ Normally, DefectDojo names your domain according to your company name. If you se
 The Pricing Plans step shows two tiles.
 
 * **Pay as you go** is the self-serve plan. Expand **Full price list** to see every rate, and set an optional **Monthly spend limit**: once a month's charges reach the limit, new findings stop being accepted until the next month. You can change the limit at any time from your subscription page. Click **Choose pay as you go** to continue.
-* **Talk to sales** is the annual plan: billed yearly, with capacity sized to your findings volume, pricing agreed with our team, custom agreement terms and an annual commitment. No tier or price is shown here; click **Talk to sales** and the team takes it from there.
+* **Pre-pay** is the annual plan: billed yearly, with volume discounts when you pre-pay, capacity sized to your findings volume, custom agreement terms and an annual commitment. No tier or price is shown here; click **Choose pre-pay** and our team takes it from there.
 
 ## Step 4: Select a Server Location (annual plans only)
 

--- a/docs/content/help/contact_sales.md
+++ b/docs/content/help/contact_sales.md
@@ -10,7 +10,7 @@ aliases:
 DefectDojo Cloud can be started in two ways:
 
 * **Pay as you go.** A monthly subscription billed to your card for what you process: a platform fee plus a per-finding rate, with Sensei AI billed per use. There is no annual commitment, and you can set a monthly spend limit. You check out with Stripe, and your instance is provisioned once checkout completes.
-* **Annual plans through our sales team.** Fixed-capacity tiers billed yearly, which save 40% or more compared with pay as you go, with pricing and agreement terms set with our team.
+* **Annual plans through our sales team.** An annual plan billed yearly, with capacity sized to your findings volume and pricing agreed with our team. Pre-paying for the year saves 40% or more compared with pay as you go.
 
 If your team requires an on-premise DefectDojo installation, please connect with our Sales team by emailing [hello@defectdojo.com](mailto:hello@defectdojo.com). The steps below apply to DefectDojo Cloud.
 
@@ -30,10 +30,10 @@ Normally, DefectDojo names your domain according to your company name. If you se
 
 ## Step 3: Choose how to buy
 
-The Pricing Plans step has two tabs.
+The Pricing Plans step shows two tiles.
 
-* **Pay as you go** shows the single self-serve plan. Expand **Full price list** to see every rate, and set an optional **Monthly spend limit**: once a month's charges reach the limit, new findings stop being accepted until the next month. You can change the limit at any time from your subscription page. Click **Choose pay as you go** to continue.
-* **Talk to sales** shows the annual tiers, each with its findings capacity. Choose the tier that fits and click **Talk to sales**. Tiers marked **Custom Pricing** are quoted individually and come with custom agreement terms and an annual commitment.
+* **Pay as you go** is the self-serve plan. Expand **Full price list** to see every rate, and set an optional **Monthly spend limit**: once a month's charges reach the limit, new findings stop being accepted until the next month. You can change the limit at any time from your subscription page. Click **Choose pay as you go** to continue.
+* **Talk to sales** is the annual plan: billed yearly, with capacity sized to your findings volume, pricing agreed with our team, custom agreement terms and an annual commitment. No tier or price is shown here; click **Talk to sales** and the team takes it from there.
 
 ## Step 4: Select a Server Location (annual plans only)
 

--- a/docs/content/help/contact_sales.md
+++ b/docs/content/help/contact_sales.md
@@ -10,7 +10,7 @@ aliases:
 DefectDojo Cloud can be started in two ways:
 
 * **Pay as you go.** A monthly subscription billed to your card for what you process: a platform fee plus a per-finding rate, with Sensei AI billed per use. There is no annual commitment, and you can set a monthly spend limit. You check out with Stripe, and your instance is provisioned once checkout completes.
-* **Pre-pay, through our sales team.** An annual plan billed yearly, with capacity sized to your findings volume and pricing agreed with our team. Pre-paying for the year saves 40% or more compared with pay as you go.
+* **Pre-pay & save, through our sales team.** An annual plan billed yearly, with capacity sized to your findings volume and pricing agreed with our team. Pre-paying for the year saves 40% or more compared with pay as you go.
 
 If your team requires an on-premise DefectDojo installation, please connect with our Sales team by emailing [hello@defectdojo.com](mailto:hello@defectdojo.com). The steps below apply to DefectDojo Cloud.
 
@@ -33,7 +33,7 @@ Normally, DefectDojo names your domain according to your company name. If you se
 The Pricing Plans step shows two tiles.
 
 * **Pay as you go** is the self-serve plan. Expand **Full price list** to see every rate, and set an optional **Monthly spend limit**: once a month's charges reach the limit, new findings stop being accepted until the next month. You can change the limit at any time from your subscription page. Click **Choose pay as you go** to continue.
-* **Pre-pay** is the annual plan: billed yearly, with volume discounts when you pre-pay, capacity sized to your findings volume, custom agreement terms and an annual commitment. No tier or price is shown here; click **Choose pre-pay** and our team takes it from there.
+* **Pre-pay & save** is the annual plan: billed yearly, with volume discounts when you pre-pay, capacity sized to your findings volume, custom agreement terms and an annual commitment. No tier or price is shown here; click **Choose pre-pay** and our team takes it from there.
 
 ## Step 4: Select a Server Location (annual plans only)
 

--- a/docs/content/help/contact_support.md
+++ b/docs/content/help/contact_support.md
@@ -21,7 +21,7 @@ See our [Community Site](https://defectdojo.com/open-source) for more informatio
 
 ## DefectDojo Pro Support
 
-DefectDojo Pro subscriptions come with full support from the DefectDojo, Inc. team during the initial trial period and beyond.
+DefectDojo Pro subscriptions come with full support from the DefectDojo, Inc. team from the first day of your subscription.
 
 ### Email
 


### PR DESCRIPTION
**Draft: hold until the cloud portal's new Pricing Plans step is live in production.** The page describes that wizard.

The Contact Sales page (`docs/content/help/contact_sales.md`) described a free two-week trial requested through the old Django wizard: a firewall step, monthly or annual billing, and Stripe checkout for every tier. It is rewritten around the current wizard:

- **Pay as you go** as the self-serve plan: monthly card billing on what you process, optional monthly spend limit, Stripe checkout.
- **Annual plans through the sales team**, which save 40% or more compared with pay as you go, with the Location step only on that path and Contact Sales as the action.

The stale screenshots of the old wizard are dropped from this page (the image files stay; another page still uses one of them).

Also: the two cloud-manager pages link to the wizard's current URL (`https://cloud.defectdojo.com/onboarding`, the old `/accounts/onboarding/step_1` only redirects there), and the support page no longer refers to an "initial trial period".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
